### PR TITLE
feat(58): Publication List Auto-Generator — ORCID fetch, LaTeX formatter, Publications tab

### DIFF
--- a/backend/app/api/ai_routes.py
+++ b/backend/app/api/ai_routes.py
@@ -28,6 +28,7 @@ from ..services.error_explainer_service import error_explainer_service
 from ..services.latex_text_extractor import extract_prose, offset_to_latex_position
 from ..services.optimization_personas import PERSONAS
 from ..services.proofreader_service import ProofreadResponse, proofread_latex
+from ..services.publications_service import publications_service
 
 logger = get_logger(__name__)
 
@@ -1574,3 +1575,118 @@ async def list_personas() -> List[PersonaItem]:
         PersonaItem(key=key, label=cfg["label"], description=cfg["description"])
         for key, cfg in PERSONAS.items()
     ]
+
+
+# ── Publications (Feature 58) ─────────────────────────────────────────────────
+
+_ORCID_RE = _re.compile(r"^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$")
+
+
+class PublicationsRequest(BaseModel):
+    source: str = Field(default="orcid", pattern="^orcid$")
+    identifier: str = Field(..., min_length=1, max_length=200)
+    year_from: Optional[int] = Field(None, ge=1900, le=2100)
+    year_to: Optional[int] = Field(None, ge=1900, le=2100)
+    pub_types: Optional[List[str]] = None
+
+    @field_validator("identifier")
+    @classmethod
+    def validate_orcid_format(cls, v: str) -> str:
+        if not _ORCID_RE.match(v.strip()):
+            raise ValueError(
+                "ORCID iD must match the format 0000-0000-0000-0000 "
+                "(16 digits in four groups, last digit may be X)"
+            )
+        return v.strip()
+
+
+class PublicationOut(BaseModel):
+    title: str
+    authors: List[str]
+    venue: str
+    year: Optional[int]
+    doi: Optional[str]
+    url: Optional[str]
+    pub_type: str
+
+
+class PublicationsResponse(BaseModel):
+    publications: List[PublicationOut]
+    latex_section: str
+    cached: bool
+
+
+def _pubs_cache_key(identifier: str, year_from: Optional[int], year_to: Optional[int], pub_types: Optional[List[str]]) -> str:
+    payload = f"{identifier}|{year_from}|{year_to}|{sorted(pub_types or [])}"
+    digest = hashlib.sha256(payload.encode()).hexdigest()[:16]
+    return f"ai:publications:{digest}"
+
+
+@router.post("/generate-publications", response_model=PublicationsResponse)
+async def generate_publications(
+    request: PublicationsRequest,
+    _user=Depends(get_current_user_optional),
+) -> PublicationsResponse:
+    """Fetch publications from ORCID and return as LaTeX bibliography block (Feature 58)."""
+    cache_key = _pubs_cache_key(
+        request.identifier, request.year_from, request.year_to, request.pub_types
+    )
+
+    # Try cache first (best-effort — fail open if Redis is not initialized)
+    try:
+        cached_data = await cache_manager.get(cache_key)
+        if cached_data:
+            return PublicationsResponse(
+                publications=cached_data["publications"],
+                latex_section=cached_data["latex_section"],
+                cached=True,
+            )
+    except Exception:
+        pass
+
+    try:
+        pubs = await publications_service.fetch_from_orcid(request.identifier)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"ORCID fetch failed for {request.identifier}: {exc}")
+        raise HTTPException(status_code=502, detail="Failed to reach ORCID API") from exc
+
+    # Apply filters
+    if request.year_from is not None:
+        pubs = [p for p in pubs if p.year is not None and p.year >= request.year_from]
+    if request.year_to is not None:
+        pubs = [p for p in pubs if p.year is not None and p.year <= request.year_to]
+    if request.pub_types:
+        pubs = [p for p in pubs if p.pub_type in request.pub_types]
+
+    latex_section = publications_service.format_as_latex(pubs)
+
+    pubs_out = [
+        PublicationOut(
+            title=p.title,
+            authors=p.authors,
+            venue=p.venue,
+            year=p.year,
+            doi=p.doi,
+            url=p.url,
+            pub_type=p.pub_type,
+        )
+        for p in pubs
+    ]
+
+    # Cache for 1 hour
+    try:
+        payload_data = {
+            "publications": [po.model_dump() for po in pubs_out],
+            "latex_section": latex_section,
+        }
+        await cache_manager.set(cache_key, payload_data, ttl=3600)
+    except Exception:
+        pass
+
+    return PublicationsResponse(
+        publications=pubs_out,
+        latex_section=latex_section,
+        cached=False,
+    )

--- a/backend/app/services/publications_service.py
+++ b/backend/app/services/publications_service.py
@@ -1,0 +1,191 @@
+"""
+Publications service for Feature 58 — Publication List Auto-Generator.
+
+Fetches publications from ORCID (free public API) and formats them as
+LaTeX bibliography entries inside a \\section{Publications} block.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import httpx
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+ORCID_API_BASE = "https://pub.orcid.org/v3.0"
+
+_KNOWN_PUB_TYPES = {"journal", "conference", "preprint", "book_chapter"}
+
+
+@dataclass
+class Publication:
+    title: str
+    authors: List[str]
+    venue: str          # journal name or conference
+    year: Optional[int]
+    doi: Optional[str]
+    url: Optional[str]
+    pub_type: str       # "journal" | "conference" | "preprint" | "book_chapter"
+
+
+class PublicationsService:
+    # ── ORCID fetch ──────────────────────────────────────────────────────────
+
+    async def fetch_from_orcid(self, orcid_id: str) -> List[Publication]:
+        """Fetch all works for an ORCID iD and return as Publication list."""
+        url = f"{ORCID_API_BASE}/{orcid_id}/works"
+        headers = {"Accept": "application/json"}
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(url, headers=headers)
+            if resp.status_code == 404:
+                raise ValueError(f"ORCID iD not found: {orcid_id}")
+            resp.raise_for_status()
+            data = resp.json()
+
+        publications: List[Publication] = []
+        for group in data.get("group", []):
+            pub = self._parse_work_group(group)
+            if pub:
+                publications.append(pub)
+
+        return publications
+
+    def _parse_work_group(self, group: dict) -> Optional[Publication]:
+        """Parse a single work-group from the ORCID /works summary response."""
+        summaries = group.get("work-summary", [])
+        if not summaries:
+            return None
+
+        # Use the first (preferred) summary
+        summary = summaries[0]
+
+        title_obj = summary.get("title", {}) or {}
+        title_inner = title_obj.get("title", {}) or {}
+        title = (title_inner.get("value") or "").strip()
+        if not title:
+            return None
+
+        year_obj = (summary.get("publication-date") or {}).get("year") or {}
+        year_raw = year_obj.get("value")
+        year: Optional[int] = int(year_raw) if year_raw and year_raw.isdigit() else None
+
+        journal_obj = summary.get("journal-title") or {}
+        venue = (journal_obj.get("value") or "").strip()
+
+        # Determine pub_type from work-type
+        work_type = (summary.get("type") or "").lower()
+        pub_type = self._map_work_type(work_type)
+
+        # External IDs → DOI / URL
+        doi: Optional[str] = None
+        url: Optional[str] = None
+        ext_ids = (summary.get("external-ids") or {}).get("external-id", []) or []
+        for ext in ext_ids:
+            id_type = (ext.get("external-id-type") or "").lower()
+            id_value = (ext.get("external-id-value") or "").strip()
+            id_url = (ext.get("external-id-url") or {}).get("value") or ""
+            if id_type == "doi" and id_value:
+                doi = id_value
+                if not url and id_url:
+                    url = id_url
+            elif id_url and not url:
+                url = id_url
+
+        # Contributors come from the detailed work record; summaries only
+        # include contributor count. We leave authors empty for the summary
+        # endpoint — callers that need contributors should fetch the full work.
+        authors: List[str] = []
+
+        return Publication(
+            title=title,
+            authors=authors,
+            venue=venue,
+            year=year,
+            doi=doi,
+            url=url,
+            pub_type=pub_type,
+        )
+
+    @staticmethod
+    def _map_work_type(work_type: str) -> str:
+        if "journal" in work_type:
+            return "journal"
+        if "conference" in work_type or "proceedings" in work_type:
+            return "conference"
+        if "preprint" in work_type or "working" in work_type:
+            return "preprint"
+        if "book" in work_type or "chapter" in work_type:
+            return "book_chapter"
+        return "journal"  # default
+
+    # ── LaTeX formatter ───────────────────────────────────────────────────────
+
+    def format_as_latex(
+        self,
+        pubs: List[Publication],
+        sort_by: str = "year",
+    ) -> str:
+        """Return a complete \\section{Publications}\\begin{enumerate}...\\end{enumerate} block."""
+        if not pubs:
+            return ""
+
+        if sort_by == "year":
+            sorted_pubs = sorted(
+                pubs,
+                key=lambda p: p.year if p.year is not None else 0,
+                reverse=True,
+            )
+        else:
+            sorted_pubs = list(pubs)
+
+        items: List[str] = []
+        for pub in sorted_pubs:
+            items.append(self._format_entry(pub))
+
+        entries = "\n".join(f"  \\item {item}" for item in items)
+        return (
+            "\\section{Publications}\n"
+            "\\begin{enumerate}\n"
+            f"{entries}\n"
+            "\\end{enumerate}"
+        )
+
+    @staticmethod
+    def _format_entry(pub: Publication) -> str:
+        """Format a single publication as a LaTeX \\item string."""
+        # Authors
+        if pub.authors:
+            authors_str = ", ".join(pub.authors) + "."
+        else:
+            authors_str = ""
+
+        # Title in double-quotes
+        title_str = f"``{pub.title}.''"
+
+        # Venue in italics
+        venue_str = f"\\textit{{{pub.venue}}}" if pub.venue else ""
+
+        # Year
+        year_str = str(pub.year) if pub.year else ""
+
+        # DOI hyperlink
+        doi_str = ""
+        if pub.doi:
+            doi_str = f" \\href{{https://doi.org/{pub.doi}}}{{{pub.doi}}}"
+
+        parts = [p for p in [authors_str, title_str, venue_str, year_str] if p]
+        entry = " ".join(parts)
+        if parts:
+            entry = entry.rstrip(".") + "."
+        if doi_str:
+            entry += doi_str
+
+        return entry
+
+
+publications_service = PublicationsService()

--- a/backend/test/test_publications.py
+++ b/backend/test/test_publications.py
@@ -1,0 +1,626 @@
+"""
+Tests for Feature 58 — Publication List Auto-Generator.
+
+Coverage map:
+  ── Service unit tests (TestPublicationsServiceUnit) ──────────────────────────
+  58U-01  fetch_from_orcid (mocked httpx) returns correctly parsed Publication list
+  58U-02  fetch_from_orcid with 404 response raises ValueError containing "not found"
+  58U-03  format_as_latex on empty list → ""
+  58U-04  format_as_latex produces \\section{Publications}
+  58U-05  format_as_latex produces \\begin{enumerate} / \\end{enumerate}
+  58U-06  format_as_latex sorts by year descending (newest first)
+  58U-07  _map_work_type: journal-article → "journal"
+  58U-08  _map_work_type: conference-paper → "conference"
+  58U-09  _map_work_type: preprint → "preprint"
+  58U-10  _map_work_type: book-chapter → "book_chapter"
+  58U-11  DOI produces \\href{https://doi.org/...} in formatted entry
+  58U-12  Missing venue produces no \\textit{} in formatted entry
+
+  ── HTTP integration tests (TestPublicationsEndpoint) ─────────────────────────
+  58I-01  Valid ORCID → 200 with publications, latex_section, cached fields
+  58I-02  Invalid ORCID format (too short) → 422
+  58I-03  Invalid ORCID format (non-digit letters) → 422
+  58I-04  ORCID 404 → 422 (not 404, not 500), detail contains "not found"
+  58I-05  ORCID network error → 502
+  58I-06  year_from filter removes publications with year < filter value
+  58I-07  year_to filter removes publications with year > filter value
+  58I-08  pub_types=["conference"] removes non-conference entries
+  58I-09  latex_section contains \\begin{enumerate} and \\section{Publications}
+  58I-10  Cache hit: patch cache_manager.get → response has cached=True
+  58I-11  Empty ORCID works list (no groups) → 200, publications=[], latex_section=""
+  58I-12  source="scholar" → 422 (pattern constraint; only "orcid" accepted for MVP)
+
+  ── Authentication tests (TestPublicationsAuth) ────────────────────────────────
+  58A-01  No Authorization header → 200 (endpoint uses get_current_user_optional)
+  58A-02  Syntactically invalid Bearer token → 200 (auth failure treated as anonymous)
+  58A-03  Expired session token → 200 (optional auth; expired ≠ 401)
+  58A-04  Valid authenticated request → 200
+
+Infrastructure notes:
+  - httpx mock: always patch app.services.publications_service.httpx.AsyncClient
+  - cache mock: patch app.api.ai_routes.cache_manager.get (AsyncMock)
+  - No real ORCID network calls in any test
+  - db_session: real Neon PostgreSQL, rolls back after each test
+  - Redis: real localhost:6379/15, but cache_manager not initialized in tests
+    (lifespan doesn't run) — cache tests use mock, not real Redis writes
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.publications_service import Publication, PublicationsService
+
+# ── Shared constants ───────────────────────────────────────────────────────────
+
+VALID_ORCID = "0000-0001-2345-6789"
+INVALID_ORCID_SHORT = "0000-0001-2345"          # only 3 groups
+INVALID_ORCID_LETTERS = "ABCD-0001-2345-6789"   # non-digit first group
+
+#: Three-entry mock that exercises all three pub_types used by filter tests.
+#: years: 2023 (journal), 2021 (conference), 2020 (preprint)
+MOCK_ORCID_RESPONSE: dict[str, Any] = {
+    "group": [
+        {
+            "work-summary": [
+                {
+                    "title": {"title": {"value": "Deep Learning for Resume Parsing"}},
+                    "publication-date": {"year": {"value": "2023"}},
+                    "journal-title": {"value": "Journal of NLP"},
+                    "type": "journal-article",
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1234/test",
+                                "external-id-url": {
+                                    "value": "https://doi.org/10.1234/test"
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        {
+            "work-summary": [
+                {
+                    "title": {"title": {"value": "LaTeX Compiler Optimization"}},
+                    "publication-date": {"year": {"value": "2021"}},
+                    "journal-title": {"value": "ICSE 2021"},
+                    "type": "conference-paper",
+                    "external-ids": {"external-id": []},
+                }
+            ]
+        },
+        {
+            "work-summary": [
+                {
+                    "title": {"title": {"value": "Survey of ATS Systems"}},
+                    "publication-date": {"year": {"value": "2020"}},
+                    "journal-title": {"value": "arXiv"},
+                    "type": "preprint",
+                    "external-ids": {"external-id": []},
+                }
+            ]
+        },
+    ]
+}
+
+MOCK_ORCID_EMPTY: dict[str, Any] = {"group": []}
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_200(json_data: Any) -> MagicMock:
+    """Build a mock httpx.Response that returns status 200 + json_data."""
+    mock = MagicMock(spec=Response)
+    mock.status_code = 200
+    mock.json.return_value = json_data
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+def _make_404() -> MagicMock:
+    """Build a mock httpx.Response for a 404 Not Found."""
+    mock = MagicMock(spec=Response)
+    mock.status_code = 404
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+@contextmanager
+def _patch_orcid(mock_resp: MagicMock):
+    """
+    Context manager that patches httpx.AsyncClient used by PublicationsService.
+
+    Usage::
+
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post("/ai/generate-publications", json={...})
+    """
+    with patch(
+        "app.services.publications_service.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+        yield mock_cls
+
+
+@contextmanager
+def _patch_orcid_error(exc: Exception):
+    """Context manager that makes the ORCID GET raise exc."""
+    with patch(
+        "app.services.publications_service.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=exc)
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+        yield mock_cls
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+# conftest already provides: client, auth_headers, expired_auth_headers, db_session
+# Import _insert_session locally so auth tests can build their own sessions.
+from conftest import _insert_session  # noqa: E402
+
+
+@pytest.fixture
+async def test_user(db_session: AsyncSession) -> dict[str, str]:
+    """Create a minimal user row and return its id + email."""
+    from sqlalchemy import text
+
+    user_id = str(uuid.uuid4())
+    email = f"test_{user_id.replace('-', '')}@example.com"
+    await db_session.execute(
+        text(
+            "INSERT INTO users "
+            "(id, email, name, email_verified, subscription_plan, "
+            "subscription_status, trial_used) "
+            "VALUES (:id, :email, 'Pub Test User', true, 'free', 'active', false) "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": user_id, "email": email},
+    )
+    await db_session.commit()
+    return {"id": user_id, "email": email}
+
+
+@pytest.fixture
+async def pub_auth_headers(
+    db_session: AsyncSession, test_user: dict[str, str]
+) -> dict[str, str]:
+    """Valid Bearer token for the test_user created above."""
+    token = await _insert_session(db_session, test_user["id"])
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Service unit tests ─────────────────────────────────────────────────────────
+
+
+class TestPublicationsServiceUnit:
+    """58U-xx — direct service tests, no HTTP, no database."""
+
+    # 58U-01 ─────────────────────────────────────────────────────────────────
+    async def test_fetch_from_orcid_returns_publications(self) -> None:
+        """fetch_from_orcid with mocked httpx returns correctly parsed list."""
+        svc = PublicationsService()
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            pubs = await svc.fetch_from_orcid(VALID_ORCID)
+
+        assert len(pubs) == 3
+        titles = {p.title for p in pubs}
+        assert "Deep Learning for Resume Parsing" in titles
+        assert "LaTeX Compiler Optimization" in titles
+        assert "Survey of ATS Systems" in titles
+
+        doi_pub = next(p for p in pubs if p.title == "Deep Learning for Resume Parsing")
+        assert doi_pub.doi == "10.1234/test"
+        assert doi_pub.year == 2023
+        assert doi_pub.pub_type == "journal"
+        assert doi_pub.venue == "Journal of NLP"
+
+    # 58U-02 ─────────────────────────────────────────────────────────────────
+    async def test_fetch_from_orcid_404_raises_value_error(self) -> None:
+        """fetch_from_orcid with 404 raises ValueError containing 'not found'."""
+        svc = PublicationsService()
+        with _patch_orcid(_make_404()):
+            with pytest.raises(ValueError, match="not found"):
+                await svc.fetch_from_orcid(VALID_ORCID)
+
+    # 58U-03 ─────────────────────────────────────────────────────────────────
+    def test_format_as_latex_empty_list(self) -> None:
+        """format_as_latex on empty list returns empty string."""
+        assert PublicationsService().format_as_latex([]) == ""
+
+    # 58U-04 ─────────────────────────────────────────────────────────────────
+    def test_format_as_latex_contains_section(self) -> None:
+        r"""format_as_latex produces \section{Publications}."""
+        pubs = [Publication("X", [], "Y", 2020, None, None, "journal")]
+        result = PublicationsService().format_as_latex(pubs)
+        assert r"\section{Publications}" in result
+
+    # 58U-05 ─────────────────────────────────────────────────────────────────
+    def test_format_as_latex_contains_enumerate(self) -> None:
+        r"""format_as_latex produces \begin{enumerate} and \end{enumerate}."""
+        pubs = [
+            Publication("Test Paper", ["A. Author"], "Journal", 2022, None, None, "journal")
+        ]
+        result = PublicationsService().format_as_latex(pubs)
+        assert r"\begin{enumerate}" in result
+        assert r"\end{enumerate}" in result
+
+    # 58U-06 ─────────────────────────────────────────────────────────────────
+    def test_format_as_latex_sorted_year_descending(self) -> None:
+        """format_as_latex sorts publications newest-first."""
+        pubs = [
+            Publication("Old Paper", [], "Venue", 2015, None, None, "journal"),
+            Publication("New Paper", [], "Venue", 2023, None, None, "journal"),
+        ]
+        result = PublicationsService().format_as_latex(pubs)
+        assert result.find("New Paper") < result.find("Old Paper"), (
+            "Newest publication should appear before older one"
+        )
+
+    # 58U-07 ─────────────────────────────────────────────────────────────────
+    def test_map_work_type_journal(self) -> None:
+        assert PublicationsService._map_work_type("journal-article") == "journal"
+
+    # 58U-08 ─────────────────────────────────────────────────────────────────
+    def test_map_work_type_conference(self) -> None:
+        assert PublicationsService._map_work_type("conference-paper") == "conference"
+
+    # 58U-09 ─────────────────────────────────────────────────────────────────
+    def test_map_work_type_preprint(self) -> None:
+        assert PublicationsService._map_work_type("preprint") == "preprint"
+
+    # 58U-10 ─────────────────────────────────────────────────────────────────
+    def test_map_work_type_book_chapter(self) -> None:
+        assert PublicationsService._map_work_type("book-chapter") == "book_chapter"
+
+    # 58U-11 ─────────────────────────────────────────────────────────────────
+    def test_format_entry_doi_produces_href(self) -> None:
+        r"""DOI produces \href{https://doi.org/...} in the formatted entry."""
+        pub = Publication("DOI Paper", [], "Journal", 2023, "10.99/test", None, "journal")
+        result = PublicationsService().format_as_latex([pub])
+        assert r"\href{https://doi.org/10.99/test}" in result
+
+    # 58U-12 ─────────────────────────────────────────────────────────────────
+    def test_format_entry_missing_venue_no_textit(self) -> None:
+        r"""Missing venue does not produce a \textit{} in the formatted entry."""
+        pub = Publication("No Venue Paper", [], "", 2023, None, None, "journal")
+        result = PublicationsService().format_as_latex([pub])
+        assert r"\textit{}" not in result
+
+
+# ── HTTP integration tests ─────────────────────────────────────────────────────
+
+
+class TestPublicationsEndpoint:
+    """58I-xx — full HTTP round-trips via ASGI TestClient."""
+
+    # 58I-01 ─────────────────────────────────────────────────────────────────
+    async def test_valid_orcid_returns_200_with_all_fields(
+        self, client: AsyncClient
+    ) -> None:
+        """Valid ORCID → 200 with publications, latex_section, cached fields."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "publications" in body
+        assert "latex_section" in body
+        assert "cached" in body
+        assert isinstance(body["publications"], list)
+        assert len(body["publications"]) == 3
+        assert isinstance(body["cached"], bool)
+
+    # 58I-02 ─────────────────────────────────────────────────────────────────
+    async def test_invalid_orcid_short_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """ORCID with only 3 groups → 422 validation error."""
+        resp = await client.post(
+            "/ai/generate-publications",
+            json={"identifier": INVALID_ORCID_SHORT},
+        )
+        assert resp.status_code == 422
+
+    # 58I-03 ─────────────────────────────────────────────────────────────────
+    async def test_invalid_orcid_letters_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """ORCID with non-digit characters in first group → 422."""
+        resp = await client.post(
+            "/ai/generate-publications",
+            json={"identifier": INVALID_ORCID_LETTERS},
+        )
+        assert resp.status_code == 422
+
+    # 58I-04 ─────────────────────────────────────────────────────────────────
+    async def test_orcid_not_found_returns_422_not_404(
+        self, client: AsyncClient
+    ) -> None:
+        """ORCID 404 from upstream → 422 (not 404, not 500)."""
+        with _patch_orcid(_make_404()):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+            )
+
+        assert resp.status_code == 422
+        assert "not found" in resp.json()["detail"].lower()
+
+    # 58I-05 ─────────────────────────────────────────────────────────────────
+    async def test_orcid_network_error_returns_502(
+        self, client: AsyncClient
+    ) -> None:
+        """ORCID API unreachable → 502 Bad Gateway."""
+        with _patch_orcid_error(Exception("Connection refused")):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+            )
+
+        assert resp.status_code == 502
+
+    # 58I-06 ─────────────────────────────────────────────────────────────────
+    async def test_year_from_filter_removes_older_publications(
+        self, client: AsyncClient
+    ) -> None:
+        """year_from=2022 keeps only the 2023 paper, drops 2021 and 2020."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID, "year_from": 2022},
+            )
+
+        assert resp.status_code == 200
+        pubs = resp.json()["publications"]
+        assert len(pubs) == 1
+        assert pubs[0]["year"] == 2023
+        assert all((p["year"] or 0) >= 2022 for p in pubs)
+
+    # 58I-07 ─────────────────────────────────────────────────────────────────
+    async def test_year_to_filter_removes_newer_publications(
+        self, client: AsyncClient
+    ) -> None:
+        """year_to=2021 keeps 2021 and 2020, drops the 2023 paper."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID, "year_to": 2021},
+            )
+
+        assert resp.status_code == 200
+        pubs = resp.json()["publications"]
+        assert len(pubs) == 2
+        assert all((p["year"] or 9999) <= 2021 for p in pubs)
+
+    # 58I-08 ─────────────────────────────────────────────────────────────────
+    async def test_pub_types_conference_filter(
+        self, client: AsyncClient
+    ) -> None:
+        """pub_types=['conference'] returns only the conference entry."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID, "pub_types": ["conference"]},
+            )
+
+        assert resp.status_code == 200
+        pubs = resp.json()["publications"]
+        assert len(pubs) == 1
+        assert pubs[0]["pub_type"] == "conference"
+        assert all(p["pub_type"] == "conference" for p in pubs)
+
+    # 58I-09 ─────────────────────────────────────────────────────────────────
+    async def test_latex_section_contains_enumerate_and_section(
+        self, client: AsyncClient
+    ) -> None:
+        r"""Response latex_section contains \begin{enumerate} and \section{Publications}."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+            )
+
+        assert resp.status_code == 200
+        latex = resp.json()["latex_section"]
+        assert r"\begin{enumerate}" in latex
+        assert r"\section{Publications}" in latex
+
+    # 58I-10 ─────────────────────────────────────────────────────────────────
+    async def test_cache_hit_returns_cached_true(
+        self, client: AsyncClient
+    ) -> None:
+        """When cache_manager.get returns a payload, response has cached=True."""
+        cached_payload = {
+            "publications": [],
+            "latex_section": r"\section{Publications}\begin{enumerate}\end{enumerate}",
+        }
+        with patch(
+            "app.api.ai_routes.cache_manager.get",
+            new_callable=AsyncMock,
+            return_value=cached_payload,
+        ):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cached"] is True
+        assert body["latex_section"] == cached_payload["latex_section"]
+        assert body["publications"] == []
+
+    # 58I-11 ─────────────────────────────────────────────────────────────────
+    async def test_empty_orcid_works_list_returns_200_empty(
+        self, client: AsyncClient
+    ) -> None:
+        """ORCID profile with no works → 200, publications=[], latex_section=''."""
+        with _patch_orcid(_make_200(MOCK_ORCID_EMPTY)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["publications"] == []
+        assert body["latex_section"] == ""
+
+    # 58I-12 ─────────────────────────────────────────────────────────────────
+    async def test_source_scholar_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """source='scholar' violates the '^orcid$' pattern constraint → 422."""
+        resp = await client.post(
+            "/ai/generate-publications",
+            json={"identifier": VALID_ORCID, "source": "scholar"},
+        )
+        assert resp.status_code == 422
+
+    # ── Publication field integrity ────────────────────────────────────────
+
+    async def test_publication_fields_in_response(
+        self, client: AsyncClient
+    ) -> None:
+        """Each publication in the response carries all required fields."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+            )
+
+        assert resp.status_code == 200
+        for pub in resp.json()["publications"]:
+            assert "title" in pub
+            assert "authors" in pub
+            assert "venue" in pub
+            assert "year" in pub
+            assert "doi" in pub
+            assert "url" in pub
+            assert "pub_type" in pub
+
+    async def test_doi_pub_has_correct_doi_value(
+        self, client: AsyncClient
+    ) -> None:
+        """The journal entry in the mock has DOI 10.1234/test."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+            )
+
+        assert resp.status_code == 200
+        journal_pubs = [
+            p for p in resp.json()["publications"] if p["pub_type"] == "journal"
+        ]
+        assert len(journal_pubs) == 1
+        assert journal_pubs[0]["doi"] == "10.1234/test"
+
+    async def test_combined_year_and_type_filter(
+        self, client: AsyncClient
+    ) -> None:
+        """Combining year_from and pub_types keeps only matching entries."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={
+                    "identifier": VALID_ORCID,
+                    "year_from": 2020,
+                    "year_to": 2022,
+                    "pub_types": ["conference", "preprint"],
+                },
+            )
+
+        assert resp.status_code == 200
+        pubs = resp.json()["publications"]
+        # 2023 journal excluded by year_from+type; 2021 conference and 2020 preprint remain
+        assert len(pubs) == 2
+        for pub in pubs:
+            assert pub["pub_type"] in ("conference", "preprint")
+            assert 2020 <= (pub["year"] or 0) <= 2022
+
+
+# ── Authentication tests ───────────────────────────────────────────────────────
+
+
+class TestPublicationsAuth:
+    """
+    58A-xx — verify that /ai/generate-publications uses get_current_user_optional
+    and therefore never blocks unauthenticated or malformed requests.
+    """
+
+    # 58A-01 ─────────────────────────────────────────────────────────────────
+    async def test_unauthenticated_no_token_returns_200(
+        self, client: AsyncClient
+    ) -> None:
+        """No Authorization header → endpoint still returns 200."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+                # no headers — anonymous request
+            )
+        assert resp.status_code == 200
+
+    # 58A-02 ─────────────────────────────────────────────────────────────────
+    async def test_invalid_bearer_token_returns_200(
+        self, client: AsyncClient
+    ) -> None:
+        """A syntactically valid but unknown Bearer token → 200, not 401."""
+        bogus_headers = {"Authorization": "Bearer totally-made-up-token-xyz"}
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+                headers=bogus_headers,
+            )
+        assert resp.status_code == 200
+
+    # 58A-03 ─────────────────────────────────────────────────────────────────
+    async def test_expired_token_returns_200(
+        self, client: AsyncClient, expired_auth_headers: dict
+    ) -> None:
+        """Expired session token → 200 (optional auth ignores expiry failures)."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+                headers=expired_auth_headers,
+            )
+        assert resp.status_code == 200
+
+    # 58A-04 ─────────────────────────────────────────────────────────────────
+    async def test_authenticated_request_returns_200(
+        self, client: AsyncClient, pub_auth_headers: dict
+    ) -> None:
+        """Valid authenticated request succeeds as expected."""
+        with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
+            resp = await client.post(
+                "/ai/generate-publications",
+                json={"identifier": VALID_ORCID},
+                headers=pub_auth_headers,
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["publications"]) == 3

--- a/backend/test/test_publications.py
+++ b/backend/test/test_publications.py
@@ -140,16 +140,17 @@ def _make_404() -> MagicMock:
 @contextmanager
 def _patch_orcid(mock_resp: MagicMock):
     """
-    Context manager that patches httpx.AsyncClient used by PublicationsService.
+    Context manager that patches httpx.AsyncClient used by PublicationsService
+    and forces a cache miss so Redis state cannot pollute test results in CI.
 
     Usage::
 
         with _patch_orcid(_make_200(MOCK_ORCID_RESPONSE)):
             resp = await client.post("/ai/generate-publications", json={...})
     """
-    with patch(
-        "app.services.publications_service.httpx.AsyncClient"
-    ) as mock_cls:
+    with patch("app.api.ai_routes.cache_manager.get", new_callable=AsyncMock, return_value=None), \
+         patch("app.api.ai_routes.cache_manager.set", new_callable=AsyncMock), \
+         patch("app.services.publications_service.httpx.AsyncClient") as mock_cls:
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_resp)
         mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -159,10 +160,10 @@ def _patch_orcid(mock_resp: MagicMock):
 
 @contextmanager
 def _patch_orcid_error(exc: Exception):
-    """Context manager that makes the ORCID GET raise exc."""
-    with patch(
-        "app.services.publications_service.httpx.AsyncClient"
-    ) as mock_cls:
+    """Context manager that makes the ORCID GET raise exc, with cache bypassed."""
+    with patch("app.api.ai_routes.cache_manager.get", new_callable=AsyncMock, return_value=None), \
+         patch("app.api.ai_routes.cache_manager.set", new_callable=AsyncMock), \
+         patch("app.services.publications_service.httpx.AsyncClient") as mock_cls:
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=exc)
         mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)

--- a/features-checklist/P2_checklist.md
+++ b/features-checklist/P2_checklist.md
@@ -989,7 +989,7 @@ delta indicator. Dashboard average score widget.
 restructures `\section{}` blocks. Diff preview before applying.
 
 ### 53A · Backend — Section Parser
-- [ ] Create `backend/app/services/latex_section_parser.py`:
+- [x] Create `backend/app/services/latex_section_parser.py`:
   ```python
   @dataclass
   class LatexSection:
@@ -1008,7 +1008,7 @@ restructures `\section{}` blocks. Diff preview before applying.
   ```
 
 ### 53B · Backend — Section Reorder Endpoint
-- [ ] Add `POST /ai/reorder-sections` to `backend/app/api/ai_routes.py`:
+- [x] Add `POST /ai/reorder-sections` to `backend/app/api/ai_routes.py`:
   ```python
   class ReorderSectionsRequest(BaseModel):
       resume_latex: str = Field(..., max_length=200_000)
@@ -1026,7 +1026,7 @@ restructures `\section{}` blocks. Diff preview before applying.
   - Apply `reorder_sections()` to produce `reordered_latex`
 
 ### 53C · Frontend — Section Reorder Panel
-- [ ] Create `frontend/src/components/SectionReorderPanel.tsx`:
+- [x] Create `frontend/src/components/SectionReorderPanel.tsx`:
   - Career stage dropdown + optional JD textarea
   - "Suggest Order" button → API call
   - Drag-and-drop list (using `@dnd-kit/sortable` from Feature 15) showing current vs AI suggestion
@@ -1034,7 +1034,7 @@ restructures `\section{}` blocks. Diff preview before applying.
   - "Apply Reordering" → `editorRef.current?.setValue(reordered_latex)`
 
 ### 53D · Tests
-- [ ] `backend/test/test_section_reorder.py`:
+- [x] `backend/test/test_section_reorder.py`:
   - `extract_sections()` correctly identifies 4 sections in test resume
   - `reorder_sections()` preserves all content, only changes order
   - Endpoint `reordered_latex` has sections in `suggested_order` sequence
@@ -1116,7 +1116,7 @@ Recommend condensing or removing. Exception for prestigious institutions.
 the LLM system prompt for the optimization run.
 
 ### 56A · Backend — Persona Profiles
-- [ ] Create `backend/app/services/optimization_personas.py`:
+- [x] Create `backend/app/services/optimization_personas.py`:
   ```python
   PERSONAS: Dict[str, dict] = {
       "startup": {
@@ -1158,22 +1158,22 @@ the LLM system prompt for the optimization run.
   ```
 
 ### 56B · Backend — Optimization Integration
-- [ ] In `backend/app/workers/orchestrator.py` (or LLM optimization task):
+- [x] In `backend/app/workers/orchestrator.py` (or LLM optimization task):
   - Add `persona: Optional[str] = None` parameter
   - If set: validate `persona in PERSONAS.keys()`, then append `PERSONAS[persona]['prompt_addon']`
     to the system prompt
-- [ ] In `JobSubmissionRequest` in `backend/app/api/job_routes.py`: add `persona: Optional[str] = None`
+- [x] In `JobSubmissionRequest` in `backend/app/api/job_routes.py`: add `persona: Optional[str] = None`
 
 ### 56C · Frontend — Persona Selector
-- [ ] In `frontend/src/app/workspace/[resumeId]/optimize/page.tsx`:
+- [x] In `frontend/src/app/workspace/[resumeId]/optimize/page.tsx`:
   - "Optimization Style" section above optimization level selector
   - Card grid: 5 persona cards with icon + label + description
   - Selected persona: `ring-2 ring-violet-500/50` border
   - Pass `persona` in optimization job request body
-- [ ] Persist selected persona in resume `metadata.last_persona` for next session
+- [x] Persist selected persona in resume `metadata.last_persona` for next session
 
 ### 56D · Tests
-- [ ] `backend/test/test_optimization_personas.py`:
+- [x] `backend/test/test_optimization_personas.py`:
   - Startup persona → system prompt contains "ownership" (mock LLM, verify prompt)
   - Invalid persona name → 422
   - `persona=null` → default behavior, no persona addon in prompt
@@ -1209,7 +1209,7 @@ before applying. No LLM needed — pure regex transformation.
 LaTeX bibliography entries. Filter by year/type. Insert complete publications section.
 
 ### 58A · Backend — Publications Service
-- [ ] Create `backend/app/services/publications_service.py`:
+- [x] Create `backend/app/services/publications_service.py`:
   ```python
   @dataclass
   class Publication:
@@ -1234,7 +1234,7 @@ LaTeX bibliography entries. Filter by year/type. Insert complete publications se
   ```
 
 ### 58B · Backend — Publications Endpoint
-- [ ] Add `POST /ai/generate-publications` to `backend/app/api/ai_routes.py`:
+- [x] Add `POST /ai/generate-publications` to `backend/app/api/ai_routes.py`:
   ```python
   class PublicationsRequest(BaseModel):
       source: str = "orcid"   # "orcid" only for MVP (Scholar requires paid SerpAPI)
@@ -1252,14 +1252,14 @@ LaTeX bibliography entries. Filter by year/type. Insert complete publications se
   - Cache by `hash(identifier + str(filters))`, TTL=3600
 
 ### 58C · Frontend — Publications Panel
-- [ ] Create `frontend/src/components/PublicationsPanel.tsx`:
+- [x] Create `frontend/src/components/PublicationsPanel.tsx`:
   - Source: ORCID ID input field
   - Filters: year range sliders, pub type checkboxes
   - "Fetch" button → shows loaded publications as checkable list
   - "Insert Publications Section" → inserts `latex_section` at cursor
 
 ### 58D · Tests
-- [ ] `backend/test/test_publications.py`:
+- [x] `backend/test/test_publications.py`:
   - Valid ORCID format passes validation
   - Invalid ORCID format → 422
   - ORCID fetch (mocked httpx) → returns publication list with correct fields

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -3358,10 +3358,6 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -7450,12 +7446,6 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1

--- a/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
@@ -23,6 +23,7 @@ import ErrorExplainerPanel from '@/components/ErrorExplainerPanel'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
 import AtsSimulatorPanel from '@/components/ats/AtsSimulatorPanel'
 import KeywordDensityMap from '@/components/KeywordDensityMap'
+import PublicationsPanel from '@/components/PublicationsPanel'
 
 const TRIM_INSTRUCTION =
   'Condense this resume to fit on exactly ONE page. Prioritize recent and most impactful content. Remove less critical details, condense bullet points, reduce descriptions. Do NOT remove any job titles, companies, degrees, or institution names.'
@@ -83,7 +84,7 @@ export default function OptimizationSuitePage() {
   const [industryOverride, setIndustryOverride] = useState<string | null>(null)
 
   // ATS tools tab
-  const [activeToolTab, setActiveToolTab] = useState<'ATS Simulator' | 'Keywords'>('ATS Simulator')
+  const [activeToolTab, setActiveToolTab] = useState<'ATS Simulator' | 'Keywords' | 'Publications'>('ATS Simulator')
 
   // Error explainer
   const [explainerOpen, setExplainerOpen] = useState(false)
@@ -708,7 +709,7 @@ export default function OptimizationSuitePage() {
           <section className="surface-panel edge-highlight overflow-hidden">
             {/* Tab bar */}
             <div className="flex border-b border-white/10">
-              {(['ATS Simulator', 'Keywords'] as const).map(tab => (
+              {(['ATS Simulator', 'Keywords', 'Publications'] as const).map(tab => (
                 <button
                   key={tab}
                   onClick={() => setActiveToolTab(tab)}
@@ -731,13 +732,21 @@ export default function OptimizationSuitePage() {
                   </p>
                   <AtsSimulatorPanel getLatexContent={() => editorRef.current?.getValue() || resume?.latex_content || ''} />
                 </>
-              ) : (
+              ) : activeToolTab === 'Keywords' ? (
                 <>
                   <p className="mb-5 text-sm text-zinc-400">
                     Paste a job description to see which keywords your resume covers. Green = present,
                     amber = partial match, red = missing. Click a missing keyword for insertion advice.
                   </p>
                   <KeywordDensityMap getLatexContent={() => editorRef.current?.getValue() || resume?.latex_content || ''} />
+                </>
+              ) : (
+                <>
+                  <p className="mb-5 text-sm text-zinc-400">
+                    Fetch your publications from ORCID and insert a formatted bibliography section
+                    directly into your resume. Filter by year range or publication type.
+                  </p>
+                  <PublicationsPanel insertAtCursor={(text) => editorRef.current?.insertAtCursor(text)} />
                 </>
               )}
             </div>

--- a/frontend/src/components/PublicationsPanel.tsx
+++ b/frontend/src/components/PublicationsPanel.tsx
@@ -1,0 +1,260 @@
+'use client'
+
+import { useState } from 'react'
+import { BookOpen, Loader2, Plus } from 'lucide-react'
+import { apiClient, type PublicationOut } from '@/lib/api-client'
+
+const PUB_TYPES = [
+  { key: 'journal', label: 'Journal' },
+  { key: 'conference', label: 'Conference' },
+  { key: 'preprint', label: 'Preprint' },
+  { key: 'book_chapter', label: 'Book Chapter' },
+] as const
+
+interface PublicationsPanelProps {
+  insertAtCursor: (text: string) => void
+}
+
+export default function PublicationsPanel({ insertAtCursor }: PublicationsPanelProps) {
+  const [orcidId, setOrcidId] = useState('')
+  const [yearFrom, setYearFrom] = useState('')
+  const [yearTo, setYearTo] = useState('')
+  const [selectedTypes, setSelectedTypes] = useState<string[]>([])
+  const [publications, setPublications] = useState<PublicationOut[]>([])
+  const [selectedPubs, setSelectedPubs] = useState<Set<number>>(new Set())
+  const [latexSection, setLatexSection] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [hasFetched, setHasFetched] = useState(false)
+
+  const toggleType = (key: string) => {
+    setSelectedTypes(prev =>
+      prev.includes(key) ? prev.filter(t => t !== key) : [...prev, key]
+    )
+  }
+
+  const togglePub = (idx: number) => {
+    setSelectedPubs(prev => {
+      const next = new Set(prev)
+      if (next.has(idx)) next.delete(idx)
+      else next.add(idx)
+      return next
+    })
+  }
+
+  const selectAll = () =>
+    setSelectedPubs(new Set(publications.map((_, i) => i)))
+
+  const deselectAll = () => setSelectedPubs(new Set())
+
+  const handleFetch = async () => {
+    const id = orcidId.trim()
+    if (!id) return
+    setIsLoading(true)
+    setError(null)
+    setPublications([])
+    setSelectedPubs(new Set())
+    setLatexSection('')
+    setHasFetched(false)
+    try {
+      const data = await apiClient.generatePublications({
+        source: 'orcid',
+        identifier: id,
+        year_from: yearFrom ? parseInt(yearFrom, 10) : undefined,
+        year_to: yearTo ? parseInt(yearTo, 10) : undefined,
+        pub_types: selectedTypes.length > 0 ? selectedTypes : undefined,
+      })
+      setPublications(data.publications)
+      setLatexSection(data.latex_section)
+      setSelectedPubs(new Set(data.publications.map((_, i) => i)))
+      setHasFetched(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch publications')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleInsert = () => {
+    const selected = publications.filter((_, i) => selectedPubs.has(i))
+    if (selected.length === 0) return
+    // Use backend-generated latex if all pubs are selected, else build from selection
+    const section =
+      selected.length === publications.length && latexSection
+        ? latexSection
+        : buildLatexFromSelected(selected)
+    insertAtCursor('\n' + section + '\n')
+  }
+
+  const buildLatexFromSelected = (pubs: PublicationOut[]): string => {
+    const items = pubs.map(p => {
+      const authorStr = p.authors.length > 0 ? p.authors.join(', ') + '.' : ''
+      const titleStr = `\`\`${p.title}.''`
+      const venueStr = p.venue ? `\\textit{${p.venue}}` : ''
+      const yearStr = p.year ? String(p.year) : ''
+      const doiStr = p.doi ? ` \\href{https://doi.org/${p.doi}}{${p.doi}}` : ''
+      const parts = [authorStr, titleStr, venueStr, yearStr].filter(Boolean)
+      let entry = parts.join(' ')
+      if (parts.length > 0) entry = entry.replace(/\.$/, '') + '.'
+      return `  \\item ${entry}${doiStr}`
+    })
+    return `\\section{Publications}\n\\begin{enumerate}\n${items.join('\n')}\n\\end{enumerate}`
+  }
+
+  const pubTypeLabel = (pub_type: string) =>
+    PUB_TYPES.find(t => t.key === pub_type)?.label ?? pub_type
+
+  return (
+    <div className="space-y-5">
+      {/* ORCID ID input */}
+      <div>
+        <label className="mb-1.5 block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+          ORCID iD
+        </label>
+        <input
+          type="text"
+          value={orcidId}
+          onChange={e => setOrcidId(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') handleFetch() }}
+          placeholder="0000-0000-0000-0000"
+          className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40 font-mono"
+        />
+        <p className="mt-1 text-[11px] text-zinc-600">
+          Find your ORCID iD at orcid.org — it's free and identifies you across publications.
+        </p>
+      </div>
+
+      {/* Filters row */}
+      <div className="flex flex-wrap gap-4">
+        {/* Year range */}
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-zinc-500">Year:</span>
+          <input
+            type="number"
+            value={yearFrom}
+            onChange={e => setYearFrom(e.target.value)}
+            placeholder="From"
+            min={1900}
+            max={2100}
+            className="w-20 rounded-lg border border-white/10 bg-black/40 px-2 py-1 text-xs text-zinc-100 outline-none transition focus:border-orange-300/40"
+          />
+          <span className="text-xs text-zinc-600">–</span>
+          <input
+            type="number"
+            value={yearTo}
+            onChange={e => setYearTo(e.target.value)}
+            placeholder="To"
+            min={1900}
+            max={2100}
+            className="w-20 rounded-lg border border-white/10 bg-black/40 px-2 py-1 text-xs text-zinc-100 outline-none transition focus:border-orange-300/40"
+          />
+        </div>
+
+        {/* Publication type checkboxes */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs text-zinc-500">Types:</span>
+          {PUB_TYPES.map(t => (
+            <label key={t.key} className="flex cursor-pointer items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={selectedTypes.includes(t.key)}
+                onChange={() => toggleType(t.key)}
+                className="accent-orange-400"
+              />
+              <span className="text-xs text-zinc-300">{t.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Fetch button */}
+      <button
+        onClick={handleFetch}
+        disabled={isLoading || !orcidId.trim()}
+        className="flex items-center gap-2 rounded-lg bg-orange-500/20 px-4 py-2.5 text-sm font-semibold text-orange-200 ring-1 ring-orange-400/20 transition hover:bg-orange-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isLoading ? <Loader2 size={14} className="animate-spin" /> : <BookOpen size={14} />}
+        {isLoading ? 'Fetching…' : 'Fetch Publications'}
+      </button>
+
+      {error && (
+        <div className="rounded-lg border border-red-400/20 bg-red-400/10 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {hasFetched && publications.length === 0 && (
+        <p className="text-sm text-zinc-500">
+          No publications found for this ORCID iD with the current filters.
+        </p>
+      )}
+
+      {publications.length > 0 && (
+        <div className="space-y-3">
+          {/* Selection controls */}
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-zinc-400">
+              {selectedPubs.size} of {publications.length} selected
+            </span>
+            <div className="flex gap-3">
+              <button onClick={selectAll} className="text-[11px] text-orange-300 hover:text-orange-200 transition">
+                Select all
+              </button>
+              <button onClick={deselectAll} className="text-[11px] text-zinc-500 hover:text-zinc-300 transition">
+                Deselect all
+              </button>
+            </div>
+          </div>
+
+          {/* Publication list */}
+          <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+            {publications.map((pub, i) => (
+              <label
+                key={i}
+                className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition ${
+                  selectedPubs.has(i)
+                    ? 'border-orange-400/30 bg-orange-400/5'
+                    : 'border-white/10 bg-white/[0.02] hover:border-white/20'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedPubs.has(i)}
+                  onChange={() => togglePub(i)}
+                  className="mt-0.5 shrink-0 accent-orange-400"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="text-xs font-semibold leading-snug text-zinc-200">{pub.title}</p>
+                  <div className="mt-1 flex flex-wrap items-center gap-2">
+                    {pub.venue && (
+                      <span className="text-[10px] italic text-zinc-500">{pub.venue}</span>
+                    )}
+                    {pub.year && (
+                      <span className="text-[10px] text-zinc-600">{pub.year}</span>
+                    )}
+                    <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-zinc-500 ring-1 ring-white/10">
+                      {pubTypeLabel(pub.pub_type)}
+                    </span>
+                    {pub.doi && (
+                      <span className="text-[10px] font-mono text-zinc-600">{pub.doi}</span>
+                    )}
+                  </div>
+                </div>
+              </label>
+            ))}
+          </div>
+
+          {/* Insert button */}
+          <button
+            onClick={handleInsert}
+            disabled={selectedPubs.size === 0}
+            className="flex items-center gap-2 rounded-lg bg-violet-500/20 px-4 py-2.5 text-sm font-semibold text-violet-200 ring-1 ring-violet-400/20 transition hover:bg-violet-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Plus size={14} />
+            Insert Publications Section ({selectedPubs.size})
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1170,6 +1170,17 @@ class ApiClient {
   }
 
   // ---------------------------------------------------------------- //
+  //  Publications (Feature 58)                                       //
+  // ---------------------------------------------------------------- //
+
+  async generatePublications(body: GeneratePublicationsRequest): Promise<GeneratePublicationsResponse> {
+    return this.request('/ai/generate-publications', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+  }
+
+  // ---------------------------------------------------------------- //
   //  Multi-format file I/O                                           //
   // ---------------------------------------------------------------- //
 
@@ -2330,6 +2341,34 @@ export interface ReorderSectionsResponse {
   suggested_order: string[]
   rationale: string
   reordered_latex: string
+  cached: boolean
+}
+
+// ------------------------------------------------------------------ //
+//  Publications (Feature 58)                                          //
+// ------------------------------------------------------------------ //
+
+export interface GeneratePublicationsRequest {
+  source?: string          // "orcid" only for MVP
+  identifier: string       // ORCID ID: 0000-0000-0000-0000
+  year_from?: number | null
+  year_to?: number | null
+  pub_types?: string[]     // ["journal", "conference", "preprint", "book_chapter"]
+}
+
+export interface PublicationOut {
+  title: string
+  authors: string[]
+  venue: string
+  year: number | null
+  doi: string | null
+  url: string | null
+  pub_type: string
+}
+
+export interface GeneratePublicationsResponse {
+  publications: PublicationOut[]
+  latex_section: string
   cached: boolean
 }
 


### PR DESCRIPTION
## Summary

Implements Feature 58 end-to-end: fetch publications from the free ORCID public API, format them as a LaTeX bibliography section, and insert directly into the resume from a new Publications tab in the optimization suite.

### Backend
- **`backend/app/services/publications_service.py`** — `PublicationsService` with `fetch_from_orcid()` (httpx async, ORCID v3 API) and `format_as_latex()` (sorted newest-first, `\section{Publications}\begin{enumerate}...\end{enumerate}`, `\href` DOI links, `\textit{venue}`)
- **`backend/app/api/ai_routes.py`** — `POST /ai/generate-publications` with ORCID regex validation (`^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$`), year_from/year_to/pub_types filters, Redis cache TTL=3600 (fail-open), 404→422, network error→502

### Frontend
- **`frontend/src/components/PublicationsPanel.tsx`** — ORCID ID input, year range filters, pub-type checkboxes, checkable publication list with select-all/deselect-all, Insert Publications Section button wired to `insertAtCursor()`
- **`frontend/src/lib/api-client.ts`** — `GeneratePublicationsRequest`, `PublicationOut`, `GeneratePublicationsResponse` types + `generatePublications()` method
- **`frontend/src/app/workspace/[resumeId]/optimize/page.tsx`** — Publications added as third tab alongside ATS Simulator and Keywords

### Tests
- **`backend/test/test_publications.py`** — 31 tests across 3 classes:
  - `TestPublicationsServiceUnit` (12): service logic, LaTeX formatting, work-type mapping
  - `TestPublicationsEndpoint` (15): HTTP round-trips, validation, filters, caching, empty list, source constraint
  - `TestPublicationsAuth` (4): optional-auth behaviour (no token, invalid token, expired token, valid token all → 200)

### Checklist
- Marks Features 53 (AI Section Reordering), 56 (AI Custom Optimization Persona), and 58 (Publication List Auto-Generator) as complete in `P2_checklist.md` — all were implemented but not ticked

## Test plan
- [ ] `ruff check .` passes clean
- [ ] `pytest backend/test/test_publications.py -v` — all 31 pass
- [ ] `pnpm run build` in `frontend/` — no TS/ESLint errors
- [ ] Navigate to `/workspace/:id/optimize` → Publications tab visible
- [ ] Enter a valid ORCID iD → publications list loads and Insert button works

Closes #127
Closes #130
Closes #132