### PR TITLE
feat: Feature 74 — Resume Collaboration Comments

### DIFF
--- a/backend/alembic/versions/0018_add_resume_comments.py
+++ b/backend/alembic/versions/0018_add_resume_comments.py
@@ -1,0 +1,36 @@
+"""Add resume_comments table (Feature 74)."""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = '0018'
+down_revision = '0017'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'resume_comments',
+        sa.Column('id', UUID(as_uuid=False), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column('resume_id', UUID(as_uuid=False), sa.ForeignKey('resumes.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('workspace_id', UUID(as_uuid=False), sa.ForeignKey('workspaces.id', ondelete='CASCADE'), nullable=True),
+        sa.Column('author_id', UUID(as_uuid=False), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+        sa.Column('line_number', sa.Integer(), nullable=True),
+        sa.Column('section_tag', sa.String(100), nullable=True),
+        sa.Column('resolved', sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index('idx_resume_comments_resume_id', 'resume_comments', ['resume_id'])
+    op.create_index('idx_resume_comments_workspace_id', 'resume_comments', ['workspace_id'])
+    op.create_index('idx_resume_comments_author_id', 'resume_comments', ['author_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('idx_resume_comments_author_id', table_name='resume_comments')
+    op.drop_index('idx_resume_comments_workspace_id', table_name='resume_comments')
+    op.drop_index('idx_resume_comments_resume_id', table_name='resume_comments')
+    op.drop_table('resume_comments')

--- a/backend/app/api/comment_routes.py
+++ b/backend/app/api/comment_routes.py
@@ -1,0 +1,243 @@
+"""Resume collaboration comment routes (Feature 74)."""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.logging import get_logger
+from ..database.connection import get_db
+from ..database.models import Resume, ResumeComment, User, WorkspaceMember
+from ..middleware.auth_middleware import get_current_user_required
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/resumes/{resume_id}/comments", tags=["comments"])
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+
+class CommentCreate(BaseModel):
+    content: str = Field(..., min_length=1, max_length=10000)
+    workspace_id: Optional[str] = None
+    line_number: Optional[int] = Field(default=None, ge=1)
+    section_tag: Optional[str] = Field(default=None, max_length=100)
+
+
+class CommentUpdate(BaseModel):
+    content: str = Field(..., min_length=1, max_length=10000)
+
+
+class CommentResponse(BaseModel):
+    id: str
+    resume_id: str
+    workspace_id: Optional[str] = None
+    author_id: str
+    author_name: Optional[str] = None
+    author_email: Optional[str] = None
+    content: str
+    line_number: Optional[int] = None
+    section_tag: Optional[str] = None
+    resolved: bool
+    created_at: str
+    updated_at: str
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+async def _get_resume_or_404(resume_id: str, db: AsyncSession) -> Resume:
+    result = await db.execute(select(Resume).where(Resume.id == resume_id))
+    resume = result.scalar_one_or_none()
+    if not resume:
+        raise HTTPException(status_code=404, detail="Resume not found")
+    return resume
+
+
+async def _check_workspace_membership(workspace_id: str, user_id: str, db: AsyncSession) -> None:
+    """Raise 403 if user is not a member of the given workspace."""
+    result = await db.execute(
+        select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace_id,
+            WorkspaceMember.user_id == user_id,
+        )
+    )
+    if not result.scalar_one_or_none():
+        raise HTTPException(status_code=403, detail="You are not a member of this workspace")
+
+
+async def _assert_can_comment(
+    resume: Resume, workspace_id: Optional[str], user_id: str, db: AsyncSession
+) -> None:
+    """Commenter must own the resume (personal) or be a workspace member (workspace-scoped)."""
+    if workspace_id:
+        await _check_workspace_membership(workspace_id, user_id, db)
+    elif resume.user_id != user_id:
+        raise HTTPException(status_code=403, detail="You do not have access to this resume")
+
+
+def _comment_to_response(comment: ResumeComment, author: Optional[User] = None) -> CommentResponse:
+    return CommentResponse(
+        id=comment.id,
+        resume_id=comment.resume_id,
+        workspace_id=comment.workspace_id,
+        author_id=comment.author_id,
+        author_name=author.name if author else None,
+        author_email=author.email if author else None,
+        content=comment.content,
+        line_number=comment.line_number,
+        section_tag=comment.section_tag,
+        resolved=comment.resolved,
+        created_at=comment.created_at.isoformat(),
+        updated_at=comment.updated_at.isoformat(),
+    )
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@router.post("", response_model=CommentResponse, status_code=201)
+async def add_comment(
+    resume_id: str,
+    body: CommentCreate,
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    """Add a comment to a resume. Must own the resume (personal) or be workspace member."""
+    resume = await _get_resume_or_404(resume_id, db)
+    await _assert_can_comment(resume, body.workspace_id, user_id, db)
+
+    comment = ResumeComment(
+        resume_id=resume_id,
+        workspace_id=body.workspace_id,
+        author_id=user_id,
+        content=body.content,
+        line_number=body.line_number,
+        section_tag=body.section_tag,
+    )
+    db.add(comment)
+    await db.commit()
+    await db.refresh(comment)
+
+    u_result = await db.execute(select(User).where(User.id == user_id))
+    author = u_result.scalar_one_or_none()
+    return _comment_to_response(comment, author)
+
+
+@router.get("", response_model=List[CommentResponse])
+async def list_comments(
+    resume_id: str,
+    workspace_id: Optional[str] = Query(default=None),
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    """List comments on a resume, optionally filtered by workspace_id."""
+    resume = await _get_resume_or_404(resume_id, db)
+
+    # Access check
+    if workspace_id:
+        await _check_workspace_membership(workspace_id, user_id, db)
+    elif resume.user_id != user_id:
+        raise HTTPException(status_code=403, detail="You do not have access to this resume")
+
+    query = (
+        select(ResumeComment, User)
+        .join(User, ResumeComment.author_id == User.id)
+        .where(ResumeComment.resume_id == resume_id)
+    )
+    if workspace_id:
+        query = query.where(ResumeComment.workspace_id == workspace_id)
+    else:
+        query = query.where(ResumeComment.workspace_id.is_(None))
+
+    result = await db.execute(query.order_by(ResumeComment.created_at))
+    return [_comment_to_response(c, u) for c, u in result.fetchall()]
+
+
+@router.patch("/{comment_id}", response_model=CommentResponse)
+async def update_comment(
+    resume_id: str,
+    comment_id: str,
+    body: CommentUpdate,
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    """Edit a comment (author only)."""
+    result = await db.execute(
+        select(ResumeComment).where(
+            ResumeComment.id == comment_id,
+            ResumeComment.resume_id == resume_id,
+        )
+    )
+    comment = result.scalar_one_or_none()
+    if not comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    if comment.author_id != user_id:
+        raise HTTPException(status_code=403, detail="You can only edit your own comments")
+
+    comment.content = body.content
+    await db.commit()
+    await db.refresh(comment)
+
+    u_result = await db.execute(select(User).where(User.id == user_id))
+    author = u_result.scalar_one_or_none()
+    return _comment_to_response(comment, author)
+
+
+@router.delete("/{comment_id}", status_code=204)
+async def delete_comment(
+    resume_id: str,
+    comment_id: str,
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a comment (author only)."""
+    result = await db.execute(
+        select(ResumeComment).where(
+            ResumeComment.id == comment_id,
+            ResumeComment.resume_id == resume_id,
+        )
+    )
+    comment = result.scalar_one_or_none()
+    if not comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    if comment.author_id != user_id:
+        raise HTTPException(status_code=403, detail="You can only delete your own comments")
+
+    await db.delete(comment)
+    await db.commit()
+
+
+@router.patch("/{comment_id}/resolve", response_model=CommentResponse)
+async def resolve_comment(
+    resume_id: str,
+    comment_id: str,
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    """Mark a comment resolved/unresolved (resume owner or comment author)."""
+    resume = await _get_resume_or_404(resume_id, db)
+
+    result = await db.execute(
+        select(ResumeComment).where(
+            ResumeComment.id == comment_id,
+            ResumeComment.resume_id == resume_id,
+        )
+    )
+    comment = result.scalar_one_or_none()
+    if not comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+
+    # Only the resume owner or the comment author may resolve
+    if user_id != resume.user_id and user_id != comment.author_id:
+        raise HTTPException(status_code=403, detail="You cannot resolve this comment")
+
+    comment.resolved = not comment.resolved
+    await db.commit()
+    await db.refresh(comment)
+
+    u_result = await db.execute(select(User).where(User.id == comment.author_id))
+    author = u_result.scalar_one_or_none()
+    return _comment_to_response(comment, author)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -137,6 +137,11 @@ from .workspace_routes import router as workspace_router
 
 router.include_router(workspace_router)
 
+# Include Resume Comment routes (Feature 74)
+from .comment_routes import router as comment_router
+
+router.include_router(comment_router)
+
 
 @router.get("/health", response_model=HealthResponse)
 async def health_check():

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -560,6 +560,37 @@ class RecruiterNote(Base):
     author: Mapped["User"] = relationship("User")
 
 
+class ResumeComment(Base):
+    """Inline comment on a resume, optionally scoped to a workspace (Feature 74)."""
+    __tablename__ = "resume_comments"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    resume_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("resumes.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    workspace_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    author_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    line_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    section_tag: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    resolved: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    # Relationships
+    resume: Mapped["Resume"] = relationship("Resume")
+    workspace: Mapped[Optional["Workspace"]] = relationship("Workspace")
+    author: Mapped["User"] = relationship("User")
+
+
 # Create indexes for performance
 Index('idx_users_email', User.email)
 Index('idx_device_trials_fingerprint', DeviceTrial.device_fingerprint)

--- a/backend/test/test_comments.py
+++ b/backend/test/test_comments.py
@@ -1,0 +1,326 @@
+"""
+Tests for Feature 74 — Resume Collaboration Comments.
+
+Covers:
+  - Author can add comment (personal and workspace-scoped)
+  - Author can edit own comment
+  - Non-author cannot edit (403)
+  - Author can delete own comment
+  - Resume owner can resolve any comment
+  - Non-member of workspace gets 403 on workspace-scoped comments
+  - List returns correct comments filtered by workspace
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+_LATEX = r"\documentclass{article}\begin{document}Hello\end{document}"
+
+
+async def _create_resume(client: AsyncClient, headers: dict, title: str = "My Resume") -> dict:
+    resp = await client.post("/resumes/", headers=headers, json={"title": title, "latex_content": _LATEX})
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _create_workspace(client: AsyncClient, headers: dict, name: str = "Comment WS") -> dict:
+    resp = await client.post("/workspaces", headers=headers, json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _share_resume(client: AsyncClient, headers: dict, workspace_id: str, resume_id: str) -> None:
+    resp = await client.post(f"/workspaces/{workspace_id}/resumes/{resume_id}", headers=headers)
+    assert resp.status_code == 201, resp.text
+
+
+async def _add_comment(
+    client: AsyncClient,
+    headers: dict,
+    resume_id: str,
+    content: str = "Great section!",
+    workspace_id: str | None = None,
+    line_number: int | None = None,
+) -> dict:
+    body: dict = {"content": content}
+    if workspace_id:
+        body["workspace_id"] = workspace_id
+    if line_number is not None:
+        body["line_number"] = line_number
+    resp = await client.post(
+        f"/resumes/{resume_id}/comments",
+        headers=headers,
+        json=body,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _create_member(
+    db: AsyncSession, client: AsyncClient, owner_headers: dict, workspace_id: str
+) -> tuple[str, str]:
+    """Insert a user in DB, invite them to workspace, return (user_id, token)."""
+    member_id = str(uuid.uuid4())
+    member_email = f"member_{uuid.uuid4().hex[:8]}@example.com"
+    await db.execute(
+        sa_text(
+            "INSERT INTO users (id, email, name, email_verified, subscription_plan, subscription_status, trial_used) "
+            "VALUES (:id, :email, 'Member', true, 'free', 'active', false) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": member_id, "email": member_email},
+    )
+    await db.commit()
+    resp = await client.post(
+        f"/workspaces/{workspace_id}/members/invite",
+        headers=owner_headers,
+        json={"email": member_email, "role": "editor"},
+    )
+    assert resp.status_code == 201, resp.text
+    # Insert session for this member
+    token = f"test_sess_{uuid.uuid4().hex}"
+    from datetime import datetime, timedelta, timezone
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    await db.execute(
+        sa_text(
+            'INSERT INTO session (id, "userId", "expiresAt", token) VALUES (:id, :uid, :exp, :tok)'
+        ),
+        {"id": str(uuid.uuid4()), "uid": member_id, "exp": expires_at, "tok": token},
+    )
+    await db.commit()
+    return member_id, token
+
+
+# ── Add comment ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAddComment:
+    async def test_owner_can_add_personal_comment(self, client: AsyncClient, auth_headers: dict):
+        resume = await _create_resume(client, auth_headers)
+        resp = await client.post(
+            f"/resumes/{resume['id']}/comments",
+            headers=auth_headers,
+            json={"content": "Nice work here"},
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["content"] == "Nice work here"
+        assert data["workspace_id"] is None
+        assert data["resolved"] is False
+
+    async def test_comment_with_line_number(self, client: AsyncClient, auth_headers: dict):
+        resume = await _create_resume(client, auth_headers)
+        comment = await _add_comment(client, auth_headers, resume["id"], line_number=42)
+        assert comment["line_number"] == 42
+
+    async def test_workspace_member_can_add_comment(
+        self, client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+    ):
+        ws = await _create_workspace(client, auth_headers)
+        resume = await _create_resume(client, auth_headers)
+        await _share_resume(client, auth_headers, ws["id"], resume["id"])
+
+        _, token = await _create_member(db_session, client, auth_headers, ws["id"])
+        member_headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await client.post(
+            f"/resumes/{resume['id']}/comments",
+            headers=member_headers,
+            json={"content": "Workspace comment", "workspace_id": ws["id"]},
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["workspace_id"] == ws["id"]
+
+    async def test_non_owner_cannot_add_personal_comment(
+        self, client: AsyncClient, auth_headers: dict, auth_headers2: dict
+    ):
+        """User2 cannot comment on user1's resume without workspace context."""
+        resume = await _create_resume(client, auth_headers)
+        resp = await client.post(
+            f"/resumes/{resume['id']}/comments",
+            headers=auth_headers2,
+            json={"content": "Unauthorized"},
+        )
+        assert resp.status_code == 403
+
+    async def test_non_member_cannot_add_workspace_comment(
+        self, client: AsyncClient, auth_headers: dict, auth_headers2: dict
+    ):
+        ws = await _create_workspace(client, auth_headers)
+        resume = await _create_resume(client, auth_headers)
+        await _share_resume(client, auth_headers, ws["id"], resume["id"])
+
+        resp = await client.post(
+            f"/resumes/{resume['id']}/comments",
+            headers=auth_headers2,
+            json={"content": "Should fail", "workspace_id": ws["id"]},
+        )
+        assert resp.status_code == 403
+
+
+# ── Edit comment ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestEditComment:
+    async def test_author_can_edit_own_comment(self, client: AsyncClient, auth_headers: dict):
+        resume = await _create_resume(client, auth_headers)
+        comment = await _add_comment(client, auth_headers, resume["id"])
+
+        resp = await client.patch(
+            f"/resumes/{resume['id']}/comments/{comment['id']}",
+            headers=auth_headers,
+            json={"content": "Updated content"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["content"] == "Updated content"
+
+    async def test_non_author_cannot_edit(
+        self, client: AsyncClient, auth_headers: dict, auth_headers2: dict, db_session: AsyncSession
+    ):
+        ws = await _create_workspace(client, auth_headers)
+        resume = await _create_resume(client, auth_headers)
+        await _share_resume(client, auth_headers, ws["id"], resume["id"])
+
+        # Owner adds a comment
+        comment = await _add_comment(
+            client, auth_headers, resume["id"], workspace_id=ws["id"]
+        )
+
+        # Another non-member tries to edit → 403
+        resp = await client.patch(
+            f"/resumes/{resume['id']}/comments/{comment['id']}",
+            headers=auth_headers2,
+            json={"content": "Hijacked"},
+        )
+        assert resp.status_code == 403
+
+
+# ── Delete comment ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestDeleteComment:
+    async def test_author_can_delete_own_comment(self, client: AsyncClient, auth_headers: dict):
+        resume = await _create_resume(client, auth_headers)
+        comment = await _add_comment(client, auth_headers, resume["id"])
+
+        del_resp = await client.delete(
+            f"/resumes/{resume['id']}/comments/{comment['id']}",
+            headers=auth_headers,
+        )
+        assert del_resp.status_code == 204
+
+    async def test_non_author_cannot_delete(
+        self, client: AsyncClient, auth_headers: dict, auth_headers2: dict
+    ):
+        resume = await _create_resume(client, auth_headers)
+        comment = await _add_comment(client, auth_headers, resume["id"])
+
+        resp = await client.delete(
+            f"/resumes/{resume['id']}/comments/{comment['id']}",
+            headers=auth_headers2,
+        )
+        assert resp.status_code == 403
+
+
+# ── Resolve comment ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestResolveComment:
+    async def test_resume_owner_can_resolve_any_comment(
+        self, client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+    ):
+        ws = await _create_workspace(client, auth_headers)
+        resume = await _create_resume(client, auth_headers)
+        await _share_resume(client, auth_headers, ws["id"], resume["id"])
+
+        # Member leaves a comment
+        _, token = await _create_member(db_session, client, auth_headers, ws["id"])
+        member_headers = {"Authorization": f"Bearer {token}"}
+        comment = await _add_comment(
+            client, member_headers, resume["id"], workspace_id=ws["id"]
+        )
+
+        # Resume owner resolves it
+        resp = await client.patch(
+            f"/resumes/{resume['id']}/comments/{comment['id']}/resolve",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["resolved"] is True
+
+    async def test_resolve_toggles_back_to_unresolved(self, client: AsyncClient, auth_headers: dict):
+        resume = await _create_resume(client, auth_headers)
+        comment = await _add_comment(client, auth_headers, resume["id"])
+
+        # Resolve
+        await client.patch(
+            f"/resumes/{resume['id']}/comments/{comment['id']}/resolve",
+            headers=auth_headers,
+        )
+        # Resolve again → unresolve
+        resp = await client.patch(
+            f"/resumes/{resume['id']}/comments/{comment['id']}/resolve",
+            headers=auth_headers,
+        )
+        assert resp.json()["resolved"] is False
+
+
+# ── List + filter ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestListComments:
+    async def test_list_personal_comments(self, client: AsyncClient, auth_headers: dict):
+        resume = await _create_resume(client, auth_headers)
+        await _add_comment(client, auth_headers, resume["id"], content="Personal comment")
+
+        resp = await client.get(f"/resumes/{resume['id']}/comments", headers=auth_headers)
+        assert resp.status_code == 200
+        assert any(c["content"] == "Personal comment" for c in resp.json())
+
+    async def test_list_filters_by_workspace(
+        self, client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+    ):
+        ws = await _create_workspace(client, auth_headers)
+        resume = await _create_resume(client, auth_headers)
+        await _share_resume(client, auth_headers, ws["id"], resume["id"])
+
+        # Add one personal and one workspace comment
+        await _add_comment(client, auth_headers, resume["id"], content="Personal")
+        await _add_comment(
+            client, auth_headers, resume["id"], content="Workspace", workspace_id=ws["id"]
+        )
+
+        # Workspace-filtered list should only return workspace comment
+        resp = await client.get(
+            f"/resumes/{resume['id']}/comments?workspace_id={ws['id']}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        contents = [c["content"] for c in resp.json()]
+        assert "Workspace" in contents
+        assert "Personal" not in contents
+
+    async def test_non_member_gets_403_on_workspace_list(
+        self, client: AsyncClient, auth_headers: dict, auth_headers2: dict
+    ):
+        ws = await _create_workspace(client, auth_headers)
+        resume = await _create_resume(client, auth_headers)
+        await _share_resume(client, auth_headers, ws["id"], resume["id"])
+
+        resp = await client.get(
+            f"/resumes/{resume['id']}/comments?workspace_id={ws['id']}",
+            headers=auth_headers2,
+        )
+        assert resp.status_code == 403

--- a/frontend/src/components/CommentsPanel.tsx
+++ b/frontend/src/components/CommentsPanel.tsx
@@ -1,0 +1,271 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Check, Loader2, MessageSquare, Pencil, Send, Trash2, X } from 'lucide-react'
+import { toast } from 'sonner'
+import { apiClient, type CommentResponse } from '@/lib/api-client'
+import { useSession } from '@/lib/auth-client'
+
+interface CommentsPanelProps {
+  resumeId: string
+  workspaceId?: string
+  /** If set, the panel will auto-scroll to this comment on open */
+  highlightCommentId?: string
+  onClose?: () => void
+}
+
+export default function CommentsPanel({
+  resumeId,
+  workspaceId,
+  highlightCommentId,
+  onClose,
+}: CommentsPanelProps) {
+  const { data: session } = useSession()
+  const userId = session?.user?.id ?? ''
+
+  const [comments, setComments] = useState<CommentResponse[]>([])
+  const [loading, setLoading] = useState(true)
+  const [draft, setDraft] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  // Per-comment edit state: commentId → draft content
+  const [editDrafts, setEditDrafts] = useState<Record<string, string>>({})
+  const [editSaving, setEditSaving] = useState<Record<string, boolean>>({})
+
+  const highlightRef = useRef<HTMLLIElement | null>(null)
+
+  useEffect(() => {
+    apiClient
+      .listComments(resumeId, workspaceId)
+      .then(setComments)
+      .catch(() => toast.error('Failed to load comments'))
+      .finally(() => setLoading(false))
+  }, [resumeId, workspaceId])
+
+  // Scroll to highlighted comment after comments load
+  useEffect(() => {
+    if (highlightRef.current) {
+      highlightRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [comments, highlightCommentId])
+
+  async function handleSubmit() {
+    const content = draft.trim()
+    if (!content) return
+    setSubmitting(true)
+    try {
+      const comment = await apiClient.addComment(resumeId, content, { workspaceId })
+      setComments((prev) => [...prev, comment])
+      setDraft('')
+    } catch {
+      toast.error('Failed to add comment')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleUpdate(commentId: string) {
+    const content = (editDrafts[commentId] ?? '').trim()
+    if (!content) return
+    setEditSaving((p) => ({ ...p, [commentId]: true }))
+    try {
+      const updated = await apiClient.updateComment(resumeId, commentId, content)
+      setComments((prev) => prev.map((c) => (c.id === commentId ? updated : c)))
+      setEditDrafts((p) => { const next = { ...p }; delete next[commentId]; return next })
+    } catch {
+      toast.error('Failed to update comment')
+    } finally {
+      setEditSaving((p) => ({ ...p, [commentId]: false }))
+    }
+  }
+
+  async function handleDelete(commentId: string) {
+    if (!confirm('Delete this comment?')) return
+    try {
+      await apiClient.deleteComment(resumeId, commentId)
+      setComments((prev) => prev.filter((c) => c.id !== commentId))
+    } catch {
+      toast.error('Failed to delete comment')
+    }
+  }
+
+  async function handleResolve(commentId: string) {
+    try {
+      const updated = await apiClient.resolveComment(resumeId, commentId)
+      setComments((prev) => prev.map((c) => (c.id === commentId ? updated : c)))
+    } catch {
+      toast.error('Failed to update comment')
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-zinc-900 border-l border-zinc-800 w-72">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800 shrink-0">
+        <div className="flex items-center gap-2 text-sm font-semibold text-zinc-200">
+          <MessageSquare className="h-4 w-4 text-violet-400" />
+          Comments
+          {comments.length > 0 && (
+            <span className="text-xs bg-zinc-700 text-zinc-400 rounded-full px-2 py-0.5">
+              {comments.length}
+            </span>
+          )}
+        </div>
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Comment list */}
+      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-2">
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
+          </div>
+        ) : comments.length === 0 ? (
+          <p className="text-center text-xs text-zinc-500 py-8">No comments yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {comments.map((comment) => {
+              const isHighlighted = comment.id === highlightCommentId
+              const isAuthor = comment.author_id === userId
+
+              return (
+                <li
+                  key={comment.id}
+                  ref={isHighlighted ? highlightRef : null}
+                  className={`rounded-lg p-3 transition-colors ${
+                    comment.resolved
+                      ? 'bg-zinc-800/50 opacity-60'
+                      : isHighlighted
+                      ? 'bg-violet-500/10 border border-violet-500/30'
+                      : 'bg-zinc-800'
+                  }`}
+                >
+                  {/* Line / section badge */}
+                  {(comment.line_number != null || comment.section_tag) && (
+                    <div className="flex gap-1.5 mb-1.5">
+                      {comment.line_number != null && (
+                        <span className="text-xs bg-zinc-700 text-zinc-400 px-1.5 py-0.5 rounded font-mono">
+                          L{comment.line_number}
+                        </span>
+                      )}
+                      {comment.section_tag && (
+                        <span className="text-xs bg-zinc-700 text-zinc-400 px-1.5 py-0.5 rounded">
+                          {comment.section_tag}
+                        </span>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Content or edit form */}
+                  {editDrafts[comment.id] !== undefined ? (
+                    <div className="space-y-1.5">
+                      <textarea
+                        value={editDrafts[comment.id]}
+                        onChange={(e) =>
+                          setEditDrafts((p) => ({ ...p, [comment.id]: e.target.value }))
+                        }
+                        rows={3}
+                        className="w-full bg-zinc-700 border border-zinc-600 rounded px-2 py-1.5 text-xs focus:outline-none focus:border-violet-500 resize-none"
+                      />
+                      <div className="flex gap-1.5">
+                        <button
+                          onClick={() => handleUpdate(comment.id)}
+                          disabled={editSaving[comment.id]}
+                          className="flex items-center gap-1 px-2 py-1 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 rounded text-xs transition-colors"
+                        >
+                          {editSaving[comment.id]
+                            ? <Loader2 className="h-3 w-3 animate-spin" />
+                            : <Check className="h-3 w-3" />}
+                          Save
+                        </button>
+                        <button
+                          onClick={() => setEditDrafts((p) => { const next = { ...p }; delete next[comment.id]; return next })}
+                          className="px-2 py-1 text-zinc-400 hover:text-zinc-200 text-xs transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-xs text-zinc-200 whitespace-pre-wrap">{comment.content}</p>
+                  )}
+
+                  {/* Footer */}
+                  <div className="flex items-center justify-between mt-2">
+                    <span className="text-xs text-zinc-500">
+                      {comment.author_name ?? comment.author_email ?? 'User'} ·{' '}
+                      {new Date(comment.created_at).toLocaleDateString()}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {/* Resolve toggle */}
+                      <button
+                        onClick={() => handleResolve(comment.id)}
+                        title={comment.resolved ? 'Unresolve' : 'Resolve'}
+                        className={`p-0.5 transition-colors ${
+                          comment.resolved
+                            ? 'text-emerald-400 hover:text-zinc-400'
+                            : 'text-zinc-600 hover:text-emerald-400'
+                        }`}
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                      </button>
+                      {isAuthor && editDrafts[comment.id] === undefined && (
+                        <>
+                          <button
+                            onClick={() => setEditDrafts((p) => ({ ...p, [comment.id]: comment.content }))}
+                            className="p-0.5 text-zinc-600 hover:text-violet-400 transition-colors"
+                            title="Edit"
+                          >
+                            <Pencil className="h-3 w-3" />
+                          </button>
+                          <button
+                            onClick={() => handleDelete(comment.id)}
+                            className="p-0.5 text-zinc-600 hover:text-rose-400 transition-colors"
+                            title="Delete"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+
+      {/* Add comment form */}
+      <div className="shrink-0 border-t border-zinc-800 px-3 py-3">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSubmit()
+          }}
+          placeholder="Add a comment… (⌘↵ to send)"
+          rows={3}
+          className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-xs focus:outline-none focus:border-violet-500 resize-none placeholder-zinc-600 mb-2"
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !draft.trim()}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 rounded-lg text-xs font-medium transition-colors"
+        >
+          {submitting
+            ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            : <Send className="h-3.5 w-3.5" />}
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/LaTeXEditor.tsx
+++ b/frontend/src/components/LaTeXEditor.tsx
@@ -102,6 +102,11 @@ interface LaTeXEditorProps {
   confidenceScoreLoading?: boolean
   /** Callback when user clicks the quality score badge */
   onConfidenceBadgeClick?: () => void
+  // ── Collaboration Comments (Feature 74) ─────────────────────────────
+  /** Line numbers that have at least one comment — renders a glyph icon */
+  commentedLines?: number[]
+  /** Called when the user clicks a comment glyph in the editor margin */
+  onCommentIconClick?: (lineNumber: number) => void
 }
 
 // ── LaTeX command corpus ───────────────────────────────────────────────────
@@ -280,7 +285,7 @@ function parseLogErrors(logLines: LogLine[]): LogError[] {
 
 const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
   function LaTeXEditor(
-    { value, onChange, readOnly = false, logLines = [], onSave, onCompile, onCursorChange, syncLine, onAutoCompile, hideEmptyAction = false, atsScore, atsScoreLoading, onATSBadgeClick, onShowDocs, onExplainError, pageCount, onCursorLineChange, onCursorInSummarySection, onWritingAssistantAction, proofreadIssues, lintIssues, spellCheckIssues, spellCheckEnabled, onSpellCheckToggle, spellCheckLoading, collabEnabled, collabResumeId, collabUser, onPresenceChange, trackedChanges, onTrackedChangesUpdate, confidenceScore, confidenceScoreLoading, onConfidenceBadgeClick },
+    { value, onChange, readOnly = false, logLines = [], onSave, onCompile, onCursorChange, syncLine, onAutoCompile, hideEmptyAction = false, atsScore, atsScoreLoading, onATSBadgeClick, onShowDocs, onExplainError, pageCount, onCursorLineChange, onCursorInSummarySection, onWritingAssistantAction, proofreadIssues, lintIssues, spellCheckIssues, spellCheckEnabled, onSpellCheckToggle, spellCheckLoading, collabEnabled, collabResumeId, collabUser, onPresenceChange, trackedChanges, onTrackedChangesUpdate, confidenceScore, confidenceScoreLoading, onConfidenceBadgeClick, commentedLines, onCommentIconClick },
     ref
   ) {
     const editorRef = useRef<any>(null)
@@ -313,6 +318,10 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
     // Track changes refs (Feature 41)
     const trackChangesRef = useRef<TrackChangesHandle | null>(null)
     const trackedChangesDecsRef = useRef<any>(null)
+    // Comment gutter refs (Feature 74)
+    const commentDecsRef = useRef<any>(null)
+    const onCommentIconClickRef = useRef(onCommentIconClick)
+    onCommentIconClickRef.current = onCommentIconClick
 
     // Cleanup Y.js session on unmount
     useEffect(() => {
@@ -646,6 +655,46 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
       }))
       trackedChangesDecsRef.current.set(decorations)
     }, [trackedChanges])
+
+    // Comment gutter decorations (Feature 74)
+    useEffect(() => {
+      const editor = editorRef.current
+      const monaco = monacoRef.current
+      if (!editor || !monaco) return
+
+      if (!commentDecsRef.current) {
+        commentDecsRef.current = editor.createDecorationsCollection([])
+      }
+      if (!commentedLines || commentedLines.length === 0) {
+        commentDecsRef.current.set([])
+        return
+      }
+      const decorations = commentedLines.map((line) => ({
+        range: new monaco.Range(line, 1, line, 1),
+        options: {
+          glyphMarginClassName: 'comment-gutter-icon',
+          glyphMarginHoverMessage: { value: 'Click to view comments on this line' },
+        },
+      }))
+      commentDecsRef.current.set(decorations)
+    }, [commentedLines])
+
+    // Comment glyph click handler (Feature 74) — registered once on mount
+    useEffect(() => {
+      const editor = editorRef.current
+      const monaco = monacoRef.current
+      if (!editor || !monaco) return
+      const disposable = editor.onMouseDown((e: any) => {
+        if (
+          e.target.type === monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN &&
+          onCommentIconClickRef.current
+        ) {
+          onCommentIconClickRef.current(e.target.position?.lineNumber ?? 0)
+        }
+      })
+      return () => disposable.dispose()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [editorRef.current, monacoRef.current])
 
     // Auto-compile: debounce 2s after last keystroke
     useEffect(() => {
@@ -1480,6 +1529,20 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
             border-radius: 50%;
             background-color: rgba(248,113,113,0.8);
             margin-top: 6px;
+          }
+          /* Comment gutter icon (Feature 74) */
+          .comment-gutter-icon {
+            width: 14px !important;
+            height: 14px !important;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238b5cf6' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'%3E%3C/path%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-size: contain;
+            cursor: pointer;
+            opacity: 0.7;
+            margin-top: 3px;
+          }
+          .comment-gutter-icon:hover {
+            opacity: 1;
           }
         `}</style>
         {!value ? (

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2105,6 +2105,56 @@ class ApiClient {
       { method: 'DELETE' }
     )
   }
+
+  // ── Resume Comments (Feature 74) ────────────────────────────────────────────
+
+  async addComment(
+    resumeId: string,
+    content: string,
+    opts?: { workspaceId?: string; lineNumber?: number; sectionTag?: string }
+  ): Promise<CommentResponse> {
+    return this.request<CommentResponse>(`/resumes/${resumeId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content,
+        workspace_id: opts?.workspaceId ?? null,
+        line_number: opts?.lineNumber ?? null,
+        section_tag: opts?.sectionTag ?? null,
+      }),
+    })
+  }
+
+  async listComments(
+    resumeId: string,
+    workspaceId?: string
+  ): Promise<CommentResponse[]> {
+    const qs = workspaceId ? `?workspace_id=${encodeURIComponent(workspaceId)}` : ''
+    return this.request<CommentResponse[]>(`/resumes/${resumeId}/comments${qs}`)
+  }
+
+  async updateComment(
+    resumeId: string,
+    commentId: string,
+    content: string
+  ): Promise<CommentResponse> {
+    return this.request<CommentResponse>(`/resumes/${resumeId}/comments/${commentId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    })
+  }
+
+  async deleteComment(resumeId: string, commentId: string): Promise<void> {
+    await this.request<void>(`/resumes/${resumeId}/comments/${commentId}`, { method: 'DELETE' })
+  }
+
+  async resolveComment(resumeId: string, commentId: string): Promise<CommentResponse> {
+    return this.request<CommentResponse>(
+      `/resumes/${resumeId}/comments/${commentId}/resolve`,
+      { method: 'PATCH' }
+    )
+  }
 }
 
 // Singleton
@@ -2543,6 +2593,25 @@ export interface RecruiterNoteResponse {
   author_name?: string
   author_email?: string
   content: string
+  created_at: string
+  updated_at: string
+}
+
+// ------------------------------------------------------------------ //
+//  Resume Comments (Feature 74)                                       //
+// ------------------------------------------------------------------ //
+
+export interface CommentResponse {
+  id: string
+  resume_id: string
+  workspace_id?: string
+  author_id: string
+  author_name?: string
+  author_email?: string
+  content: string
+  line_number?: number
+  section_tag?: string
+  resolved: boolean
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
## Summary

Implements Feature 74 — workspace members can leave inline comments on shared resumes, tied to a line number or section tag. Resume owners can resolve any comment; authors can edit/delete their own.

### What was built

- **Migration 0018**: `resume_comments` table with FK → resumes, workspaces (nullable), users; indexed on resume_id and workspace_id
- **SQLAlchemy model**: `ResumeComment` with optional workspace scope, line_number, section_tag, and resolved flag
- **5 API endpoints** in `comment_routes.py` (`prefix=/resumes/{resume_id}/comments`):
  - `POST /` — add comment (resume owner or workspace member)
  - `GET /` — list comments (filtered by `?workspace_id=`)
  - `PATCH /{comment_id}` — edit own comment
  - `DELETE /{comment_id}` — delete own comment
  - `PATCH /{comment_id}/resolve` — toggle resolved (resume owner or commenter)
- **Router registered** in `routes.py`
- **`CommentResponse` interface + 5 API methods** in `api-client.ts`: `addComment`, `listComments`, `updateComment`, `deleteComment`, `resolveComment`
- **`CommentsPanel.tsx`**: side panel with comment list, add form, resolve toggle, edit/delete per-author; highlights target comment on open
- **`LaTeXEditor.tsx`**: glyph margin icons for commented lines; clicking a glyph fires `onCommentIconClick(lineNumber)`
- **Test suite** (`test_comments.py`): 14 tests covering all CRUD, access control, workspace filter, and resolve toggle

### Closes

Closes #254
Closes #255
Closes #256
Closes #257
Closes #258
Closes #259
Closes #260