### PR TITLE
feat(88): Compile Error History

### DIFF
--- a/backend/app/api/job_routes.py
+++ b/backend/app/api/job_routes.py
@@ -667,6 +667,10 @@ async def get_job_result(
             compilation_time = result_data.get("compilation_time")
             pdf_size = result_data.get("pdf_size")
             error_msg = result_data.get("error")
+            # Prefer the specific LaTeX error line (e.g. "! Undefined control sequence.")
+            # over the generic "pdflatex exited with code 1" message.
+            latex_error_line = result_data.get("latex_error_line")
+            stored_error = (latex_error_line or error_msg or "")[:500] or None
             await db.execute(
                 update(Compilation)
                 .where(Compilation.job_id == job_id)
@@ -674,7 +678,7 @@ async def get_job_result(
                     status=final_status,
                     compilation_time=compilation_time,
                     pdf_size=pdf_size,
-                    error_message=error_msg[:500] if error_msg else None,
+                    error_message=stored_error,
                 )
             )
             await db.commit()

--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -394,6 +394,52 @@ async def search_resumes(
     )
 
 
+# ── Error History (Feature 88) ────────────────────────────────────────────
+
+
+class ErrorHistorySummarySchema(BaseModel):
+    error_type: str
+    count: int
+    last_seen: datetime
+    last_resume_id: Optional[str]
+    last_resume_title: Optional[str]
+    example_line: str
+    resolved: bool
+
+
+@router.get("/error-history", response_model=List[ErrorHistorySummarySchema])
+async def get_error_history(
+    limit: int = Query(default=50, ge=1, le=200),
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_required),
+):
+    """
+    Return grouped compile-error history for the current user.
+
+    Each entry represents a distinct LaTeX error type with occurrence count,
+    last-seen timestamp, the offending resume, and whether it has since
+    been resolved (i.e. a successful compile of that same resume followed).
+    Sorted by count DESC, last_seen DESC.
+    """
+    from ..services.error_history_service import error_history_service
+
+    summaries = await error_history_service.get_error_history(
+        user_id=user_id, db=db, limit=limit
+    )
+    return [
+        ErrorHistorySummarySchema(
+            error_type=s.error_type,
+            count=s.count,
+            last_seen=s.last_seen,
+            last_resume_id=s.last_resume_id,
+            last_resume_title=s.last_resume_title,
+            example_line=s.example_line,
+            resolved=s.resolved,
+        )
+        for s in summaries
+    ]
+
+
 @router.get("/{resume_id}", response_model=ResumeResponse)
 async def get_resume(
     resume_id: str,

--- a/backend/app/services/error_history_service.py
+++ b/backend/app/services/error_history_service.py
@@ -1,0 +1,155 @@
+"""
+Feature 88 — Compile Error History.
+
+Aggregates failed Compilation records for a user, groups them by LaTeX error
+type, and determines whether each recurring error has since been resolved.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database.models import Compilation, Resume
+
+# ── Patterns for classifying error_message values ──────────────────────────
+
+# pdflatex "! ..." lines — already stored verbatim after the worker enhancement
+_BANG_RE = re.compile(r"^!\s+(.+)$", re.MULTILINE)
+
+# Fallback human-readable category for non-"!" messages
+_CATEGORY_MAP: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"timed? ?out", re.I), "Compilation Timeout"),
+    (re.compile(r"exited with code", re.I), "LaTeX Compile Error"),
+    (re.compile(r"internal", re.I), "Internal Error"),
+]
+
+
+def _extract_error_type(error_message: Optional[str]) -> str:
+    """
+    Return a short human-readable error type string from an error_message.
+
+    For messages that begin with "! " (stored since Feature 88 worker change),
+    extract the text after "!". For older/generic messages fall back to
+    category matching.
+    """
+    if not error_message:
+        return "Unknown Error"
+
+    m = _BANG_RE.search(error_message)
+    if m:
+        # Normalise: strip trailing dot + period, collapse whitespace
+        return re.sub(r"\s+", " ", m.group(1).rstrip(".")).strip()
+
+    for pattern, label in _CATEGORY_MAP:
+        if pattern.search(error_message):
+            return label
+
+    return error_message[:80].strip()
+
+
+# ── Public dataclass ────────────────────────────────────────────────────────
+
+@dataclass
+class ErrorHistorySummary:
+    error_type: str
+    count: int
+    last_seen: datetime
+    last_resume_id: Optional[str]
+    last_resume_title: Optional[str]
+    example_line: str       # full error_message of the most-recent occurrence
+    resolved: bool          # True if the offending resume compiled successfully afterwards
+
+
+# ── Service ─────────────────────────────────────────────────────────────────
+
+class ErrorHistoryService:
+
+    async def get_error_history(
+        self,
+        user_id: str,
+        db: AsyncSession,
+        limit: int = 50,
+    ) -> list[ErrorHistorySummary]:
+        """
+        Return up to *limit* grouped error summaries for *user_id*, sorted by
+        count DESC then last_seen DESC.
+        """
+        # 1. All failed compilations for this user (most-recent first)
+        failed_result = await db.execute(
+            select(Compilation)
+            .where(
+                Compilation.user_id == user_id,
+                Compilation.status == "failed",
+                Compilation.error_message.isnot(None),
+            )
+            .order_by(Compilation.created_at.desc())
+        )
+        failed: list[Compilation] = list(failed_result.scalars().all())
+
+        if not failed:
+            return []
+
+        # 2. All *successful* compilations for this user (keyed by resume_id)
+        #    We only need to know if any success happened AFTER a failure for the
+        #    same resume — so load them all and bucket by resume_id.
+        success_result = await db.execute(
+            select(Compilation.resume_id, Compilation.created_at)
+            .where(
+                Compilation.user_id == user_id,
+                Compilation.status == "completed",
+                Compilation.resume_id.isnot(None),
+            )
+        )
+        # Map resume_id → max(created_at) of successful compiles
+        latest_success: dict[str, datetime] = {}
+        for row in success_result.all():
+            rid, ts = row
+            if rid and (rid not in latest_success or ts > latest_success[rid]):
+                latest_success[rid] = ts
+
+        # 3. Resolve resume titles in one bulk query
+        resume_ids = {c.resume_id for c in failed if c.resume_id}
+        title_map: dict[str, str] = {}
+        if resume_ids:
+            res_result = await db.execute(
+                select(Resume.id, Resume.title).where(Resume.id.in_(resume_ids))
+            )
+            title_map = {r.id: r.title for r in res_result.all()}
+
+        # 4. Group by error_type
+        groups: dict[str, list[Compilation]] = {}
+        for comp in failed:
+            etype = _extract_error_type(comp.error_message)
+            groups.setdefault(etype, []).append(comp)
+
+        # 5. Build summaries
+        summaries: list[ErrorHistorySummary] = []
+        for error_type, compilations in groups.items():
+            # compilations already sorted by created_at DESC (latest first)
+            latest = compilations[0]
+            rid = latest.resume_id
+            resolved = False
+            if rid and rid in latest_success:
+                resolved = latest_success[rid] > latest.created_at
+
+            summaries.append(ErrorHistorySummary(
+                error_type=error_type,
+                count=len(compilations),
+                last_seen=latest.created_at,
+                last_resume_id=rid,
+                last_resume_title=title_map.get(rid) if rid else None,
+                example_line=latest.error_message or "",
+                resolved=resolved,
+            ))
+
+        # 6. Sort: count DESC, last_seen DESC
+        summaries.sort(key=lambda s: (-s.count, -s.last_seen.timestamp()))
+        return summaries[:limit]
+
+
+error_history_service = ErrorHistoryService()

--- a/backend/app/workers/latex_worker.py
+++ b/backend/app/workers/latex_worker.py
@@ -228,6 +228,7 @@ def compile_latex_task(
 
         # ── Stream log lines ─────────────────────────────────────────
         page_count: Optional[int] = None
+        first_latex_error: Optional[str] = None  # first "! ..." line from pdflatex
         for line in proc.stdout:
             stripped = line.rstrip()
             if not stripped:
@@ -237,6 +238,10 @@ def compile_latex_task(
             m = PAGE_COUNT_RE.search(stripped)
             if m:
                 page_count = int(m.group(1))
+
+            # Capture the first "! <error type>" line for persistent storage
+            if first_latex_error is None and stripped.startswith("!"):
+                first_latex_error = stripped[:250]
 
             is_error_line = (
                 "error" in stripped.lower()
@@ -373,7 +378,10 @@ def compile_latex_task(
             "error_message": error_msg,
             "retryable": False,
         })
-        return {"success": False, "job_id": job_id, "error": error_msg}
+        result = {"success": False, "job_id": job_id, "error": error_msg}
+        if first_latex_error:
+            result["latex_error_line"] = first_latex_error
+        return result
 
     except SoftTimeLimitExceeded:
         logger.error(f"LaTeX task {task_id} hit soft time limit for job {job_id}")

--- a/backend/test/test_error_history.py
+++ b/backend/test/test_error_history.py
@@ -1,0 +1,322 @@
+"""
+Feature 88 — Compile Error History tests.
+
+Tests:
+1. get_error_history — user with 3 failed compilations (different error types) → 3 entries
+2. get_error_history — same error in multiple compilations → count > 1
+3. get_error_history — error followed by successful compile → resolved=True
+4. get_error_history — no failed compilations → returns empty list (not 404)
+5. _extract_error_type — parses "! Undefined control sequence." banner line
+6. _extract_error_type — falls back to category for generic "pdflatex exited" msg
+7. GET /resumes/error-history → 200 with correct payload via FastAPI test client
+8. GET /resumes/error-history?limit=1 → respects limit parameter
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.services.error_history_service import (
+    ErrorHistoryService,
+    _extract_error_type,
+)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _make_compilation(
+    *,
+    user_id: str = "user-001",
+    resume_id: str | None = None,
+    status: str = "failed",
+    error_message: str | None = None,
+    created_at: datetime | None = None,
+) -> MagicMock:
+    c = MagicMock()
+    c.id = str(uuid.uuid4())
+    c.user_id = user_id
+    c.resume_id = resume_id or str(uuid.uuid4())
+    c.status = status
+    c.error_message = error_message
+    c.created_at = created_at or datetime.now(timezone.utc)
+    return c
+
+
+def _make_resume(*, resume_id: str, title: str = "My Resume") -> MagicMock:
+    r = MagicMock()
+    r.id = resume_id
+    r.title = title
+    return r
+
+
+def _mock_db_for_history(
+    failed: list[MagicMock],
+    successes: list[tuple[str, datetime]] | None = None,
+    resumes: list[MagicMock] | None = None,
+) -> AsyncMock:
+    """
+    Build an AsyncMock db whose execute() returns appropriate results for the
+    three queries ErrorHistoryService.get_error_history() issues:
+      1. SELECT failed compilations
+      2. SELECT successful (resume_id, created_at) pairs
+      3. SELECT resume (id, title) rows
+    """
+    db = AsyncMock()
+    call_count = 0
+
+    async def _execute(stmt):
+        nonlocal call_count
+        call_count += 1
+
+        if call_count == 1:
+            # Failed compilations
+            result = MagicMock()
+            result.scalars.return_value.all.return_value = failed
+            return result
+
+        if call_count == 2:
+            # Successful compilations — returns (resume_id, created_at) rows
+            rows = successes or []
+            result = MagicMock()
+            result.all.return_value = rows
+            return result
+
+        # Resume titles
+        resume_rows = resumes or []
+        result = MagicMock()
+        result.all.return_value = resume_rows
+        return result
+
+    db.execute = _execute
+    return db
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 1. _extract_error_type unit tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractErrorType:
+
+    def test_bang_line_parsed(self):
+        result = _extract_error_type("! Undefined control sequence.")
+        assert result == "Undefined control sequence"
+
+    def test_bang_line_without_dot(self):
+        result = _extract_error_type("! Missing $ inserted")
+        assert result == "Missing $ inserted"
+
+    def test_timeout_fallback(self):
+        result = _extract_error_type("Compilation timed out after 60s (free plan limit)")
+        assert result == "Compilation Timeout"
+
+    def test_generic_latex_error_fallback(self):
+        result = _extract_error_type("pdflatex exited with code 1")
+        assert result == "LaTeX Compile Error"
+
+    def test_none_returns_unknown(self):
+        result = _extract_error_type(None)
+        assert result == "Unknown Error"
+
+    def test_empty_string_falls_through(self):
+        result = _extract_error_type("")
+        assert result == "Unknown Error"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 2–4. ErrorHistoryService.get_error_history
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestGetErrorHistory:
+
+    service = ErrorHistoryService()
+
+    @pytest.mark.asyncio
+    async def test_three_distinct_errors_returns_three_entries(self):
+        """User with 3 failed compilations of different types → 3 grouped entries."""
+        now = datetime.now(timezone.utc)
+        resume_id = str(uuid.uuid4())
+        failed = [
+            _make_compilation(error_message="! Undefined control sequence.", resume_id=resume_id, created_at=now),
+            _make_compilation(error_message="! Missing $ inserted.", resume_id=resume_id, created_at=now - timedelta(hours=1)),
+            _make_compilation(error_message="Compilation timed out after 60s", resume_id=resume_id, created_at=now - timedelta(hours=2)),
+        ]
+        db = _mock_db_for_history(failed)
+        result = await self.service.get_error_history("user-001", db, limit=50)
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_same_error_multiple_times_counted(self):
+        """Same LaTeX error in 3 compilations → single entry with count=3."""
+        now = datetime.now(timezone.utc)
+        resume_id = str(uuid.uuid4())
+        failed = [
+            _make_compilation(error_message="! Undefined control sequence.", resume_id=resume_id, created_at=now),
+            _make_compilation(error_message="! Undefined control sequence.", resume_id=resume_id, created_at=now - timedelta(hours=1)),
+            _make_compilation(error_message="! Undefined control sequence.", resume_id=resume_id, created_at=now - timedelta(hours=2)),
+        ]
+        db = _mock_db_for_history(failed)
+        result = await self.service.get_error_history("user-001", db, limit=50)
+        assert len(result) == 1
+        assert result[0].count == 3
+        assert result[0].error_type == "Undefined control sequence"
+
+    @pytest.mark.asyncio
+    async def test_error_followed_by_success_is_resolved(self):
+        """If resume has a successful compile AFTER the last error → resolved=True."""
+        resume_id = str(uuid.uuid4())
+        error_time = datetime.now(timezone.utc) - timedelta(hours=2)
+        success_time = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        failed = [
+            _make_compilation(
+                error_message="! Undefined control sequence.",
+                resume_id=resume_id,
+                created_at=error_time,
+            )
+        ]
+        db = _mock_db_for_history(
+            failed,
+            successes=[(resume_id, success_time)],
+        )
+        result = await self.service.get_error_history("user-001", db, limit=50)
+        assert len(result) == 1
+        assert result[0].resolved is True
+
+    @pytest.mark.asyncio
+    async def test_error_without_subsequent_success_is_not_resolved(self):
+        """Error not followed by a successful compile → resolved=False."""
+        resume_id = str(uuid.uuid4())
+        error_time = datetime.now(timezone.utc) - timedelta(hours=1)
+        # Success happened BEFORE the error
+        success_time = datetime.now(timezone.utc) - timedelta(hours=3)
+
+        failed = [
+            _make_compilation(
+                error_message="! Undefined control sequence.",
+                resume_id=resume_id,
+                created_at=error_time,
+            )
+        ]
+        db = _mock_db_for_history(
+            failed,
+            successes=[(resume_id, success_time)],
+        )
+        result = await self.service.get_error_history("user-001", db, limit=50)
+        assert len(result) == 1
+        assert result[0].resolved is False
+
+    @pytest.mark.asyncio
+    async def test_no_failed_compilations_returns_empty_list(self):
+        """User with zero failed compilations → empty list, no exception."""
+        db = _mock_db_for_history(failed=[])
+        result = await self.service.get_error_history("user-001", db, limit=50)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_sorted_by_count_desc(self):
+        """Most-frequent error type appears first."""
+        now = datetime.now(timezone.utc)
+        resume_id = str(uuid.uuid4())
+        failed = [
+            # "Missing $" appears twice
+            _make_compilation(error_message="! Missing $ inserted.", resume_id=resume_id, created_at=now),
+            _make_compilation(error_message="! Missing $ inserted.", resume_id=resume_id, created_at=now - timedelta(hours=1)),
+            # "Undefined control sequence" appears once
+            _make_compilation(error_message="! Undefined control sequence.", resume_id=resume_id, created_at=now - timedelta(hours=2)),
+        ]
+        db = _mock_db_for_history(failed)
+        result = await self.service.get_error_history("user-001", db, limit=50)
+        assert result[0].error_type == "Missing $ inserted"
+        assert result[0].count == 2
+
+    @pytest.mark.asyncio
+    async def test_limit_respected(self):
+        """limit parameter caps the number of returned entries."""
+        now = datetime.now(timezone.utc)
+        failed = [
+            _make_compilation(error_message=f"! Error type {i}.", created_at=now - timedelta(hours=i))
+            for i in range(10)
+        ]
+        db = _mock_db_for_history(failed)
+        result = await self.service.get_error_history("user-001", db, limit=3)
+        assert len(result) <= 3
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 5. Route-level test via FastAPI test client
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_route_app():
+    from app.api.resume_routes import router as resume_router
+    from app.database.connection import get_db
+    from app.middleware.auth_middleware import get_current_user_required
+
+    app = FastAPI()
+    app.include_router(resume_router)
+
+    app.dependency_overrides[get_current_user_required] = lambda: "user-route-test"
+
+    # DB mock returns empty list for the first execute (failed compilations)
+    mock_db = AsyncMock()
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = []
+    mock_db.execute = AsyncMock(return_value=result_mock)
+
+    async def _get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _get_db
+    return app, mock_db
+
+
+class TestErrorHistoryRoute:
+
+    @pytest.mark.asyncio
+    async def test_get_error_history_returns_200(self):
+        app, _ = _make_route_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/resumes/error-history")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.asyncio
+    async def test_get_error_history_limit_param_accepted(self):
+        app, _ = _make_route_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/resumes/error-history?limit=10")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_get_error_history_unauthenticated_returns_401_or_422(self):
+        """Without auth override, endpoint should reject unauthenticated requests."""
+        from app.api.resume_routes import router as resume_router
+        from app.database.connection import get_db
+
+        bare_app = FastAPI()
+        bare_app.include_router(resume_router)
+
+        mock_db = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=result_mock)
+
+        async def _get_db():
+            yield mock_db
+        bare_app.dependency_overrides[get_db] = _get_db
+
+        transport = ASGITransport(app=bare_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/resumes/error-history")
+        # Auth middleware returns 401 or 403 when no token provided
+        assert resp.status_code in (401, 403, 422)

--- a/features-checklist/P3_checklist.md
+++ b/features-checklist/P3_checklist.md
@@ -1044,7 +1044,7 @@ Build a personal "error log" helping users recognize recurring mistakes. Uses ex
 `compilations` table — no new schema required.
 
 ### 88A · Backend — Error Aggregation Service
-- [ ] Create `backend/app/services/error_history_service.py`:
+- [x] Create `backend/app/services/error_history_service.py`:
   ```python
   class ErrorHistoryService:
       async def get_error_history(
@@ -1067,22 +1067,22 @@ Build a personal "error log" helping users recognize recurring mistakes. Uses ex
   ```
 
 ### 88B · Backend — Endpoint
-- [ ] Add `GET /resumes/error-history?limit=50` to `backend/app/api/resume_routes.py`:
+- [x] Add `GET /resumes/error-history?limit=50` to `backend/app/api/resume_routes.py`:
   - Returns list of `ErrorHistorySummary` from `ErrorHistoryService.get_error_history()`
   - Grouped and sorted by `count DESC, last_seen DESC`
 
 ### 88C · Frontend — Error History Panel
-- [ ] Create `frontend/src/components/CompileErrorHistory.tsx`:
+- [x] Create `frontend/src/components/CompileErrorHistory.tsx`:
   - Triggered from editor by "Error History" button in Log Viewer panel header
   - Displays table: Error Type | Times Encountered | Last Seen | Status (Resolved / Recurring)
   - Click a row → expand details with `example_line` and link to the resume it occurred in
   - "Most common mistake" banner for error_type with highest count
   - Empty state: "No compile errors yet — great work!"
-- [ ] In `frontend/src/lib/api-client.ts`:
+- [x] In `frontend/src/lib/api-client.ts`:
   - Add `getErrorHistory(): Promise<ErrorHistorySummary[]>`
 
 ### 88D · Tests
-- [ ] Create `backend/test/test_error_history.py` — 4 tests:
+- [x] Create `backend/test/test_error_history.py` — 16 tests (expanded from 4):
   - User with 3 failed compilations → `get_error_history` returns 3 grouped entries
   - Same error in multiple compilations → `count > 1` in summary
   - Error followed by successful compile → `resolved: true`
@@ -1097,7 +1097,7 @@ Applies a grayscale CSS filter to the PDF canvas — purely display-side, origin
 Zero backend changes.
 
 ### 89A · Frontend — Toggle Button
-- [ ] In `frontend/src/components/PDFPreview.tsx` (or equivalent PDF viewer component):
+- [x] In `frontend/src/components/PDFPreview.tsx` (or equivalent PDF viewer component):
   - Add `printPreviewMode: boolean` state (default `false`)
   - "B&W Print Preview" button in PDF viewer toolbar (printer icon)
   - When `printPreviewMode=true`:
@@ -1106,15 +1106,17 @@ Zero backend changes.
   - Toggle off restores full color
 
 ### 89B · Color Dependency Warnings
-- [ ] In print preview mode, run a lightweight analysis of the LaTeX source:
+- [x] In print preview mode, run a lightweight analysis of the LaTeX source:
   - Check for `\textcolor`, `\color`, `\colorbox`, `\definecolor` usage
   - If found: show warning list under the preview: "Color-dependent elements detected —
     these may become invisible or lose meaning in grayscale print:"
   - List each detected color usage with the line number (link to editor line)
 
 ### 89C · Integration
-- [ ] Add `printPreviewMode` prop to `LaTeXEditor.tsx` if needed to pass line warnings back
-- [ ] Persist print preview mode preference to `localStorage` per user
+- [x] Pass `latexContent` + `onJumpToLine` props from edit page to PDFPreview
+- [x] Persist print preview mode preference to `localStorage` per user (`latexy_print_preview`)
+- [x] Color analysis extracted to `frontend/src/lib/print-preview.ts` (testable)
+- [x] 10 vitest tests in `frontend/src/__tests__/print-preview.test.ts`
 
 ---
 
@@ -1125,7 +1127,7 @@ Figma (via plugin API), allowing users to create a visually designed resume vers
 Complements the ATS-safe LaTeX version with a design-focused output.
 
 ### 90A · Backend — Canva-Compatible Export Format
-- [ ] Add `GET /resumes/{resume_id}/export/canva` to `backend/app/api/export_routes.py`:
+- [x] Add `GET /resumes/{resume_id}/export/canva` to `backend/app/api/export_routes.py`:
   ```python
   class CanvaResumeExport(BaseModel):
       # Canva Content Import API format
@@ -1148,7 +1150,7 @@ Complements the ATS-safe LaTeX version with a design-focused output.
   ```
 
 ### 90B · Backend — Figma-Compatible Export Format
-- [ ] Add `GET /resumes/{resume_id}/export/figma` to `backend/app/api/export_routes.py`:
+- [x] Add `GET /resumes/{resume_id}/export/figma` to `backend/app/api/export_routes.py`:
   - Returns structured JSON mapping resume sections to Figma text nodes:
     ```python
     class FigmaResumeExport(BaseModel):
@@ -1167,25 +1169,25 @@ Complements the ATS-safe LaTeX version with a design-focused output.
   - This JSON is consumed by a Figma plugin (separate artifact) that populates a resume frame
 
 ### 90C · Frontend — Export Buttons
-- [ ] In `frontend/src/components/ExportDropdown.tsx` (or wherever export options are shown):
+- [x] In `frontend/src/components/ExportDropdown.tsx` (or wherever export options are shown):
   - Add "Export to Canva" option: calls `GET /resumes/{id}/export/canva`,
     then opens Canva import URL with the JSON payload
   - Add "Export to Figma" option: calls `GET /resumes/{id}/export/figma`,
     downloads `resume-figma.json` for use in Figma plugin
   - Both options show tooltip: "Opens [Canva/Figma] with your resume content pre-filled"
-- [ ] In `frontend/src/lib/api-client.ts`:
+- [x] In `frontend/src/lib/api-client.ts`:
   - Add `exportCanva(resumeId: string): Promise<CanvaResumeExport>`
   - Add `exportFigma(resumeId: string): Promise<Blob>` (returns downloadable JSON)
 
 ### 90D · Figma Plugin (Separate Artifact)
-- [ ] Create `frontend/figma-plugin/` directory:
+- [x] Create `frontend/figma-plugin/` directory:
   - `manifest.json`: Figma plugin manifest with `networkAccess: ["latexy.io"]`
   - `code.ts`: plugin entry that reads the JSON and populates a Figma resume template frame
   - `ui.html`: simple plugin UI: "Fetch from Latexy" button, API key input
   - This plugin is published to the Figma Community separately
 
 ### 90E · Tests
-- [ ] Create `backend/test/test_export_canva_figma.py` — 4 tests:
+- [x] Create `backend/test/test_export_canva_figma.py` — 4 tests:
   - `GET /resumes/{id}/export/canva` returns JSON with `elements` array non-empty
   - Section headers appear as `type: "HEADING"` elements
   - `GET /resumes/{id}/export/figma` returns JSON with `sections` array

--- a/frontend/src/app/workspace/[resumeId]/edit/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/edit/page.tsx
@@ -112,6 +112,7 @@ import SnippetMarketplace from '@/components/SnippetMarketplace'
 import MacroLibraryPanel from '@/components/MacroLibraryPanel'
 import TikZEditor from '@/components/TikZEditor'
 import SlideViewer from '@/components/SlideViewer'
+import CompileErrorHistory from '@/components/CompileErrorHistory'
 
 
 type RightTab = 'preview' | 'ai' | 'logs' | 'history' | 'references' | 'interview' | 'design' | 'proofread' | 'packages' | 'linter' | 'symbols' | 'changes' | 'docs' | 'layout' | 'snippets' | 'macros' | 'tikz'
@@ -736,6 +737,7 @@ export default function ResumeEditPage() {
   const [contactFormatterOpen, setContactFormatterOpen] = useState(false)
   const [salaryEstimatorOpen, setSalaryEstimatorOpen] = useState(false)
   const [sectionReorderOpen, setSectionReorderOpen] = useState(false)
+  const [showErrorHistory, setShowErrorHistory] = useState(false)
   const [docCommand, setDocCommand] = useState<string | undefined>(undefined)
 
   // Priority queue badge (Feature 34)
@@ -2457,23 +2459,32 @@ export default function ResumeEditPage() {
                   <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-700">
                     {isCompiling ? 'Compilation output' : isAiRunning ? 'AI pipeline logs' : 'Last run logs'}
                   </span>
-                  <span
-                    className={`text-[10px] font-medium capitalize ${
-                      isAnyRunning
-                        ? 'text-orange-400'
-                        : compileStream.status === 'completed' || aiStream.status === 'completed'
-                        ? 'text-emerald-400'
-                        : 'text-zinc-600'
-                    }`}
-                  >
-                    {isAnyRunning
-                      ? 'Running'
-                      : compileStream.status !== 'idle'
-                      ? compileStream.status
-                      : aiStream.status !== 'idle'
-                      ? aiStream.status
-                      : '—'}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => setShowErrorHistory(true)}
+                      className="text-[10px] font-medium text-zinc-500 hover:text-orange-400 transition"
+                      title="View error history"
+                    >
+                      Error History
+                    </button>
+                    <span
+                      className={`text-[10px] font-medium capitalize ${
+                        isAnyRunning
+                          ? 'text-orange-400'
+                          : compileStream.status === 'completed' || aiStream.status === 'completed'
+                          ? 'text-emerald-400'
+                          : 'text-zinc-600'
+                      }`}
+                    >
+                      {isAnyRunning
+                        ? 'Running'
+                        : compileStream.status !== 'idle'
+                        ? compileStream.status
+                        : aiStream.status !== 'idle'
+                        ? aiStream.status
+                        : '—'}
+                    </span>
+                  </div>
                 </div>
                 <LogViewer lines={logLines} maxHeight="100%" className="h-full text-[11px]" />
               </div>
@@ -2773,6 +2784,11 @@ export default function ResumeEditPage() {
           setLatexContent(newLatex)
         }}
       />
+
+      {/* Compile Error History (Feature 88) */}
+      {showErrorHistory && (
+        <CompileErrorHistory onClose={() => setShowErrorHistory(false)} />
+      )}
 
       {/* Diff viewer modal */}
       {showDiffModal && (

--- a/frontend/src/components/CompileErrorHistory.tsx
+++ b/frontend/src/components/CompileErrorHistory.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { AlertCircle, CheckCircle2, ChevronDown, ChevronRight, Clock, RefreshCw, Trophy, X } from 'lucide-react'
+import Link from 'next/link'
+import { apiClient, type ErrorHistorySummary } from '@/lib/api-client'
+
+interface CompileErrorHistoryProps {
+  onClose: () => void
+}
+
+function formatRelativeDate(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const days = Math.floor(diff / 86_400_000)
+  if (days === 0) return 'Today'
+  if (days === 1) return 'Yesterday'
+  if (days < 30) return `${days} days ago`
+  const months = Math.floor(days / 30)
+  if (months === 1) return '1 month ago'
+  if (months < 12) return `${months} months ago`
+  return `${Math.floor(months / 12)}y ago`
+}
+
+export default function CompileErrorHistory({ onClose }: CompileErrorHistoryProps) {
+  const [summaries, setSummaries] = useState<ErrorHistorySummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await apiClient.getErrorHistory(50)
+      setSummaries(data)
+    } catch {
+      setError('Failed to load error history')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const toggle = (errorType: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(errorType)) next.delete(errorType)
+      else next.add(errorType)
+      return next
+    })
+  }
+
+  const topError = summaries[0]
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="w-full max-w-2xl rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl flex flex-col max-h-[90vh]">
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-white/10 shrink-0">
+          <div className="flex items-center gap-2.5">
+            <AlertCircle size={18} className="text-orange-400" />
+            <h2 className="text-sm font-semibold text-white">Compile Error History</h2>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={load}
+              disabled={loading}
+              className="p-1.5 rounded-lg text-zinc-400 hover:text-white hover:bg-white/10 disabled:opacity-40 transition"
+              title="Refresh"
+            >
+              <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+            </button>
+            <button
+              onClick={onClose}
+              className="p-1.5 rounded-lg text-zinc-400 hover:text-white hover:bg-white/10 transition"
+              aria-label="Close"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">
+
+          {/* Most-common error banner */}
+          {topError && topError.count > 1 && (
+            <div className="mx-4 mt-4 flex items-start gap-3 rounded-xl border border-orange-500/20 bg-orange-500/[0.07] px-4 py-3">
+              <Trophy size={16} className="mt-0.5 shrink-0 text-orange-400" />
+              <div className="min-w-0">
+                <p className="text-xs font-semibold text-orange-300">Most common mistake</p>
+                <p className="mt-0.5 truncate text-sm font-mono text-orange-100">{topError.error_type}</p>
+                <p className="mt-0.5 text-xs text-orange-400/70">
+                  Encountered {topError.count} time{topError.count !== 1 ? 's' : ''}
+                  {topError.resolved ? ' · resolved' : ' · still recurring'}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Loading */}
+          {loading && (
+            <div className="flex items-center justify-center py-16 text-sm text-zinc-500">
+              <RefreshCw size={16} className="mr-2 animate-spin" />
+              Loading…
+            </div>
+          )}
+
+          {/* Error */}
+          {!loading && error && (
+            <div className="flex flex-col items-center gap-3 py-16 text-sm text-zinc-500">
+              <AlertCircle size={24} className="text-red-400" />
+              <span>{error}</span>
+              <button
+                onClick={load}
+                className="rounded-lg bg-white/10 px-3 py-1.5 text-xs text-white hover:bg-white/15 transition"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!loading && !error && summaries.length === 0 && (
+            <div className="flex flex-col items-center gap-3 py-20">
+              <CheckCircle2 size={28} className="text-emerald-400" />
+              <p className="text-sm font-medium text-zinc-300">No compile errors yet — great work!</p>
+              <p className="text-xs text-zinc-500">Error patterns will appear here as you compile your resumes.</p>
+            </div>
+          )}
+
+          {/* Error table */}
+          {!loading && !error && summaries.length > 0 && (
+            <table className="w-full text-sm mt-4">
+              <thead>
+                <tr className="border-b border-white/5 text-left">
+                  <th className="px-5 pb-2 text-xs font-medium text-zinc-500 w-1/2">Error Type</th>
+                  <th className="px-3 pb-2 text-xs font-medium text-zinc-500 text-center">Times</th>
+                  <th className="px-3 pb-2 text-xs font-medium text-zinc-500">Last Seen</th>
+                  <th className="px-3 pb-2 text-xs font-medium text-zinc-500 text-center">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summaries.map((s) => {
+                  const isExpanded = expanded.has(s.error_type)
+                  return (
+                    <>
+                      <tr
+                        key={s.error_type}
+                        className="group cursor-pointer border-b border-white/5 hover:bg-white/[0.03] transition"
+                        onClick={() => toggle(s.error_type)}
+                      >
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-2">
+                            <span className="shrink-0 text-zinc-500">
+                              {isExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+                            </span>
+                            <span className="font-mono text-xs text-orange-300 truncate max-w-[260px]" title={s.error_type}>
+                              {s.error_type}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-3 py-3 text-center">
+                          <span className="rounded-full bg-orange-500/20 px-2 py-0.5 text-xs font-semibold text-orange-300">
+                            {s.count}×
+                          </span>
+                        </td>
+                        <td className="px-3 py-3 text-xs text-zinc-400 whitespace-nowrap">
+                          <span className="flex items-center gap-1.5">
+                            <Clock size={11} className="shrink-0 text-zinc-600" />
+                            {formatRelativeDate(s.last_seen)}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3 text-center">
+                          {s.resolved ? (
+                            <span className="flex items-center justify-center gap-1 text-xs text-emerald-400">
+                              <CheckCircle2 size={12} />
+                              Resolved
+                            </span>
+                          ) : (
+                            <span className="flex items-center justify-center gap-1 text-xs text-amber-400">
+                              <AlertCircle size={12} />
+                              Recurring
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+
+                      {/* Expanded detail row */}
+                      {isExpanded && (
+                        <tr key={`${s.error_type}-detail`} className="border-b border-white/5 bg-white/[0.02]">
+                          <td colSpan={4} className="px-6 py-3 space-y-2">
+                            <div>
+                              <p className="text-[10px] font-semibold uppercase tracking-wide text-zinc-500 mb-1">Example output</p>
+                              <code className="block rounded-md bg-black/50 px-3 py-2 font-mono text-xs text-orange-200 break-all">
+                                {s.example_line || '(no details)'}
+                              </code>
+                            </div>
+                            {s.last_resume_id && (
+                              <div className="flex items-center gap-2 text-xs text-zinc-400">
+                                <span className="shrink-0">Last in:</span>
+                                <Link
+                                  href={`/workspace/${s.last_resume_id}/edit`}
+                                  className="text-violet-400 hover:text-violet-300 underline underline-offset-2 truncate"
+                                  onClick={onClose}
+                                >
+                                  {s.last_resume_title ?? s.last_resume_id}
+                                </Link>
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-white/10 px-6 py-3 shrink-0 flex items-center justify-between">
+          <p className="text-xs text-zinc-600">
+            {summaries.length > 0
+              ? `${summaries.length} error type${summaries.length !== 1 ? 's' : ''} found`
+              : 'No errors'}
+          </p>
+          <button
+            onClick={onClose}
+            className="rounded-lg bg-white/10 px-4 py-1.5 text-xs font-medium text-white hover:bg-white/15 transition"
+          >
+            Close
+          </button>
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2486,6 +2486,15 @@ class ApiClient {
   async getSubmission(id: string): Promise<ApplicationSubmission> {
     return this.request<ApplicationSubmission>(`/apply/submissions/${encodeURIComponent(id)}`)
   }
+
+  // ── Feature 88 — Compile Error History ───────────────────────────────────
+
+  async getErrorHistory(limit = 50): Promise<ErrorHistorySummary[]> {
+    return this.request<ErrorHistorySummary[]>(
+      `/resumes/error-history?limit=${limit}`
+    )
+  }
+
 }
 
 // Singleton
@@ -3175,3 +3184,16 @@ export interface ApplicationSubmission {
   error_message: string | null
   created_at: string
 }
+
+// ── Feature 88 — Compile Error History ───────────────────────────────────────
+
+export interface ErrorHistorySummary {
+  error_type: string
+  count: number
+  last_seen: string
+  last_resume_id: string | null
+  last_resume_title: string | null
+  example_line: string
+  resolved: boolean
+}
+


### PR DESCRIPTION
## Summary

- Captures the first `! ` LaTeX error line during compilation and stores it in the `compilations.error_message` column
- `ErrorHistoryService` queries failed compilations, groups by error type, computes recurrence count and `resolved` status (success compile after the last error)
- New `GET /resumes/error-history` endpoint (registered before `/{resume_id}` to avoid route collision)
- `CompileErrorHistory` modal in the editor: sortable table (Error Type | Times | Last Seen | Status), expandable rows showing `example_line` + link to the resume, "Most common mistake" amber banner
- `getErrorHistory()` + `ErrorHistorySummary` type added to `api-client.ts`
- "Error History" button added to Log Viewer panel header in the edit page

## Test plan
- [x] 16 backend tests in `test_error_history.py` — grouping, count, resolved flag, empty history
- [x] CI green on feat/88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Error History panel accessible from the resume editor logs tab, displaying compilation error summaries grouped by error type with occurrence counts, last-seen timestamps, and resolution status.
  * Error detail view showing example error lines and links to affected resumes.

* **Improvements**
  * Enhanced error tracking during LaTeX compilation to capture first error line.
  * Improved job state management and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->