### PR TITLE
Audit fixes: Features 77–90 (11 bugs across 3 audits)

### DIFF
--- a/backend/app/api/career_routes.py
+++ b/backend/app/api/career_routes.py
@@ -22,6 +22,7 @@ from ..core.logging import get_logger
 from ..database.connection import get_db
 from ..database.models import CareerAnalysis, CareerRole, Resume
 from ..middleware.auth_middleware import get_current_user_required as get_current_user
+from ..middleware.auth_middleware import require_admin
 from ..services.career_path_service import career_path_service
 
 logger = get_logger(__name__)
@@ -246,7 +247,7 @@ async def search_career_roles(
 @admin_router.post("/career-graph/seed", response_model=SeedResponse)
 async def seed_career_graph(
     db: AsyncSession = Depends(get_db),
-    user_id: str = Depends(get_current_user),
+    _admin_user_id: str = Depends(require_admin),
 ) -> SeedResponse:
     """
     Seed the career graph with roles and transitions (admin only, idempotent).

--- a/backend/app/api/career_routes.py
+++ b/backend/app/api/career_routes.py
@@ -39,6 +39,8 @@ class AnalyzeRequest(BaseModel):
 
 
 class CareerRoleSchema(BaseModel):
+    model_config = {'from_attributes': True}
+
     id: str
     title: str
     level: str
@@ -47,11 +49,10 @@ class CareerRoleSchema(BaseModel):
     typical_yoe_min: Optional[int] = None
     typical_yoe_max: Optional[int] = None
 
-    class Config:
-        from_attributes = True
-
 
 class CareerAnalysisSchema(BaseModel):
+    model_config = {'from_attributes': True}
+
     id: str
     resume_id: str
     target_role_id: Optional[str] = None
@@ -65,9 +66,6 @@ class CareerAnalysisSchema(BaseModel):
     # Resolved path roles (populated on detail endpoint)
     path_roles: Optional[list[CareerRoleSchema]] = None
     target_role: Optional[CareerRoleSchema] = None
-
-    class Config:
-        from_attributes = True
 
 
 class SeedResponse(BaseModel):

--- a/backend/app/api/macro_routes.py
+++ b/backend/app/api/macro_routes.py
@@ -108,7 +108,7 @@ async def update_macro(
         raise HTTPException(status_code=404, detail='Macro not found')
     if macro.user_id != current_user.id:
         raise HTTPException(status_code=403, detail='Access denied')
-    for field, val in body.model_dump(exclude_none=True).items():
+    for field, val in body.model_dump(exclude_unset=True).items():
         setattr(macro, field, val)
     await db.commit()
     await db.refresh(macro)

--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -45,6 +45,7 @@ class ResumeUpdate(BaseModel):
 class ResumeResponse(ResumeBase):
     id: str
     user_id: str
+    document_type: str = "resume"
     parent_resume_id: Optional[str] = None
     variant_count: int = 0
     # resume_settings is the ORM attribute; we expose it as "metadata" in JSON
@@ -272,6 +273,7 @@ async def list_resumes(
     limit: int = 20,
     parent_id: Optional[str] = Query(None),
     archived: bool = Query(False),
+    document_type: Optional[str] = Query(None),
     db: AsyncSession = Depends(get_db),
     user_id: str = Depends(get_current_user_required)
 ):
@@ -283,6 +285,8 @@ async def list_resumes(
     filters = [Resume.user_id == user_id]
     if parent_id is not None:
         filters.append(Resume.parent_resume_id == parent_id)
+    if document_type is not None:
+        filters.append(Resume.document_type == document_type)
     # Filter by archive status
     if archived:
         filters.append(Resume.archived_at.is_not(None))

--- a/backend/app/api/snippet_routes.py
+++ b/backend/app/api/snippet_routes.py
@@ -18,6 +18,7 @@ from ..database.connection import get_db
 from ..database.models import Snippet, SnippetInstall, SnippetUpvote, User
 from ..middleware.auth_middleware import (
     get_current_user_optional,
+    require_admin,
 )
 from ..middleware.auth_middleware import (
     get_current_user_required as get_current_user,
@@ -333,7 +334,7 @@ async def toggle_upvote(
 @admin_router.post('/snippets/seed', status_code=200)
 async def seed_official_snippets(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    _admin_user_id: str = Depends(require_admin),
 ) -> dict:
     """Upsert official snippets by title (idempotent)."""
     upserted = 0

--- a/backend/app/api/snippet_routes.py
+++ b/backend/app/api/snippet_routes.py
@@ -228,7 +228,7 @@ async def update_snippet(
         raise HTTPException(status_code=403, detail='Only the author can update this snippet')
     if body.content:
         _check_content_safety(body.content)
-    for field, val in body.model_dump(exclude_none=True).items():
+    for field, val in body.model_dump(exclude_unset=True).items():
         setattr(snippet, field, val)
     await db.commit()
     await db.refresh(snippet)

--- a/backend/app/api/tenant_routes.py
+++ b/backend/app/api/tenant_routes.py
@@ -217,16 +217,8 @@ async def update_tenant(
     """Update tenant branding. Only owner or admin can update."""
     tenant = await _require_tenant_owner_or_admin(tenant_id, user_id, db)
 
-    if body.name is not None:
-        tenant.name = body.name
-    if body.logo_url is not None:
-        tenant.logo_url = body.logo_url
-    if body.primary_color is not None:
-        tenant.primary_color = body.primary_color
-    if body.custom_domain is not None:
-        tenant.custom_domain = body.custom_domain or None
-    if body.active is not None:
-        tenant.active = body.active
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(tenant, field, value)
 
     await db.commit()
     await db.refresh(tenant)

--- a/backend/app/api/tenant_routes.py
+++ b/backend/app/api/tenant_routes.py
@@ -6,8 +6,6 @@ prefix: /tenants
 All write endpoints require the caller to be the tenant owner or an admin member.
 """
 
-from __future__ import annotations
-
 import logging
 import re
 from datetime import datetime

--- a/backend/app/services/document_export_service.py
+++ b/backend/app/services/document_export_service.py
@@ -304,24 +304,26 @@ class DocumentExportService:
                     "style": {"fontSize": 10, "indent": True},
                 })
 
-            elif self._DATE_RE.search(line):
-                # Date range line → smaller italic text
-                clean = re.sub(r'\*\*(.+?)\*\*', r'\1', line)
-                clean = re.sub(r'\*(.+?)\*', r'\1', clean)
-                elements.append({
-                    "type": "TEXT",
-                    "text": clean,
-                    "style": {"italic": True, "fontSize": 9},
-                })
-
             elif '**' in line:
-                # Bold company/role line
+                # Bold company/role line — check before date regex so that
+                # combined lines like "**Acme Corp**  —  **2021–2024**" are
+                # rendered bold rather than as a date line.
                 clean = re.sub(r'\*\*(.+?)\*\*', r'\1', line)
                 clean = re.sub(r'\*(.+?)\*', r'\1', clean)
                 elements.append({
                     "type": "TEXT",
                     "text": clean,
                     "style": {"bold": True, "fontSize": 11},
+                })
+
+            elif self._DATE_RE.search(line):
+                # Date range line (plain text, no bold markers) → smaller italic text
+                clean = re.sub(r'\*\*(.+?)\*\*', r'\1', line)
+                clean = re.sub(r'\*(.+?)\*', r'\1', clean)
+                elements.append({
+                    "type": "TEXT",
+                    "text": clean,
+                    "style": {"italic": True, "fontSize": 9},
                 })
 
             else:
@@ -388,15 +390,11 @@ class DocumentExportService:
                     current_entry = _new_entry()
                 current_entry["bullets"].append(line[2:].strip())
 
-            elif self._DATE_RE.search(line):
-                if current_entry is None:
-                    current_entry = _new_entry()
-                clean = re.sub(r'\*\*(.+?)\*\*', r'\1', line)
-                clean = re.sub(r'\*(.+?)\*', r'\1', clean)
-                current_entry["date"] = clean
-
             elif '**' in line and line.count('**') >= 2:
-                # Bold line → heading (company) or subheading (role)
+                # Bold line → heading (company) or subheading (role).
+                # Must come before date regex: combined lines like
+                # "**Acme Corp**  —  **2021–2024**" should populate heading,
+                # not date.
                 if current_entry is None:
                     current_entry = _new_entry()
                 clean = re.sub(r'\*\*(.+?)\*\*', r'\1', line)
@@ -405,6 +403,14 @@ class DocumentExportService:
                     current_entry["heading"] = clean
                 else:
                     current_entry["subheading"] = clean
+
+            elif self._DATE_RE.search(line):
+                # Plain-text date range (no bold markers)
+                if current_entry is None:
+                    current_entry = _new_entry()
+                clean = re.sub(r'\*\*(.+?)\*\*', r'\1', line)
+                clean = re.sub(r'\*(.+?)\*', r'\1', clean)
+                current_entry["date"] = clean
 
             elif line and not line.startswith('#'):
                 if current_entry is None:

--- a/backend/test/test_career_paths.py
+++ b/backend/test/test_career_paths.py
@@ -340,6 +340,7 @@ class TestCareerGraphSeedRequiresAdmin:
     def test_seed_career_graph_uses_require_admin(self):
         """POST /admin/career-graph/seed must gate on require_admin (BUG-04)."""
         import inspect
+
         from app.api.career_routes import seed_career_graph
         from app.middleware.auth_middleware import require_admin
         sig = inspect.signature(seed_career_graph)

--- a/backend/test/test_career_paths.py
+++ b/backend/test/test_career_paths.py
@@ -334,6 +334,20 @@ class TestAnalysesOrdering:
         assert ordered[1].id == older.id
 
 
+# ── BUG-04 regression: career-graph seed requires require_admin ───────────────
+
+class TestCareerGraphSeedRequiresAdmin:
+    def test_seed_career_graph_uses_require_admin(self):
+        """POST /admin/career-graph/seed must gate on require_admin (BUG-04)."""
+        import inspect
+        from app.api.career_routes import seed_career_graph
+        from app.middleware.auth_middleware import require_admin
+        sig = inspect.signature(seed_career_graph)
+        deps = [p.default.dependency for p in sig.parameters.values()
+                if hasattr(p.default, 'dependency')]
+        assert require_admin in deps, 'seed_career_graph must depend on require_admin'
+
+
 # ── Mock helpers ──────────────────────────────────────────────────────────────
 
 

--- a/backend/test/test_compile_settings.py
+++ b/backend/test/test_compile_settings.py
@@ -175,6 +175,7 @@ def _make_mock_resume(extra_meta=None):
     resume.github_sync_enabled = False
     resume.github_repo_name = None
     resume.github_last_sync_at = None
+    resume.document_type = "resume"
     from datetime import datetime
     resume.created_at = datetime(2024, 1, 1)
     resume.updated_at = datetime(2024, 1, 1)

--- a/backend/test/test_export_canva_figma.py
+++ b/backend/test/test_export_canva_figma.py
@@ -255,3 +255,88 @@ class TestFigmaRoute:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.get(f"/export/{resume_id}/figma")
         assert resp.status_code == 403
+
+
+# ── Regression tests: BUG-01 / BUG-02 (audit F90) ────────────────────────────
+# A line like \textbf{Acme Corp} \hfill \textbf{2021--2024} produces markdown
+# "**Acme Corp**   —  **2021–2024**".  _DATE_RE matches because "2021" + "–"
+# are present.  Before the fix, the date check ran first, causing to_canva() to
+# render the line as tiny italic text and to_figma() to put the whole line in
+# entry["date"] instead of entry["heading"].
+
+_COMBINED_LATEX = r"""
+\documentclass{article}
+\begin{document}
+
+\section{Experience}
+\textbf{Acme Corp} \hfill \textbf{2021--2024}
+
+\textit{Senior Engineer}
+
+\begin{itemize}
+  \item Built scalable systems
+\end{itemize}
+
+\end{document}
+"""
+
+
+class TestBug01CanvaBoldVsDateOrdering:
+    """BUG-01: to_canva() must not misclassify a bold company+date line as a date line."""
+
+    service = DocumentExportService()
+
+    def test_combined_bold_date_line_is_rendered_bold_not_italic(self):
+        """Lines with '**' should be classified as bold TEXT, not italic date TEXT."""
+        result = self.service.to_canva(_COMBINED_LATEX)
+        text_elements = [e for e in result["elements"] if e["type"] == "TEXT"]
+        # The "Acme Corp" / "2021–2024" combined line must appear as bold
+        bold_texts = [e for e in text_elements if e["style"].get("bold")]
+        assert any("Acme" in e["text"] for e in bold_texts), (
+            "Expected company+date line rendered as bold TEXT; got: "
+            + str(text_elements)
+        )
+
+    def test_combined_bold_date_line_is_not_rendered_italic_small(self):
+        """Lines with '**' must NOT be given italic/fontSize-9 date styling."""
+        result = self.service.to_canva(_COMBINED_LATEX)
+        italic_small = [
+            e for e in result["elements"]
+            if e["type"] == "TEXT"
+            and e["style"].get("italic")
+            and e["style"].get("fontSize", 10) <= 9
+            and "Acme" in e["text"]
+        ]
+        assert italic_small == [], (
+            "Company+date line must not be styled as italic date text; found: "
+            + str(italic_small)
+        )
+
+
+class TestBug02FigmaBoldVsDateOrdering:
+    """BUG-02: to_figma() must not put a bold company line into entry['date']."""
+
+    service = DocumentExportService()
+
+    def test_company_name_goes_into_heading_not_date(self):
+        """Bold company line must populate entry['heading'], not entry['date']."""
+        result = self.service.to_figma(_COMBINED_LATEX)
+        exp_sections = [s for s in result["sections"] if "experience" in s["title"].lower()]
+        assert exp_sections, "Expected an Experience section"
+        entries = exp_sections[0]["entries"]
+        assert entries, "Expected at least one entry in Experience"
+        entry = entries[0]
+        assert "Acme" in entry["heading"], (
+            f"Expected 'Acme' in entry['heading'], got heading={entry['heading']!r}, "
+            f"date={entry['date']!r}"
+        )
+
+    def test_date_field_does_not_contain_company_name(self):
+        """entry['date'] must not contain the company name."""
+        result = self.service.to_figma(_COMBINED_LATEX)
+        exp_sections = [s for s in result["sections"] if "experience" in s["title"].lower()]
+        entries = exp_sections[0]["entries"]
+        entry = entries[0]
+        assert "Acme" not in entry["date"], (
+            f"Company name leaked into entry['date']: {entry['date']!r}"
+        )

--- a/backend/test/test_macros.py
+++ b/backend/test/test_macros.py
@@ -194,3 +194,23 @@ class TestUpdateMacro:
 
         # Verify setattr was called via model_dump
         mock_db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_patch_null_clears_shortcut(self):
+        """PATCH /macros/{id} with shortcut=null must clear the field (BUG-03)."""
+        user = make_user()
+        macro = make_macro(user.id, shortcut='ctrl+shift+b')
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = macro
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        # Construct body with shortcut explicitly set to None
+        body = MacroUpdate(shortcut=None)
+        # model_dump(exclude_unset=True) must include shortcut=None
+        dumped = body.model_dump(exclude_unset=True)
+        assert 'shortcut' in dumped, 'exclude_unset=True must preserve explicit null'
+        assert dumped['shortcut'] is None

--- a/backend/test/test_resumes.py
+++ b/backend/test/test_resumes.py
@@ -1,4 +1,6 @@
+import inspect
 import uuid
+from datetime import datetime, timezone
 
 import pytest
 from httpx import AsyncClient
@@ -126,3 +128,39 @@ class TestResumeCRUD:
         # Try to access with 'auth_headers' (different user)
         resp = await client.get(f"/resumes/{resume_id}", headers=auth_headers)
         assert resp.status_code == 404 # We return 404 instead of 403 for privacy usually
+
+
+# ── BUG-01 / BUG-02 (F86): document_type field in schema and list filter ──────
+
+
+class TestDocumentTypeField:
+    """Unit tests for BUG-01 (document_type in ResumeResponse) and BUG-02 (list filter)."""
+
+    def test_resume_response_includes_document_type(self):
+        """ResumeResponse schema exposes document_type field (BUG-01 fix)."""
+        from app.api.resume_routes import ResumeResponse
+
+        now = datetime.now(timezone.utc)
+        r = ResumeResponse(
+            id="abc", user_id="u1", title="Test", latex_content=r"\doc",
+            document_type="beamer", created_at=now, updated_at=now,
+        )
+        assert r.document_type == "beamer"
+
+    def test_resume_response_document_type_defaults_to_resume(self):
+        """ResumeResponse.document_type defaults to 'resume' when not provided."""
+        from app.api.resume_routes import ResumeResponse
+
+        now = datetime.now(timezone.utc)
+        r = ResumeResponse(
+            id="abc", user_id="u1", title="Test", latex_content=r"\doc",
+            created_at=now, updated_at=now,
+        )
+        assert r.document_type == "resume"
+
+    def test_list_resumes_accepts_document_type_filter(self):
+        """list_resumes handler signature includes document_type parameter (BUG-02 fix)."""
+        from app.api.resume_routes import list_resumes
+
+        sig = inspect.signature(list_resumes)
+        assert "document_type" in sig.parameters

--- a/backend/test/test_snippets.py
+++ b/backend/test/test_snippets.py
@@ -375,3 +375,19 @@ class TestPatchNullClearing:
         dumped = body.model_dump(exclude_unset=True)
         assert 'title' in dumped
         assert 'description' not in dumped
+
+
+# ── BUG-04 regression: admin seed endpoints require require_admin ──────────────
+
+class TestAdminSeedRequiresAdmin:
+    def test_snippet_seed_uses_require_admin(self):
+        """POST /admin/snippets/seed must gate on require_admin, not get_current_user (BUG-04)."""
+        from app.api.snippet_routes import seed_official_snippets
+        from app.middleware.auth_middleware import require_admin
+        dep_calls = [str(d.dependency) for d in seed_official_snippets.__fastapi_dependencies__] if hasattr(seed_official_snippets, '__fastapi_dependencies__') else []
+        # Inspect the underlying FastAPI dependant via the __wrapped__ or signature
+        import inspect
+        sig = inspect.signature(seed_official_snippets)
+        deps = [p.default.dependency for p in sig.parameters.values()
+                if hasattr(p.default, 'dependency')]
+        assert require_admin in deps, 'seed_official_snippets must depend on require_admin'

--- a/backend/test/test_snippets.py
+++ b/backend/test/test_snippets.py
@@ -351,3 +351,27 @@ class TestOfficialSnippetSeed:
         from app.data.official_snippets import OFFICIAL_SNIPPETS
         for s in OFFICIAL_SNIPPETS:
             assert s['category'] in valid_cats, f"Invalid category in '{s['title']}': {s['category']}"
+
+
+# ── BUG-03 regression: PATCH exclude_unset allows null clearing ───────────────
+
+class TestPatchNullClearing:
+    def test_snippet_update_exclude_unset_preserves_null(self):
+        """PATCH /snippets/{id} with null field must clear it (BUG-03).
+
+        model_dump(exclude_unset=True) includes fields the caller explicitly
+        set (even to None); exclude_none=True would silently drop them.
+        """
+        from app.api.snippet_routes import SnippetUpdate
+        body = SnippetUpdate(description=None)
+        dumped = body.model_dump(exclude_unset=True)
+        assert 'description' in dumped, 'exclude_unset=True must preserve explicit null'
+        assert dumped['description'] is None
+
+    def test_snippet_update_omitted_field_not_in_dump(self):
+        """Fields not provided at all must NOT appear in the patch dump."""
+        from app.api.snippet_routes import SnippetUpdate
+        body = SnippetUpdate(title='New Title')
+        dumped = body.model_dump(exclude_unset=True)
+        assert 'title' in dumped
+        assert 'description' not in dumped

--- a/backend/test/test_tenants.py
+++ b/backend/test/test_tenants.py
@@ -521,3 +521,59 @@ class TestListMembersAuth:
         result = await list_members(tenant_id=tenant.id, db=db, user_id=member_user.id)
         assert len(result) == 1
         assert result[0].user_id == member_user.id
+
+
+# ── BUG-03 (F85): PATCH /tenants/{id} can clear optional branding fields ──────
+
+
+class TestUpdateTenantNullClearing:
+    """Tests for BUG-03: update_tenant PATCH must clear nullable fields when sent as null."""
+
+    def test_exclude_unset_includes_explicit_none(self):
+        """TenantUpdate.model_dump(exclude_unset=True) includes fields explicitly set to null."""
+        body = TenantUpdate.model_validate({'logo_url': None})
+        dumped = body.model_dump(exclude_unset=True)
+        assert 'logo_url' in dumped
+        assert dumped['logo_url'] is None
+
+    def test_exclude_unset_omits_missing_fields(self):
+        """TenantUpdate.model_dump(exclude_unset=True) omits fields absent from request."""
+        body = TenantUpdate.model_validate({'name': 'New Name'})
+        dumped = body.model_dump(exclude_unset=True)
+        assert 'name' in dumped
+        assert 'logo_url' not in dumped
+
+    @pytest.mark.asyncio
+    async def test_null_logo_url_clears_field(self):
+        """PATCH with logo_url=null clears the tenant's logo_url (BUG-03 fix)."""
+        owner_id = _uid()
+        tenant = make_tenant(owner_id)
+        tenant.logo_url = 'https://old.example.com/logo.png'
+
+        # Simulate JSON body: {"logo_url": null}
+        body = TenantUpdate.model_validate({'logo_url': None})
+
+        db = _mock_db()
+        db.refresh = AsyncMock(side_effect=lambda obj: None)
+
+        with patch('app.api.tenant_routes._require_tenant_owner_or_admin', new=AsyncMock(return_value=tenant)):
+            await update_tenant(tenant_id=tenant.id, body=body, db=db, user_id=owner_id)
+
+        assert tenant.logo_url is None
+        db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_null_primary_color_clears_field(self):
+        """PATCH with primary_color=null clears the tenant's primary_color (BUG-03 fix)."""
+        owner_id = _uid()
+        tenant = make_tenant(owner_id, primary_color='#6d28d9')
+
+        body = TenantUpdate.model_validate({'primary_color': None})
+
+        db = _mock_db()
+        db.refresh = AsyncMock(side_effect=lambda obj: None)
+
+        with patch('app.api.tenant_routes._require_tenant_owner_or_admin', new=AsyncMock(return_value=tenant)):
+            await update_tenant(tenant_id=tenant.id, body=body, db=db, user_id=owner_id)
+
+        assert tenant.primary_color is None

--- a/docs/audit-f77-f83.md
+++ b/docs/audit-f77-f83.md
@@ -1,0 +1,228 @@
+# Audit Report: Features 77–83
+
+**Date:** 2026-05-07
+**Auditor:** Claude Code
+**Scope:** Features 77 (Dropbox Sync), 78 (WYSIWYG Editor), 79 (PWA/Offline), 80 (Career Path), 81 (Benchmarking), 82 (Snippet Marketplace), 83 (Keyboard Macro System)
+
+---
+
+## Phase 1 — Environment Verification
+
+| Check | Result |
+|-------|--------|
+| Backend health | N/A — backend not running during audit (requires `./scripts/dev.sh app`) |
+| Alembic current | **0019** — migrations 0020–0023 not applied to dev DB |
+| `ruff check` | ✅ CLEAN (0 errors) |
+| `pytest` (56 tests, features 80–83) | ✅ 56/56 PASSING |
+| `pnpm run build` | ✅ CLEAN (0 TS errors) |
+
+**Note on migrations:** `alembic current = 0019`. Migrations 0020–0023 (F77–F83) are present in `alembic/versions/` but have not been applied to the running Postgres instance. Running `make migrate` or `./scripts/dev.sh app` (which calls `alembic upgrade head`) is required before live API tests. This is a deployment/ops concern, not a code bug — migrations are well-formed and reversible.
+
+---
+
+## Phase 2 — Live API Audit Summary
+
+Live API audit was conducted via code inspection (backend not running). Key findings are elevated to the bug list below. All endpoint contracts were verified against Pydantic models.
+
+---
+
+## Phase 3 — Frontend–Backend Contract Audit
+
+| Feature | Interface | Field | Status |
+|---------|-----------|-------|--------|
+| F80 | `CareerAnalysisResponse.created_at` | `string` | ✅ matches `isoformat()` |
+| F80 | `CareerRoleResponse` | all fields | ✅ exact match |
+| F81 | `BenchmarkResult` | all fields | ✅ exact match |
+| F82 | `SnippetResponse` | all fields | ✅ exact match |
+| F83 | `MacroResponse.actions` | `Record<string, unknown>[]` TS vs `list[dict]` Python | ✅ compatible (JSON roundtrip) |
+| F83 | `MacroResponse.description` / `.shortcut` | `string \| null \| undefined` TS | ✅ matches `Optional[str]` Python |
+
+No schema mismatches found. All field names use consistent `snake_case` throughout (backend serializes natively, frontend uses them as-is).
+
+---
+
+## Phase 4 — Log & Error Analysis
+
+- **No SQLAlchemy lazy-loading warnings** — all relationships use `lazy='selectin'` or are accessed within session scope.
+- **Pydantic v1 `class Config`** — `CareerRoleSchema` and `CareerAnalysisSchema` in `career_routes.py` use the deprecated `class Config: from_attributes = True` pattern instead of Pydantic v2's `model_config`. Emits deprecation warnings in logs.
+- **`exclude_none=True` in PATCH handlers** — silently discards `null` values in `SnippetUpdate` and `MacroUpdate`, making it impossible to clear optional fields.
+
+---
+
+## Phase 5 — Gap Analysis
+
+| Sub-task | Spec | Implementation | Match |
+|----------|------|----------------|-------|
+| F77-A | DB migration with token encryption | ✅ `0020_add_dropbox_integration.py` | ✅ |
+| F78-B | WYSIWYG round-trip fidelity | Parser drops epilogue (`\end{document}`) | ❌ BUG-01 |
+| F79-C | PWA manifest with correct icon spec | SVG icons use pixel `sizes` instead of `"any"` | ⚠️ BUG-05 |
+| F80-C | Career path BFS returns empty (not 500) when no path | ✅ returns empty list | ✅ |
+| F80-E | Admin seed endpoint — admin only | Uses `get_current_user`, not `require_admin` | ❌ BUG-04 |
+| F81-A | Benchmark validates ats_score range | ✅ rejects < 0 or > 100 with 422 | ✅ |
+| F82-A | Shell-injection patterns rejected | ✅ all 9 patterns blocked | ✅ |
+| F82-B | Install idempotency | ✅ count increments exactly once | ✅ |
+| F82-B | Admin seed — admin only | Uses `get_current_user`, not `require_admin` | ❌ BUG-04 |
+| F82-C | PATCH can clear optional fields (tags, etc.) | `exclude_none=True` blocks nulls | ❌ BUG-03 |
+| F83-C | MacroRecorder captures actions faithfully | Double-records cursor after insert | ❌ BUG-02 |
+| F83-D | PATCH can clear shortcut | `exclude_none=True` blocks null shortcut | ❌ BUG-03 |
+
+---
+
+## Phase 6 — Bug Triage
+
+### BUG-01 · P1 · F78 — WYSIWYG parser drops document epilogue
+
+**Feature:** 78 — WYSIWYG Editor
+**Severity:** P1 — Feature broken
+**File:** `frontend/src/lib/wysiwyg/latex-parser.ts`
+
+**Description:**
+`epilogueLines` is declared on line 60 but never populated. Any content after the last `\section` block (most importantly `\end{document}`) is buffered as part of the last section and becomes a `raw` entry instead of going to `doc.epilogue`. After round-trip, `\end{document}` is wrapped inside the last section's content, which can be placed inside a `\resumeSubHeadingListEnd` block — producing invalid LaTeX that fails to compile.
+
+**Reproduction:**
+```typescript
+const latex = `\\documentclass{resume}\n\\begin{document}\n\n\\section{Skills}\n\n\\end{document}`
+const { doc } = parseResume(latex)
+// doc.epilogue === '' (BUG: should be '\\end{document}')
+// doc.sections[0].entries[0].type === 'raw' (BUG: \end{document} as a raw entry)
+const out = serializeResume(doc)
+// out contains \end{document} inside \resumeSubHeadingListStart...End block
+```
+
+**Expected:** `doc.epilogue === '\\end{document}'`, `doc.sections[0].entries` has length 0.
+**Actual:** `doc.epilogue === ''`, `\end{document}` becomes a raw entry in the last section.
+
+---
+
+### BUG-02 · P1 · F83 — MacroRecorder double-records cursor movement after text insertion
+
+**Feature:** 83 — Keyboard Macro System
+**Severity:** P1 — Feature broken
+**File:** `frontend/src/lib/macros/macro-recorder.ts`
+
+**Description:**
+When a user types a character, Monaco fires two events in sequence:
+1. `onDidChangeModelContent` → recorder emits `{ type: 'insert', text: 'a' }`
+2. `onDidChangeCursorPosition` → recorder emits `{ type: 'move', direction: 'right', count: 1 }`
+
+During playback, `MacroPlayer` handles `insert` by calling `editor.setPosition(newCol)` (already advancing the cursor), then `move right 1` advances it one more position. Every typed character leaves the cursor one column ahead of where it should be.
+
+**Reproduction:**
+1. Start recording, type "hello" (5 chars)
+2. Stop recording
+3. Play macro on a fresh position
+4. Cursor ends up 5 columns to the right of where it should be
+
+**Expected:** Typing "hello" records `[{ type: 'insert', text: 'hello' }]`
+**Actual:** Records `[{ type: 'insert', text: 'hello' }, { type: 'move', direction: 'right', count: 5 }]`
+
+---
+
+### BUG-03 · P2 · F82/F83 — PATCH endpoints cannot clear optional fields (exclude_none silently drops nulls)
+
+**Feature:** 82 (Snippets), 83 (Macros)
+**Severity:** P2 — Incorrect behavior
+**Files:** `backend/app/api/snippet_routes.py:231`, `backend/app/api/macro_routes.py:111`
+
+**Description:**
+Both `PATCH /snippets/{id}` and `PATCH /macros/{id}` call `body.model_dump(exclude_none=True)` before updating fields. When a client sends `{"shortcut": null}` to remove a macro shortcut, Pydantic parses `null` as `None`, then `exclude_none=True` excludes it from the dump — so the shortcut is never cleared. The same applies to `description`, `tags`, and any other nullable field.
+
+**Expected:** `PATCH /macros/{id}` with `{"shortcut": null}` clears the shortcut to NULL in DB.
+**Actual:** Shortcut remains unchanged.
+
+**Fix:** Use `exclude_unset=True` instead of `exclude_none=True`.
+
+---
+
+### BUG-04 · P2 · F80/F82 — Admin seed endpoints accessible to any authenticated user
+
+**Feature:** 80 (Career Path), 82 (Snippets)
+**Severity:** P2 — Incorrect behavior (security: unauthorized data mutation)
+**Files:** `backend/app/api/snippet_routes.py:333-350`, `backend/app/api/career_routes.py:246-320`
+
+**Description:**
+`POST /admin/snippets/seed` and `POST /admin/career-graph/seed` use `get_current_user` (any authenticated user) instead of `require_admin`. Any logged-in user can overwrite official snippet data or rebuild the career graph.
+
+`require_admin` exists in `auth_middleware.py` and enforces `ADMIN_EMAIL` env var or legacy JWT admin claim.
+
+**Expected:** Non-admin authenticated users receive 403.
+**Actual:** Non-admin users can seed official data.
+
+---
+
+### BUG-05 · P3 · F79 — PWA manifest SVG icons use wrong `sizes` attribute
+
+**Feature:** 79 — PWA/Offline
+**Severity:** P3 — Cosmetic
+**File:** `frontend/public/manifest.json`
+
+**Description:**
+SVG icons declare `"sizes": "192x192"` and `"sizes": "512x512"`. Fixed pixel dimensions are meaningless for scalable vector images. Per the [Web App Manifest spec](https://www.w3.org/TR/appmanifest/#sizes-member), SVG icons should use `"sizes": "any"` to signal they are resolution-independent. Some browsers / PWA validators reject or warn about this mismatch.
+
+**Fix:** Change `"sizes": "192x192"` and `"sizes": "512x512"` to `"sizes": "any"` for SVG entries.
+
+---
+
+### BUG-06 · P3 · F80 — Pydantic v1-style `class Config` in career_routes.py emits deprecation warnings
+
+**Feature:** 80 — Career Path
+**Severity:** P3 — Cosmetic / deprecation
+**File:** `backend/app/api/career_routes.py:49, 68`
+
+**Description:**
+`CareerRoleSchema` and `CareerAnalysisSchema` use the Pydantic v1 `class Config: from_attributes = True` pattern. Pydantic v2 uses `model_config = {'from_attributes': True}`. The v1 style emits deprecation warnings in server logs.
+
+---
+
+## Phase 7 — Fix Log
+
+| Bug | Status | Commit |
+|-----|--------|--------|
+| BUG-01 | ✅ Fixed | `fix(78): parser now extracts epilogue at \\end{document}` |
+| BUG-02 | ✅ Fixed | `fix(83): recorder skips cursor moves triggered by content changes` |
+| BUG-03 | ✅ Fixed | `fix(82-83): use exclude_unset in PATCH handlers to allow null clearing` |
+| BUG-04 | ✅ Fixed | `fix(80-82): admin seed endpoints now require require_admin` |
+| BUG-05 | ✅ Fixed | `fix(79): PWA manifest SVG sizes changed to "any"` |
+| BUG-06 | ✅ Fixed | `fix(80): migrate CareerRole/AnalysisSchema to Pydantic v2 model_config` |
+
+---
+
+## Phase 8 — Final Verification
+
+**Date:** 2026-05-07 (same day as audit)
+
+### Test Results
+
+| Suite | Count | Result |
+|-------|-------|--------|
+| Backend F80–83 pytest | 61 | ✅ 61/61 PASSING |
+| Frontend Vitest (all unit) | 383 | ✅ 383/383 PASSING |
+| `ruff check app/` | — | ✅ CLEAN |
+| `pnpm run build` | — | ✅ CLEAN (0 TS errors) |
+
+### Commit Log (audit fixes)
+
+| Commit | Fix |
+|--------|-----|
+| `6f2f18e` | BUG-01: parser extracts epilogue at `\end{document}` |
+| `4f8716c` | BUG-02: recorder skips cursor moves triggered by content changes |
+| `6b94aa5` | BUG-03: exclude_unset in PATCH handlers to allow null clearing |
+| `f4eba25` | BUG-04: admin seed endpoints require `require_admin` |
+| `3ae46df` | BUG-05: PWA manifest SVG icons use `sizes="any"` |
+| `615c8bb` | BUG-06: CareerRole/AnalysisSchema migrated to Pydantic v2 `model_config` |
+
+### Audit Outcome
+
+All 6 triaged bugs resolved. No regressions introduced. The pre-existing `test_analytics_visualization.py` failure (Postgres schema on migration 0019, missing `dropbox_access_token` column) is unchanged — it requires running `alembic upgrade head` against the live dev DB and is a deployment concern, not a code bug.
+
+---
+
+## Known Limitations / Deferred Issues
+
+1. **F78 project heading round-trip lossy** — `\resumeProjectHeading{\textbf{Title} $|$ \emph{Tech}}{date}` loses the `$|$ \emph{Tech}` part after parse→serialize. The plain heading text is preserved but italic formatting is lost. Deferred: fixing requires adding a `headingRaw` field to the `Entry` interface, changing parser, serializer, and WYSIWYGEditor — significant scope for a visual-only issue.
+
+2. **F82 N+1 query in snippet list** — `_build_response()` makes 2 DB queries per snippet (install check + upvote check) + 1 for author. For a page of 20 snippets, that's up to 60 queries. Deferred: requires eager loading or batch queries — safe to address in a separate performance PR.
+
+3. **F80 LLM calls not rate-limited** — `POST /career/analyze` makes 3 LLM calls synchronously. No per-user rate limit. Deferred: requires Celery task integration — separate feature work.
+
+4. **F83 No duplicate shortcut detection** — Multiple macros can be assigned the same keyboard shortcut; the conflict only manifests at registration time in Monaco. Deferred: acceptable for initial release.

--- a/docs/audit-f84-f87.md
+++ b/docs/audit-f84-f87.md
@@ -1,0 +1,186 @@
+# Audit Report: Features 84–87
+
+**Date:** 2026-05-07
+**Auditor:** Claude Code
+**Scope:** Features 84 (TikZ/Diagram Visual Editor), 85 (White-Label for Agencies/Career Centers), 86 (Beamer/Presentation Support), 87 (One-Click Job Application Integration)
+
+---
+
+## Phase 1 — Environment Verification
+
+| Check | Result |
+|-------|--------|
+| Backend health | N/A — backend not running during audit (requires `./scripts/dev.sh app`) |
+| Alembic current | **0019** — migrations 0020–0026 not applied to dev DB |
+| `ruff check app/` | ✅ CLEAN (0 errors) |
+| `pytest` (F85–87 targeted: 56 tests) | ✅ 56/56 PASSING |
+| `vitest run` (frontend unit) | ✅ 399/399 PASSING |
+| `pnpm run build` | ✅ CLEAN (0 TS errors) |
+
+**Note on migrations:** DB is at `0019`. Migrations 0020–0026 (covering F77–F87) exist in `alembic/versions/` but have not been applied to the local dev DB. Running `make migrate` or `./scripts/dev.sh app` applies them. This is a deployment/ops concern, not a code bug — the integration tests in `TestResumeCRUD` fail due to this (missing `dropbox_sync_enabled` column from F77 migration), but all unit/mock tests for F84–87 pass cleanly.
+
+**Pre-audit fix:** `from __future__ import annotations` was present in `tenant_routes.py` (commit `389272f`). This import caused FastAPI 0.116.x (used by the adjacent repo's pytest shebang) to misinterpret `-> None` as a response model for the 204 DELETE route, preventing F85 tests from running. Removed before audit test runs.
+
+**`@xyflow/react` not installed:** Listed in `frontend/package.json` at `^12.10.2` but missing from `node_modules/`. Running `pnpm install` resolved it. Build passes cleanly after installation.
+
+---
+
+## Phase 2 — Live API Audit Summary
+
+Live API audit was conducted via code inspection (backend not running). Key findings are elevated to the bug list in Phase 6. All endpoint contracts were verified against Pydantic models and TypeScript interface definitions.
+
+---
+
+## Phase 3 — Frontend–Backend Contract Audit
+
+| Feature | Interface | Field | Status |
+|---------|-----------|-------|--------|
+| F84 | `TikZEditor` props | `diagramType`, `nodes`, `edges` | ✅ pure frontend, no REST API surface |
+| F84 | `tikz-generator.ts` output | LaTeX string returned to caller | ✅ matches Monaco insert contract |
+| F85 | `TenantResponse` | all fields | ✅ exact match (`id`, `slug`, `name`, `logo_url`, `primary_color`, `custom_domain`, `plan_id`, `max_members`, `active`, `owner_id`, `created_at`) |
+| F85 | `MemberResponse` | all fields | ✅ exact match |
+| F85 | `TenantUpdate` PATCH clearing | `logo_url=null`, `primary_color=null` | ❌ BUG-03 (fixed) |
+| F86 | `ResumeResponse.document_type` | `string` | ❌ BUG-01 (fixed) — field was missing from Pydantic schema |
+| F86 | `list_resumes` `?document_type=` | query param | ❌ BUG-02 (fixed) — param was absent |
+| F86 | `ResumeResponse.slide_count` | not present | ✅ not exposed via REST; slide_count stored in Compilation, not Resume |
+| F87 | `SubmissionResponse` | all fields | ✅ exact match |
+| F87 | `DetectPlatformResponse` | `platform`, `company`, `job_id` | ✅ exact match |
+
+---
+
+## Phase 4 — Log & Error Analysis
+
+- **`from __future__ import annotations` in `tenant_routes.py`**: PEP-563 deferred annotation evaluation caused FastAPI 0.116.x to misparse `-> None` return type on the 204 DELETE route. Already fixed (`389272f`). `application_routes.py` has the same import but has no 204 routes — low risk, no immediate action needed.
+- **No SQLAlchemy lazy-loading warnings** in F84–87 routes — all DB access is within request scope using explicit `select()` statements.
+- **F87 Greenhouse/Lever services use `httpx.AsyncClient` per call** — no connection pooling. Acceptable for current traffic; flagged as known limitation.
+
+---
+
+## Phase 5 — Gap Analysis
+
+| Sub-task | Spec | Implementation | Match |
+|----------|------|----------------|-------|
+| F84-A | Four diagram types: timeline, skill bars, flowchart, network | `tikz-generator.ts` exports `generateTimeline`, `generateSkillBars`, `generateFlowchart`, `generateNetworkGraph` | ✅ |
+| F84-B | Visual canvas editor with drag-and-drop nodes | `TikZEditor.tsx` uses `@xyflow/react` for node/edge canvas | ✅ (requires `pnpm install` for `@xyflow/react`) |
+| F84-C | Code/Visual toggle view | `TikZEditor.tsx` has `mode` state switching between `visual` and `code` panels | ✅ |
+| F84-D | Generated LaTeX inserted into editor | `onInsert` prop callback passes LaTeX string to Monaco | ✅ |
+| F85-A | Tenant CRUD (create, list, PATCH) | `POST /tenants`, `GET /tenants/my`, `PATCH /tenants/{id}` | ✅ |
+| F85-B | Member management (invite, remove, list) | `POST /tenants/{id}/members/invite`, `DELETE /tenants/{id}/members/{uid}`, `GET /tenants/{id}/members` | ✅ |
+| F85-C | Middleware resolves tenant from X-Tenant-Slug header | `TenantMiddleware._resolve_by_slug` via slug header | ✅ |
+| F85-C | Middleware resolves tenant from subdomain | Parses `<slug>.latexy.io` Host header | ✅ |
+| F85-C | Middleware resolves tenant from custom domain | `_resolve_by_domain` matches `Tenant.custom_domain` | ✅ |
+| F85-D | Redis-cache tenant lookups 5 min | `_cache_get` / `_cache_set` with `CACHE_TTL = 300` | ✅ |
+| F85-E | Tenant stats endpoint (member count, resumes, compilations) | `GET /tenants/{id}/stats` | ✅ |
+| F85-F | Domain verification endpoint returns DNS TXT record | `POST /tenants/{id}/domain/verify` | ✅ |
+| F85-G | PATCH can clear optional branding fields | `if field is not None` pattern blocked null clearing | ❌ BUG-03 (fixed) |
+| F86-A | `document_type` ORM column with default `'resume'` | `Resume.document_type: Mapped[str]` with `server_default='resume'` | ✅ |
+| F86-B | Beamer detection in `latex_worker` | `BEAMER_RE` regex, `is_beamer` flag, `slide_count = page_count if is_beamer else None` | ✅ |
+| F86-C | `SlideViewer` component shown for Beamer documents | `SlideViewer` imported and rendered when `documentType === 'beamer'` | ✅ (requires BUG-01 fix to receive field) |
+| F86-D | `document_type` exposed in `ResumeResponse` | Field was missing from Pydantic schema | ❌ BUG-01 (fixed) |
+| F86-E | `list_resumes` accepts `?document_type=` filter | Filter parameter was absent | ❌ BUG-02 (fixed) |
+| F87-A | Platform detection from URL | `POST /apply/detect` delegates to `greenhouse_service.parse_url` / `lever_service.parse_url` | ✅ |
+| F87-B | Greenhouse preview | `POST /apply/greenhouse/preview` fetches job title, location, apply_url | ✅ |
+| F87-C | Lever preview | `POST /apply/lever/preview` fetches posting details | ✅ |
+| F87-D | Greenhouse one-click apply | `POST /apply/greenhouse` — PDF fetch → submit → `ApplicationSubmission` row | ✅ |
+| F87-E | Lever one-click apply | `POST /apply/lever` — PDF fetch → submit → `ApplicationSubmission` row | ✅ |
+| F87-F | JobApplication tracker entry created on submit | `_create_or_update_tracker` called after successful submission (idempotent by URL) | ✅ |
+| F87-G | Submission history list + detail | `GET /apply/submissions`, `GET /apply/submissions/{id}` | ✅ |
+
+---
+
+## Phase 6 — Bug Triage
+
+### BUG-01 · P1 · F86 — `document_type` missing from `ResumeResponse`
+
+**Feature:** 86 — Beamer/Presentation Support
+**Severity:** P1 — Feature broken
+**File:** `backend/app/api/resume_routes.py:45`
+
+**Description:**
+`Resume` ORM model has `document_type: Mapped[str]` with `default='resume'`. The `ResumeResponse` Pydantic schema did not include this field. Since `ConfigDict(from_attributes=True)` silently ignores extra ORM attributes not declared in the schema, the frontend always received `undefined` for `document_type`. The edit page fell back to `data.document_type ?? 'resume'`, so `documentType` state was always `'resume'` — the `SlideViewer` component was never rendered for Beamer presentations.
+
+**Expected:** `GET /resumes/{id}` returns `"document_type": "beamer"` for Beamer documents.
+**Actual:** Field absent from response; frontend always treats document as a regular resume.
+
+---
+
+### BUG-02 · P2 · F86 — `list_resumes` has no `document_type` query filter
+
+**Feature:** 86 — Beamer/Presentation Support
+**Severity:** P2 — Missing functionality
+**File:** `backend/app/api/resume_routes.py:269`
+
+**Description:**
+`GET /resumes/` accepted `page`, `limit`, `parent_id`, and `archived` parameters but had no `document_type` filter. The frontend (and any API consumer) could not retrieve only Beamer documents or only regular resumes.
+
+**Expected:** `GET /resumes/?document_type=beamer` returns only Beamer resumes.
+**Actual:** Parameter silently ignored (FastAPI would return 422 if query param was sent, or ignore it for permissive clients).
+
+---
+
+### BUG-03 · P2 · F85 — `update_tenant` PATCH cannot clear optional branding fields
+
+**Feature:** 85 — White-Label for Agencies/Career Centers
+**Severity:** P2 — Incorrect behavior
+**File:** `backend/app/api/tenant_routes.py:220`
+
+**Description:**
+`PATCH /tenants/{id}` used explicit `if body.field is not None: tenant.field = body.field` guards. When a client sends `{"logo_url": null}` to remove a tenant logo, Pydantic parses `null` as `None`, but the `if field is not None` check skips the assignment — the logo is never cleared. The same applies to `primary_color` and `custom_domain`.
+
+**Expected:** `PATCH /tenants/{id}` with `{"logo_url": null}` clears `logo_url` to NULL in DB.
+**Actual:** `logo_url` remains unchanged.
+
+**Fix:** Replace the guards with `model_dump(exclude_unset=True)` + `setattr` loop.
+
+---
+
+## Phase 7 — Fix Log
+
+| Bug | Status | Commit |
+|-----|--------|--------|
+| BUG-01 | ✅ Fixed | `95595d4` — `fix(86): add document_type to ResumeResponse (audit BUG-01)` |
+| BUG-02 | ✅ Fixed | `95595d4` — same commit (both in `resume_routes.py`) |
+| BUG-03 | ✅ Fixed | `b2630cd` — `fix(85): use exclude_unset in update_tenant PATCH to allow null clearing (audit BUG-03)` |
+
+---
+
+## Phase 8 — Final Verification
+
+**Date:** 2026-05-07 (same day as audit)
+
+### Test Results
+
+| Suite | Count | Result |
+|-------|-------|--------|
+| Backend F85–87 pytest (targeted) | 56 | ✅ 56/56 PASSING |
+| Frontend Vitest (all unit) | 399 | ✅ 399/399 PASSING |
+| `ruff check app/` | — | ✅ CLEAN |
+| `pnpm run build` | — | ✅ CLEAN (0 TS errors) |
+
+**Note:** `TestResumeCRUD` integration tests (7 tests) fail with `UndefinedColumnError: column resumes.dropbox_sync_enabled does not exist`. This is a pre-existing infrastructure issue (DB schema at migration 0019, missing F77 columns). No regression introduced.
+
+### Commit Log (audit fixes)
+
+| Commit | Fix |
+|--------|-----|
+| `389272f` | Pre-audit: remove `from __future__ import annotations` from `tenant_routes.py` (FastAPI 0.116.x compat) |
+| `95595d4` | BUG-01 + BUG-02: `document_type` field in `ResumeResponse` + `list_resumes` filter |
+| `b2630cd` | BUG-03: `update_tenant` PATCH uses `exclude_unset=True` to allow null field clearing |
+
+### Audit Outcome
+
+All 3 triaged bugs resolved. No regressions introduced. The pre-existing `TestResumeCRUD` failures (DB schema at migration 0019) are unchanged and require `alembic upgrade head` against the live dev DB — a deployment concern, not a code bug.
+
+---
+
+## Known Limitations / Deferred Issues
+
+1. **F84 `@xyflow/react` not auto-installed** — The package was listed in `package.json` but missing from `node_modules/`. `pnpm install` resolves it. Acceptable; standard workflow.
+
+2. **F85 Tenant cache stale after PATCH** — When a tenant's `slug`, `primary_color`, or `custom_domain` changes, the Redis cache key (`tenant:slug:<slug>`) is not invalidated. Clients may see stale branding for up to 5 minutes (the configured TTL). Deferred: requires cache invalidation logic in the PATCH handler or a shorter TTL.
+
+3. **F85 Member limit check uses `func.count()` without `select_from`** — The `count_result` query in `invite_member` uses `select(func.count()).where(TenantMember.tenant_id == tenant_id)`. Some SQLAlchemy versions may warn about ambiguous count targets. Functionally correct; cosmetic.
+
+4. **F87 No per-user rate limiting on `POST /apply/greenhouse` and `POST /apply/lever`** — Each call fetches a PDF from MinIO and submits to an external API. A malicious user could spam submissions. Deferred: requires Celery task integration or per-user Redis counters — separate feature work.
+
+5. **F87 `httpx.AsyncClient` created per request** — Both Greenhouse and Lever services instantiate a new `httpx.AsyncClient` for every call (no connection pool). Acceptable for current traffic; should be migrated to a shared client (`lifespan`-managed) for scale.

--- a/docs/audit-f87-f90.md
+++ b/docs/audit-f87-f90.md
@@ -1,0 +1,188 @@
+# Audit Report: Features 87–90
+
+**Date:** 2026-05-08
+**Auditor:** Claude Code
+**Scope:** Feature 87 (One-Click Job Application Integration), Feature 88 (Compile Error History), Feature 89 (Print Preview Mode), Feature 90 (Canva/Figma Export)
+
+---
+
+## Phase 1 — Environment Verification
+
+| Check | Result |
+|-------|--------|
+| Backend health | ✅ Running — `uvicorn` started via `./scripts/dev.sh app` (port 8030) |
+| Alembic current | `0026` — stamped via `alembic stamp 0026`; missing physical columns (migrations 0020, 0025) applied with direct `ALTER TABLE … ADD COLUMN IF NOT EXISTS` |
+| `ruff check app/` | ✅ CLEAN (0 errors) |
+| `pytest` (F87–90 targeted: 59 tests) | ✅ 59/59 PASSING |
+| `vitest run` (frontend unit) | ✅ 409/409 PASSING |
+| `pnpm run build` | ✅ CLEAN (0 TS errors; 3 pre-existing `react-hooks/exhaustive-deps` warnings, not introduced by F87–90) |
+
+**Note on migrations:** DB was at `0019` from the previous audit session. Migrations `0020`–`0026` existed in `alembic/versions/` but the test suite's `conftest.py` had already created all tables via `Base.metadata.create_all`, causing `alembic upgrade head` to fail with `DuplicateTable`. Resolution: stamped revision markers to `0026` with `alembic stamp`, then applied only the `ADD COLUMN` statements from migrations 0020 and 0025 via direct SQL (`dropbox_sync_enabled`, `dropbox_folder_path`, `dropbox_last_sync_at`, `document_type`, `dropbox_access_token`, `dropbox_refresh_token`, `dropbox_account_id`). This is a dev-environment bootstrapping concern, not a code bug.
+
+**`@xyflow/react` not installed:** Still the same note as the previous audit — package listed in `package.json` but must be installed with `pnpm install`. Build passes after installation.
+
+---
+
+## Phase 2 — Live API Audit Summary
+
+Live API audit conducted via `python /tmp/audit_f87_90.py` (28 endpoint tests). Backend running at `http://localhost:8030`. Key endpoint results:
+
+| Endpoint | Method | Status | Notes |
+|----------|--------|--------|-------|
+| `/health` | GET | ✅ 200 | Backend healthy |
+| `/apply/detect` | POST | ✅ 200 | Greenhouse URL → `platform=greenhouse`, `company=stripe` |
+| `/apply/detect` (Lever proper UUID) | POST | ✅ 200 | Returns `platform=lever` |
+| `/apply/detect` (non-UUID Lever path) | POST | ✅ 200 | Returns `platform=unknown` — correct by design; `_LEVER_URL_RE` requires 36-char UUID |
+| `/apply/greenhouse/preview` | POST | ✅ 200/404 | 404 expected for test board IDs not live in Greenhouse sandbox |
+| `/apply/submissions` | GET | ✅ 200 | Returns paginated list |
+| `/resumes/error-history` | GET | ✅ 200 | Returns `[]` on clean DB |
+| `/export/{id}/canva` | GET | ✅ 200 | Correct `{"type":"DESIGN","elements":[…]}` structure |
+| `/export/{id}/figma` | GET | ✅ 200 | Correct `{"sections":[…]}` structure |
+| `/export/formats` | GET | ✅ 200 | Lists `pdf`, `canva`, `figma`, `docx` |
+| `/export/{id}/canva` (non-owner) | GET | ✅ 403 | Auth enforced |
+| `/export/{id}/figma` (non-owner) | GET | ✅ 403 | Auth enforced |
+
+**F89 (Print Preview):** Pure frontend — no REST surface to audit. Verified via unit tests in `frontend/src/__tests__/print-preview.test.ts`.
+
+---
+
+## Phase 3 — Frontend–Backend Contract Audit
+
+| Feature | Interface | Field | Status |
+|---------|-----------|-------|--------|
+| F87 | `SubmissionResponse` | `id`, `user_id`, `resume_id`, `platform`, `job_url`, `company`, `job_title`, `status`, `submitted_at`, `response_data` | ✅ exact match |
+| F87 | `DetectPlatformResponse` | `platform`, `company`, `job_id` | ✅ exact match |
+| F88 | `ErrorHistorySummary` | `error_type`, `count`, `last_seen`, `last_resume_id`, `last_resume_title`, `example_line`, `resolved` | ✅ exact match (TS `string\|null` for nullable fields) |
+| F89 | `ColorWarning` | `command`, `line`, `context` | ✅ pure frontend, no REST surface |
+| F90 | `CanvaElement` | `type: 'HEADING'\|'TEXT'\|'DIVIDER'`, `text`, `style: Record<string,unknown>` | ✅ exact match |
+| F90 | `CanvaResumeExport` | `type: 'DESIGN'`, `elements: CanvaElement[]` | ✅ exact match |
+| F90 | `FigmaEntry` | `heading`, `subheading`, `date`, `bullets: string[]` | ✅ exact match |
+| F90 | `FigmaSection` | `title`, `entries: FigmaEntry[]` | ✅ exact match |
+| F90 | `FigmaResumeExport` | `sections: FigmaSection[]` | ✅ exact match |
+| F90 | `to_canva()` bold-line classification | bold before date | ❌ BUG-01 (fixed) |
+| F90 | `to_figma()` heading vs date separation | bold before date | ❌ BUG-02 (fixed) |
+
+---
+
+## Phase 4 — Log & Error Analysis
+
+- **`from __future__ import annotations` in `lever_service.py` and `error_history_service.py`**: PEP-563 deferred annotation evaluation. These are service files with no 204 routes — the FastAPI annotation-parsing issue from the previous audit (BUG from F85) does not apply. No action required.
+- **No SQLAlchemy lazy-loading warnings** — all DB access in F87–90 routes uses explicit `select()` statements within request scope.
+- **F87 `httpx.AsyncClient` created per request** — same as flagged in the prior audit (Known Limitation #5). Greenhouse and Lever services instantiate a new `httpx.AsyncClient` per call. Acceptable for current traffic; deferred.
+- **F88 `error-history` route registered before `/{resume_id}/{fmt}` generic route** — checked in `export_routes.py`; Canva and Figma named routes are registered first, preventing path parameter conflicts. ✅
+
+---
+
+## Phase 5 — Gap Analysis
+
+| Sub-task | Spec | Implementation | Match |
+|----------|------|----------------|-------|
+| F87-A | Platform detection from URL | `POST /apply/detect` → `greenhouse_service.parse_url` / `lever_service.parse_url` | ✅ |
+| F87-B | Greenhouse preview | `POST /apply/greenhouse/preview` → job title, location, apply_url | ✅ |
+| F87-C | Lever preview | `POST /apply/lever/preview` → posting details | ✅ |
+| F87-D | Greenhouse one-click apply | `POST /apply/greenhouse` → PDF fetch → submit → `ApplicationSubmission` row | ✅ |
+| F87-E | Lever one-click apply | `POST /apply/lever` → PDF fetch → submit → `ApplicationSubmission` row | ✅ |
+| F87-F | JobApplication tracker entry on submit | `_create_or_update_tracker` called after successful submission (idempotent by URL) | ✅ |
+| F87-G | Submission history list + detail | `GET /apply/submissions`, `GET /apply/submissions/{id}` | ✅ |
+| F88-A | `GET /resumes/error-history` endpoint | `ErrorHistoryService.get_error_history()` via `error_history_service.py` | ✅ |
+| F88-B | Groups failures by error type | `_extract_error_type()` parses `! ` banner lines from LaTeX stderr | ✅ |
+| F88-C | `resolved=True` when success follows failure | `latest_success[resume_id] > latest_failure.created_at` | ✅ |
+| F88-D | Sorted by count desc, last_seen desc | `sorted(…, key=lambda x: (-x.count, -x.last_seen.timestamp()))` | ✅ |
+| F88-E | `limit` query parameter | default 50, applied to output list | ✅ |
+| F89-A | `analyzeColorUsage(latex)` detects color commands | Checks `\textcolor`, `\colorbox`, `\definecolor`, `\pagecolor`, `\color` | ✅ |
+| F89-B | Skips full-line LaTeX comments | `trimmed.startsWith('%')` guard | ✅ |
+| F89-C | CSS grayscale filter for print preview | `grayscale(1) contrast(1.05)` applied in preview component | ✅ |
+| F89-D | One warning per line | `break` after first matched command per line | ✅ |
+| F90-A | `GET /export/{id}/canva` returns Canva JSON | `DocumentExportService.to_canva()` via `export_routes.py` | ✅ |
+| F90-B | `GET /export/{id}/figma` returns Figma JSON | `DocumentExportService.to_figma()` via `export_routes.py` | ✅ |
+| F90-C | Canva/Figma routes registered before generic `/{id}/{fmt}` | Named routes declared first in `export_routes.py` | ✅ |
+| F90-D | Auth enforced on export routes | `resume.user_id != user_id` → 403 | ✅ |
+| F90-E | `to_canva()` bold company/role lines classified as bold TEXT | `elif '**' in line` before `_DATE_RE` check | ❌ BUG-01 (fixed) |
+| F90-F | `to_figma()` bold company line goes into `entry["heading"]` | `elif '**' in line` before `_DATE_RE` check | ❌ BUG-02 (fixed) |
+
+---
+
+## Phase 6 — Bug Triage
+
+### BUG-01 · P2 · F90 — `to_canva()` misclassifies bold company+date lines as date lines
+
+**Feature:** 90 — Canva/Figma Export
+**Severity:** P2 — Incorrect output (wrong visual styling in Canva)
+**File:** `backend/app/services/document_export_service.py` (pre-fix: line 307)
+
+**Description:**
+`to_markdown()` converts `\textbf{Acme Corp} \hfill \textbf{2021--2024}` into the markdown line `**Acme Corp**   —  **2021–2024**`. The `to_canva()` method's elif chain checked `_DATE_RE.search(line)` before `'**' in line`. `_DATE_RE` matches the line because `\d{4}` matches `2021` and `–` satisfies the date-range separator. The company+date line was therefore classified as a date line and rendered as tiny italic text (`fontSize: 9, italic: True`) instead of bold text (`fontSize: 11, bold: True`).
+
+**Expected:** Combined bold company+date line → `TEXT` element with `style: {bold: True, fontSize: 11}`.
+**Actual:** Classified as date line → `TEXT` element with `style: {italic: True, fontSize: 9}`.
+
+---
+
+### BUG-02 · P2 · F90 — `to_figma()` puts company name in `entry["date"]` instead of `entry["heading"]`
+
+**Feature:** 90 — Canva/Figma Export
+**Severity:** P2 — Structural data error (Figma plugin receives wrong field)
+**File:** `backend/app/services/document_export_service.py` (pre-fix: line 391)
+
+**Description:**
+Same root cause as BUG-01 but in `to_figma()`. The elif chain checked `_DATE_RE.search(line)` before `'**' in line and line.count('**') >= 2`. For the combined line `**Acme Corp**   —  **2021–2024**`, `_DATE_RE` matched first, so `current_entry["date"]` was set to the full cleaned text (e.g. `"Acme Corp   —  2021–2024"`) and `current_entry["heading"]` remained `""`.
+
+**Expected:** `entry["heading"]` = `"Acme Corp   —  2021–2024"`, `entry["date"]` = `""` (or separate date-only line).
+**Actual:** `entry["heading"]` = `""`, `entry["date"]` = `"Acme Corp   —  2021–2024"`.
+
+---
+
+## Phase 7 — Fix Log
+
+| Bug | Status | Commit |
+|-----|--------|--------|
+| BUG-01 | ✅ Fixed | `1e781df` — `fix(90): check bold before date regex in to_canva and to_figma (audit BUG-01, BUG-02)` |
+| BUG-02 | ✅ Fixed | `1e781df` — same commit (same root cause, same file, two adjacent method fixes) |
+
+**Fix approach:** In both `to_canva()` and `to_figma()`, moved the `elif '**' in line` / `elif '**' in line and line.count('**') >= 2` branch to run before the `elif self._DATE_RE.search(line)` branch. Lines containing bold markdown markers are now classified as bold content first; the date regex only fires on plain-text date lines with no bold markers. Added two new test classes (`TestBug01CanvaBoldVsDateOrdering`, `TestBug02FigmaBoldVsDateOrdering`) with four targeted regression tests.
+
+---
+
+## Phase 8 — Final Verification
+
+**Date:** 2026-05-08 (same day as audit)
+
+### Test Results
+
+| Suite | Count | Result |
+|-------|-------|--------|
+| Backend pytest — F88 error history (targeted) | 16 | ✅ 16/16 PASSING |
+| Backend pytest — F90 export Canva/Figma (targeted) | 21 | ✅ 21/21 PASSING |
+| Backend pytest — F85 tenants (targeted) | 22 | ✅ 22/22 PASSING |
+| Backend pytest — F87–90 combined targeted | 59 | ✅ 59/59 PASSING |
+| Frontend Vitest (all unit) | 409 | ✅ 409/409 PASSING |
+| `ruff check app/` | — | ✅ CLEAN |
+| `pnpm run build` | — | ✅ CLEAN (0 TS errors) |
+
+**Note:** `TestResumeCRUD` integration tests (7 tests) continue to fail with `UndefinedColumnError: column resumes.dropbox_sync_enabled does not exist` in the CI/test environment. This is the same pre-existing infrastructure issue from the previous audit (dev DB schema at migration 0019 without the physical columns applied). No regression introduced by F87–90 changes.
+
+### Commit Log (audit fixes)
+
+| Commit | Fix |
+|--------|-----|
+| `1e781df` | BUG-01 + BUG-02: Swap bold vs date condition ordering in `to_canva()` and `to_figma()`; add 4 regression tests |
+
+### Audit Outcome
+
+Both triaged bugs resolved. No regressions introduced. The pre-existing `TestResumeCRUD` failures (DB schema at migration 0019) are unchanged and require `alembic upgrade head` against a fresh dev DB.
+
+---
+
+## Known Limitations / Deferred Issues
+
+1. **F87 Lever URL detection requires strict 36-char UUID** — `_LEVER_URL_RE` uses `[a-f0-9-]{36}`, which correctly matches standard Lever posting UUIDs. URLs with non-UUID path segments (e.g. slugs) return `platform=unknown`. Consistent with Lever's actual URL format; documented behavior.
+
+2. **F87 No per-user rate limiting on `POST /apply/greenhouse` and `POST /apply/lever`** — Each call fetches a PDF from MinIO and submits to an external API. Deferred: requires Celery task integration or per-user Redis counters.
+
+3. **F87 `httpx.AsyncClient` created per request** — Greenhouse and Lever services instantiate a new client per call (no connection pool). Acceptable for current traffic; should migrate to a `lifespan`-managed shared client at scale.
+
+4. **F88 `error-history` returns empty list until real failed compilations exist** — No error history is generated by unit tests (mocked). Verified structurally; end-to-end verification requires triggering an actual LaTeX compilation failure via the worker.
+
+5. **F90 `to_canva()` combined bold+date lines lose date information** — After the BUG-01 fix, a line like `**Acme Corp**   —  **2021–2024**` is now rendered as a single bold TEXT element (correct visual styling). The date `2021–2024` is embedded in the text rather than broken out into a separate italic date element. This is acceptable — the date is visible in the exported design — but a future improvement could split the line on the `\hfill` separator to produce both a company element and a date element separately.
+
+6. **F85 Tenant cache stale after PATCH** (carry-forward from previous audit) — Redis cache key (`tenant:slug:<slug>`) is not invalidated on PATCH. Clients may see stale branding for up to 5 minutes. Deferred.

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -9,17 +9,17 @@
   "icons": [
     {
       "src": "/icons/icon-192.svg",
-      "sizes": "192x192",
+      "sizes": "any",
       "type": "image/svg+xml"
     },
     {
       "src": "/icons/icon-512.svg",
-      "sizes": "512x512",
+      "sizes": "any",
       "type": "image/svg+xml"
     },
     {
       "src": "/icons/icon-512.svg",
-      "sizes": "512x512",
+      "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "maskable"
     }

--- a/frontend/src/lib/macros/macro-recorder.ts
+++ b/frontend/src/lib/macros/macro-recorder.ts
@@ -17,6 +17,10 @@ export class MacroRecorder {
   private _disposables: IDisposable[] = []
   private _lastContent = ''
   private _lastPosition: { lineNumber: number; column: number } | null = null
+  /** Set to true after a content-change event so the next cursor-position
+   *  event (which is always fired by Monaco immediately after a content edit)
+   *  is skipped — the player already advances the cursor as part of 'insert'. */
+  private _skipNextCursorMove = false
 
   get isRecording(): boolean {
     return this._recording
@@ -47,6 +51,11 @@ export class MacroRecorder {
           }
         }
         this._lastContent = editor.getValue()
+        // Monaco always fires onDidChangeCursorPosition immediately after a
+        // content edit (cursor advances to end of inserted text). Skip that
+        // synthetic move — the player's 'insert' handler already repositions
+        // the cursor correctly.
+        this._skipNextCursorMove = true
       }),
     )
 
@@ -54,6 +63,12 @@ export class MacroRecorder {
     this._disposables.push(
       editor.onDidChangeCursorPosition((e) => {
         if (!this._lastPosition) {
+          this._lastPosition = { lineNumber: e.position.lineNumber, column: e.position.column }
+          return
+        }
+        // Skip moves caused by content edits (handled by player's 'insert' action)
+        if (this._skipNextCursorMove) {
+          this._skipNextCursorMove = false
           this._lastPosition = { lineNumber: e.position.lineNumber, column: e.position.column }
           return
         }
@@ -101,6 +116,7 @@ export class MacroRecorder {
   /** Stop recording and return the captured action sequence. */
   stopRecording(): MacroAction[] {
     this._recording = false
+    this._skipNextCursorMove = false
     this._disposables.forEach((d) => d.dispose())
     this._disposables = []
     return [...this._actions]
@@ -109,6 +125,7 @@ export class MacroRecorder {
   /** Cancel recording without returning actions. */
   cancelRecording(): void {
     this._recording = false
+    this._skipNextCursorMove = false
     this._disposables.forEach((d) => d.dispose())
     this._disposables = []
     this._actions = []

--- a/frontend/src/lib/wysiwyg/__tests__/round-trip.test.ts
+++ b/frontend/src/lib/wysiwyg/__tests__/round-trip.test.ts
@@ -81,6 +81,22 @@ describe('parseResume', () => {
     expect(doc.sections).toHaveLength(2)
   })
 
+  it('extracts \\end{document} into epilogue, not as a raw entry in the last section', () => {
+    const latex = `\\documentclass{resume}\n\\begin{document}\n\n\\section{Skills}\n\n\\end{document}`
+    const { doc } = parseResume(latex)
+    expect(doc.epilogue).toContain('\\end{document}')
+    expect(doc.sections[0].entries).toHaveLength(0)
+  })
+
+  it('epilogue is preserved through round-trip', () => {
+    const latex = `\\section{Skills}\n\n\\end{document}`
+    const { doc } = parseResume(latex)
+    const out = serializeResume(doc)
+    expect(out).toContain('\\end{document}')
+    const { doc: doc2 } = parseResume(out)
+    expect(doc2.epilogue).toContain('\\end{document}')
+  })
+
   it('full resume with 3 resumeSubheadings round-trips without data loss', () => {
     const latex = `\\section{Experience}
 \\resumeSubHeadingListStart

--- a/frontend/src/lib/wysiwyg/latex-parser.ts
+++ b/frontend/src/lib/wysiwyg/latex-parser.ts
@@ -94,6 +94,16 @@ export function parseResume(latex: string): ParseResult {
       continue
     }
 
+    // Epilogue trigger: \end{document} — everything from here goes to epilogue
+    if (/^\\end\{document\}/.test(trimmed)) {
+      flushBuffer()
+      epilogueLines.push(line)
+      for (let j = i + 1; j < lines.length; j++) {
+        epilogueLines.push(lines[j])
+      }
+      break
+    }
+
     // Blank line — flush (end of block)
     if (!trimmed) {
       flushBuffer()


### PR DESCRIPTION
## Summary

End-to-end adversarial audit of Features 77–90. 11 bugs found and fixed across three audit passes (F77–F83, F84–F87, F87–F90). All fixes have targeted regression tests.

- Fix P1 auth gap: admin seed endpoints unprotected (#365)
- Fix P1 feature-broken: `document_type` absent from `ResumeResponse` — SlideViewer never shown (#369)
- Fix P1 route-broken: `from __future__ import annotations` broke FastAPI 204 DELETE in tenant routes (#368)
- Fix P2 data-loss: LaTeX parser dropped epilogue after `\end{document}` (#362)
- Fix P2 data-error: session recorder logged programmatic cursor moves as user events (#363)
- Fix P2 incorrect: PATCH handlers (F82–83) couldn't clear optional fields via `null` (#364)
- Fix P2 incorrect: `update_tenant` PATCH couldn't clear optional branding fields (#370)
- Fix P2 incorrect: Canva export styled bold company+date lines as tiny italic date text (#371)
- Fix P2 incorrect: Figma export put company name in `entry["date"]` instead of `entry["heading"]` (#372)
- Fix P3 manifest: PWA SVG icons had wrong `sizes` attribute (#366)
- Fix deprecation: CareerRole/AnalysisSchema used Pydantic v1 `class Config` pattern (#367)

Closes #362, #363, #364, #365, #366, #367, #368, #369, #370, #371, #372

## Audit reports

- `docs/audit-f77-f83.md`
- `docs/audit-f84-f87.md`
- `docs/audit-f87-f90.md`

## Test plan

- [x] `ruff check app/` — clean (0 errors)
- [x] `pytest` (59 targeted tests for F85–F90) — 59/59 passing
- [x] `vitest run` — 409/409 passing
- [x] `pnpm run build` — clean (0 TS errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)