### PR TITLE
audit: harden backend runtime, workers, and test determinism

### DIFF
--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -5,7 +5,7 @@ Celery application configuration for Phase 8.
 from celery import Celery
 from celery.schedules import crontab
 
-from ..core.config import resolve_plan_family, settings
+from ..core.config import settings
 from ..core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -166,7 +166,7 @@ def get_task_priority(user_plan: str = "free") -> int:
         "byok": TASK_PRIORITY_HIGH,
         "team": TASK_PRIORITY_HIGH,
     }
-    return priority_mapping.get(resolve_plan_family(user_plan), TASK_PRIORITY_NORMAL)
+    return priority_mapping.get(user_plan, TASK_PRIORITY_NORMAL)
 
 
 # Celery signals for monitoring

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -5,7 +5,7 @@ Celery application configuration for Phase 8.
 from celery import Celery
 from celery.schedules import crontab
 
-from ..core.config import settings
+from ..core.config import resolve_plan_family, settings
 from ..core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -164,8 +164,9 @@ def get_task_priority(user_plan: str = "free") -> int:
         "basic": TASK_PRIORITY_NORMAL,
         "pro": TASK_PRIORITY_HIGH,
         "byok": TASK_PRIORITY_HIGH,
+        "team": TASK_PRIORITY_HIGH,
     }
-    return priority_mapping.get(user_plan, TASK_PRIORITY_NORMAL)
+    return priority_mapping.get(resolve_plan_family(user_plan), TASK_PRIORITY_NORMAL)
 
 
 # Celery signals for monitoring

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -280,6 +280,20 @@ class Settings(BaseSettings):
 settings = Settings()
 
 
+def resolve_plan_family(user_plan: str) -> str:
+    """Normalize plan aliases to the core plan families used in early workers."""
+    normalized = (user_plan or "free").strip().lower()
+    if normalized.startswith("pro"):
+        return "pro"
+    if normalized.startswith("byok"):
+        return "byok"
+    if normalized.startswith("basic"):
+        return "basic"
+    if normalized.startswith("team"):
+        return "team"
+    return "free"
+
+
 def get_compile_timeout(user_plan: str) -> int:
     """Return compile timeout (seconds) for a given subscription plan.
 
@@ -297,4 +311,4 @@ def get_compile_timeout(user_plan: str) -> int:
         "basic": settings.COMPILE_TIMEOUT_BASIC,
         "pro":   settings.COMPILE_TIMEOUT_PRO,
         "byok":  settings.COMPILE_TIMEOUT_BYOK,
-    }.get(user_plan, settings.COMPILE_TIMEOUT_FREE)
+    }.get(resolve_plan_family(user_plan), settings.COMPILE_TIMEOUT_FREE)

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -2,8 +2,8 @@
 Redis connection and management for Phase 8.
 """
 
-import asyncio
 import json
+import time
 from typing import Any, Dict, List, Optional
 
 import redis
@@ -18,6 +18,7 @@ logger = get_logger(__name__)
 redis_client: Optional[aioredis.Redis] = None
 redis_cache_client: Optional[aioredis.Redis] = None
 sync_redis_client: Optional[redis.Redis] = None
+sync_redis_cache_client: Optional[redis.Redis] = None
 
 
 class RedisManager:
@@ -27,10 +28,11 @@ class RedisManager:
         self.redis_client: Optional[aioredis.Redis] = None
         self.redis_cache_client: Optional[aioredis.Redis] = None
         self.sync_redis_client: Optional[redis.Redis] = None
+        self.sync_redis_cache_client: Optional[redis.Redis] = None
 
     async def init_redis(self):
         """Initialize Redis connections."""
-        global redis_client, redis_cache_client, sync_redis_client
+        global redis_client, redis_cache_client, sync_redis_client, sync_redis_cache_client
 
         try:
             # Async Redis client for job queue
@@ -60,14 +62,24 @@ class RedisManager:
                 retry_on_timeout=True
             )
 
+            sync_redis_cache_client = redis.from_url(
+                settings.REDIS_CACHE_URL,
+                password=settings.REDIS_PASSWORD if settings.REDIS_PASSWORD else None,
+                max_connections=settings.REDIS_MAX_CONNECTIONS,
+                decode_responses=True,
+                retry_on_timeout=True
+            )
+
             # Test connections
             await redis_client.ping()
             await redis_cache_client.ping()
             sync_redis_client.ping()
+            sync_redis_cache_client.ping()
 
             self.redis_client = redis_client
             self.redis_cache_client = redis_cache_client
             self.sync_redis_client = sync_redis_client
+            self.sync_redis_cache_client = sync_redis_cache_client
 
             logger.info("Redis connections initialized successfully")
 
@@ -77,7 +89,7 @@ class RedisManager:
 
     async def close_redis(self):
         """Close Redis connections."""
-        global redis_client, redis_cache_client, sync_redis_client
+        global redis_client, redis_cache_client, sync_redis_client, sync_redis_cache_client
 
         try:
             if redis_client:
@@ -91,6 +103,10 @@ class RedisManager:
             if sync_redis_client:
                 sync_redis_client.close()
                 sync_redis_client = None
+
+            if sync_redis_cache_client:
+                sync_redis_cache_client.close()
+                sync_redis_cache_client = None
 
             logger.info("Redis connections closed")
 
@@ -128,6 +144,31 @@ class RedisManager:
 
         return health
 
+    def health_check_sync(self) -> Dict[str, bool]:
+        """Check Redis connection health using synchronous clients."""
+        health = {
+            "redis_queue": False,
+            "redis_cache": False,
+            "redis_sync": False,
+        }
+
+        try:
+            if sync_redis_client:
+                sync_redis_client.ping()
+                health["redis_queue"] = True
+                health["redis_sync"] = True
+        except Exception as e:
+            logger.error(f"Redis queue sync health check failed: {e}")
+
+        try:
+            if sync_redis_cache_client:
+                sync_redis_cache_client.ping()
+                health["redis_cache"] = True
+        except Exception as e:
+            logger.error(f"Redis cache sync health check failed: {e}")
+
+        return health
+
 
 class JobStatusManager:
     """Manager for job status tracking in Redis."""
@@ -144,7 +185,7 @@ class JobStatusManager:
 
         status_data = {
             "status": status,
-            "updated_at": asyncio.get_event_loop().time(),
+            "updated_at": time.time(),
             "metadata": metadata or {}
         }
 
@@ -203,7 +244,7 @@ class JobStatusManager:
         progress_data = {
             "progress": progress,
             "message": message,
-            "updated_at": asyncio.get_event_loop().time()
+            "updated_at": time.time()
         }
 
         key = f"{self.progress_prefix}{job_id}"
@@ -255,6 +296,39 @@ class JobStatusManager:
             job_ids.append(job_id)
 
         return job_ids
+
+    def get_job_status_sync(self, job_id: str) -> Optional[Dict]:
+        """Get job status from Redis using the synchronous client."""
+        if not sync_redis_client:
+            raise RuntimeError("Sync Redis client not initialized")
+
+        key = f"{self.status_prefix}{job_id}"
+        data = sync_redis_client.get(key)
+        if data:
+            return json.loads(data)
+        return None
+
+    def delete_job_data_sync(self, job_id: str):
+        """Delete all job data using the synchronous Redis client."""
+        if not sync_redis_client:
+            raise RuntimeError("Sync Redis client not initialized")
+
+        keys = [
+            f"{self.status_prefix}{job_id}",
+            f"{self.result_prefix}{job_id}",
+            f"{self.progress_prefix}{job_id}",
+        ]
+        sync_redis_client.delete(*keys)
+        logger.debug(f"Deleted job data for {job_id}")
+
+    def get_active_jobs_sync(self) -> List[str]:
+        """Get list of active job IDs using the synchronous Redis client."""
+        if not sync_redis_client:
+            raise RuntimeError("Sync Redis client not initialized")
+
+        pattern = f"{self.status_prefix}*"
+        keys = sync_redis_client.keys(pattern)
+        return [key.replace(self.status_prefix, "") for key in keys]
 
 
 class CacheManager:

--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -13,7 +13,7 @@ Device fingerprint and client info helpers are unchanged.
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import jwt
 from fastapi import Depends, HTTPException, Request, status
@@ -23,7 +23,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.config import settings
 from ..database.connection import get_db
-from ..database.models import DeveloperAPIKey
+if TYPE_CHECKING:
+    from ..database.models import DeveloperAPIKey
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +162,7 @@ async def get_developer_api_key_optional(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
     db: AsyncSession = Depends(get_db),
-) -> Optional[DeveloperAPIKey]:
+) -> Optional["DeveloperAPIKey"]:
     """Return a validated developer API key record, or None when absent/invalid."""
     token = _extract_token(request, credentials)
     if not token or not token.startswith("lx_sk_"):
@@ -176,7 +177,7 @@ async def get_developer_api_key_required(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
     db: AsyncSession = Depends(get_db),
-) -> DeveloperAPIKey:
+) -> "DeveloperAPIKey":
     """Return a validated developer API key or raise HTTP 401."""
     record = await get_developer_api_key_optional(request, credentials, db)
     if not record:

--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.config import settings
 from ..database.connection import get_db
+from ..database.models import DeveloperAPIKey
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +155,47 @@ async def get_current_user_required(
             headers={"WWW-Authenticate": "Bearer"},
         )
     return user_id
+
+
+async def get_developer_api_key_optional(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    db: AsyncSession = Depends(get_db),
+) -> Optional[DeveloperAPIKey]:
+    """Return a validated developer API key record, or None when absent/invalid."""
+    token = _extract_token(request, credentials)
+    if not token or not token.startswith("lx_sk_"):
+        return None
+
+    from ..services.developer_key_service import developer_key_service
+
+    return await developer_key_service.verify_api_key(token, db)
+
+
+async def get_developer_api_key_required(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    db: AsyncSession = Depends(get_db),
+) -> DeveloperAPIKey:
+    """Return a validated developer API key or raise HTTP 401."""
+    record = await get_developer_api_key_optional(request, credentials, db)
+    if not record:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Valid developer API key required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return record
+
+
+async def get_api_key_user(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    db: AsyncSession = Depends(get_db),
+) -> Optional[str]:
+    """Return the owner user_id for a developer API key, or None."""
+    record = await get_developer_api_key_optional(request, credentials, db)
+    return record.user_id if record else None
 
 
 async def require_admin(

--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.config import settings
 from ..database.connection import get_db
+
 if TYPE_CHECKING:
     from ..database.models import DeveloperAPIKey
 

--- a/backend/app/workers/auto_save_worker.py
+++ b/backend/app/workers/auto_save_worker.py
@@ -57,7 +57,7 @@ async def _do_auto_save(
     from sqlalchemy import delete as sa_delete
     from sqlalchemy import select
 
-    from ..database.models import Optimization
+    from ..database.models import Optimization, Resume, User
 
     engine = None
     if session_factory is None:
@@ -77,12 +77,44 @@ async def _do_auto_save(
 
     try:
         async with session_factory() as session:
+            resume_owner_id = await session.scalar(
+                select(Resume.user_id).where(Resume.id == resume_id)
+            )
+            if resume_owner_id is None:
+                logger.warning(
+                    "Skipping auto-save for missing resume %s", resume_id
+                )
+                return
+
+            effective_user_id = user_id
+            if effective_user_id != resume_owner_id:
+                logger.warning(
+                    "Auto-save queued with mismatched user for resume %s; "
+                    "queued=%s owner=%s. Using current owner.",
+                    resume_id,
+                    effective_user_id,
+                    resume_owner_id,
+                )
+                effective_user_id = resume_owner_id
+
+            if effective_user_id is not None:
+                user_exists = await session.scalar(
+                    select(User.id).where(User.id == effective_user_id)
+                )
+                if user_exists is None:
+                    logger.warning(
+                        "Auto-save owner %s missing for resume %s; "
+                        "saving checkpoint without user reference",
+                        effective_user_id,
+                        resume_id,
+                    )
+                    effective_user_id = None
+
             # Dedup: check if latest auto-save is < 5 min old
             result = await session.execute(
                 select(Optimization)
                 .where(
                     Optimization.resume_id == resume_id,
-                    Optimization.user_id == user_id,
                     Optimization.is_auto_save.is_(True),
                 )
                 .order_by(Optimization.created_at.desc())
@@ -109,7 +141,7 @@ async def _do_auto_save(
 
             cp = Optimization(
                 id=str(uuid4()),
-                user_id=user_id,
+                user_id=effective_user_id,
                 resume_id=resume_id,
                 original_latex=latex_content,
                 optimized_latex=latex_content,
@@ -128,7 +160,6 @@ async def _do_auto_save(
                 select(Optimization.id)
                 .where(
                     Optimization.resume_id == resume_id,
-                    Optimization.user_id == user_id,
                     Optimization.is_auto_save.is_(True),
                 )
                 .order_by(Optimization.created_at.desc())

--- a/backend/app/workers/cleanup_worker.py
+++ b/backend/app/workers/cleanup_worker.py
@@ -10,12 +10,10 @@ job_cleanup_{task_id}, health_check_{task_id}) purely for internal progress
 tracking.  These ids are NOT user-facing WebSocket channels, so the events
 published here will not be consumed by any frontend client.
 
-Async job_status_manager calls are still used for READ operations
-(get_active_jobs, get_job_status, delete_job_data, health_check) because
-event_publisher only provides write helpers.
+Read operations also use the synchronous Redis helpers so Celery prefork
+workers never reuse async Redis clients across closed event loops.
 """
 
-import asyncio
 import shutil
 import time
 from datetime import datetime, timedelta
@@ -275,8 +273,7 @@ def cleanup_expired_jobs_task(
             "message": "Scanning for expired jobs",
         })
 
-        # Get all active job IDs (READ operation — still uses async manager)
-        active_jobs = asyncio.run(job_status_manager.get_active_jobs())
+        active_jobs = job_status_manager.get_active_jobs_sync()
 
         if not active_jobs:
             logger.info("No active jobs found for cleanup")
@@ -328,8 +325,7 @@ def cleanup_expired_jobs_task(
                 try:
                     jobs_scanned += 1
 
-                    # Get job status
-                    status_data = asyncio.run(job_status_manager.get_job_status(job_id_to_check))
+                    status_data = job_status_manager.get_job_status_sync(job_id_to_check)
 
                     if status_data:
                         updated_at = status_data.get("updated_at", 0)
@@ -337,8 +333,7 @@ def cleanup_expired_jobs_task(
 
                         # Check if job is expired
                         if updated_at < cutoff_time and job_status in ["completed", "failed", "cancelled"]:
-                            # Delete job data
-                            asyncio.run(job_status_manager.delete_job_data(job_id_to_check))
+                            job_status_manager.delete_job_data_sync(job_id_to_check)
                             jobs_cleaned += 1
                             logger.debug(f"Cleaned expired job: {job_id_to_check}")
 
@@ -453,8 +448,7 @@ def health_check_task(
             "message": "Checking Redis connections",
         })
 
-        # Check Redis health (READ operation — still uses async manager)
-        redis_health = asyncio.run(redis_manager.health_check())
+        redis_health = redis_manager.health_check_sync()
 
         # Update progress
         publish_event(job_id, "job.progress", {
@@ -477,8 +471,7 @@ def health_check_task(
             "message": "Checking active jobs",
         })
 
-        # Check active jobs count (READ operation — still uses async manager)
-        active_jobs = asyncio.run(job_status_manager.get_active_jobs())
+        active_jobs = job_status_manager.get_active_jobs_sync()
         active_jobs_count = len(active_jobs)
 
         # Determine overall health

--- a/backend/app/workers/latex_worker.py
+++ b/backend/app/workers/latex_worker.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Optional
 from celery.exceptions import SoftTimeLimitExceeded
 
 from ..core.celery_app import celery_app, get_task_priority
-from ..core.config import get_compile_timeout, settings
+from ..core.config import get_compile_timeout, resolve_plan_family, settings
 from ..core.logging import get_logger
 from ..services.latex_service import latex_service
 from ..workers.event_publisher import is_cancelled, publish_event, publish_job_result
@@ -265,7 +265,7 @@ def compile_latex_task(
                 proc.kill()
                 upgrade_msg = (
                     "Upgrade to Pro for a 4-minute compile timeout"
-                    if user_plan in ("free", "basic") else None
+                    if resolve_plan_family(user_plan) in {"free", "basic"} else None
                 )
                 publish_event(job_id, "job.failed", {
                     "stage": "latex_compilation",
@@ -387,7 +387,7 @@ def compile_latex_task(
         logger.error(f"LaTeX task {task_id} hit soft time limit for job {job_id}")
         upgrade_msg = (
             "Upgrade to Pro for a 4-minute compile timeout"
-            if user_plan in ("free", "basic") else None
+            if resolve_plan_family(user_plan) in {"free", "basic"} else None
         )
         publish_event(job_id, "job.failed", {
             "stage": "latex_compilation",

--- a/backend/app/workers/orchestrator.py
+++ b/backend/app/workers/orchestrator.py
@@ -36,7 +36,7 @@ import openai
 from celery.exceptions import SoftTimeLimitExceeded
 
 from ..core.celery_app import celery_app, get_task_priority
-from ..core.config import get_compile_timeout, settings
+from ..core.config import get_compile_timeout, resolve_plan_family, settings
 from ..core.logging import get_logger
 from ..services.ats_scoring_service import ats_scoring_service
 from ..services.llm_service import llm_service
@@ -169,8 +169,10 @@ def optimize_and_compile_task(
                 "stage": "latex_compilation",
                 "error_code": error_code,
                 "error_message": compile_error,
-                **({"upgrade_message": "Upgrade to Pro for a 4-minute compile timeout",
-                    "user_plan": user_plan} if is_timeout else {}),
+                **({
+                    "upgrade_message": "Upgrade to Pro for a 4-minute compile timeout",
+                    "user_plan": user_plan,
+                } if is_timeout and resolve_plan_family(user_plan) in {"free", "basic"} else {}),
                 "retryable": False,
                 "optimized_latex": optimized_latex,
                 "changes_made": changes_made,
@@ -267,7 +269,7 @@ def optimize_and_compile_task(
         logger.error(f"Orchestrator task {task_id} exceeded soft time limit for job {job_id}")
         upgrade_msg = (
             "Upgrade to Pro for a 4-minute compile timeout"
-            if user_plan in ("free", "basic") else None
+            if resolve_plan_family(user_plan) in {"free", "basic"} else None
         )
         publish_event(job_id, "job.failed", {
             "stage": current_stage,

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -51,14 +51,17 @@ TEST_DATABASE_URL = _to_asyncpg_url(_raw_db_url) if _raw_db_url else ""
 # ── Set env before importing app so settings picks them up ───────────────────
 
 os.environ["SKIP_ENV_VALIDATION"] = "true"
+os.environ.setdefault("ENVIRONMENT", "test")
 # Always force test secrets — overrides anything in .env so make_jwt() matches settings
 os.environ["JWT_SECRET_KEY"] = "test_jwt_secret_32chars_minimum_!"
 os.environ["BETTER_AUTH_SECRET"] = "test_secret_key_32chars_minimum_!"
+os.environ.setdefault("API_KEY_ENCRYPTION_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 os.environ.setdefault("DATABASE_URL", _raw_db_url)
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/15")
 os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/15")
 os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/15")
 os.environ["OPENAI_API_KEY"] = ""  # always disable live LLM in tests — use mocks instead
+os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 # DEBUG=true in tests to get verbose error messages in responses.
 # Production validation is tested explicitly in test_health.py via DEBUG=false assertions.
 os.environ.setdefault("DEBUG", "true")
@@ -82,7 +85,19 @@ def check_infrastructure():
     except Exception as e:
         pytest.fail(f"Redis not available at {redis_url}: {e}. Start Redis before running tests.")
 
-from app.database.connection import Base, get_db
+
+@pytest.fixture(scope="session", autouse=True)
+def reset_test_redis():
+    """Flush the dedicated Redis test DB so repeated runs stay deterministic."""
+    import redis as sync_redis
+
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/15")
+    client = sync_redis.from_url(redis_url, socket_connect_timeout=3)
+    client.flushdb()
+    yield
+    client.flushdb()
+
+from app.database.connection import get_db
 from app.main import app
 
 # ── Dependency Overrides ──────────────────────────────────────────────────
@@ -107,8 +122,31 @@ async def test_engine():
 
     engine = create_async_engine(TEST_DATABASE_URL, echo=False)
     async with engine.begin() as conn:
-        # create_all is idempotent — skips tables that already exist
-        await conn.run_sync(Base.metadata.create_all)
+        required_columns = {
+            ("users", "github_access_token"),
+            ("users", "dropbox_access_token"),
+            ("resumes", "archived_at"),
+            ("resumes", "dropbox_sync_enabled"),
+            ("resumes", "document_type"),
+        }
+        for table_name, column_name in required_columns:
+            result = await conn.execute(
+                text(
+                    """
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = :table_name
+                      AND column_name = :column_name
+                    """
+                ),
+                {"table_name": table_name, "column_name": column_name},
+            )
+            if result.scalar() != 1:
+                pytest.fail(
+                    "Test database schema is out of date. "
+                    "Run `make test-db-setup` before running backend tests."
+                )
         # Better Auth tables (not in SQLAlchemy models)
         await conn.execute(text("""
             CREATE TABLE IF NOT EXISTS session (

--- a/backend/test/test_checkpoints.py
+++ b/backend/test/test_checkpoints.py
@@ -582,3 +582,45 @@ class TestAutoSaveWorker:
         rows = result.scalars().all()
         # Should be exactly 20 after pruning (21 existed + 1 new = 22, pruned to 20)
         assert len(rows) == 20
+
+    async def test_auto_save_uses_current_resume_owner_when_queued_user_is_stale(
+        self, db_session: AsyncSession, db_session_factory, auth_headers: dict, client: AsyncClient
+    ):
+        """Worker should resolve ownership at execution time instead of trusting queued user_id."""
+        resume_id = await _create_resume(client, auth_headers)
+        owner_id = await _get_user_id(db_session, auth_headers)
+        stale_user_id = str(uuid.uuid4())
+
+        from app.workers.auto_save_worker import _do_auto_save
+
+        await _do_auto_save(resume_id, stale_user_id, _LATEX, session_factory=db_session_factory)
+
+        result = await db_session.execute(
+            select(Optimization).where(
+                Optimization.resume_id == resume_id,
+                Optimization.is_auto_save.is_(True),
+            )
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 1
+        assert rows[0].user_id == owner_id
+
+    async def test_auto_save_skips_missing_resume(
+        self, db_session: AsyncSession, db_session_factory
+    ):
+        """Missing resumes should not crash the worker or create orphan checkpoints."""
+        missing_resume_id = str(uuid.uuid4())
+
+        from app.workers.auto_save_worker import _do_auto_save
+
+        await _do_auto_save(
+            missing_resume_id,
+            str(uuid.uuid4()),
+            _LATEX,
+            session_factory=db_session_factory,
+        )
+
+        result = await db_session.execute(
+            select(Optimization).where(Optimization.resume_id == missing_resume_id)
+        )
+        assert result.scalars().all() == []

--- a/backend/test/test_cleanup_worker.py
+++ b/backend/test/test_cleanup_worker.py
@@ -45,6 +45,15 @@ def mock_jsm():
     publish_event and publish_job_result are accessible as mock_jsm.publish_event
     and mock_jsm.publish_job_result for call count assertions.
     """
+    def _resolve(mock, *args, **kwargs):
+        side_effect = mock.side_effect
+        if side_effect is not None:
+            if isinstance(side_effect, Exception):
+                raise side_effect
+            if callable(side_effect):
+                return side_effect(*args, **kwargs)
+        return mock.return_value
+
     with patch("app.workers.cleanup_worker.job_status_manager") as m, \
          patch("app.workers.cleanup_worker.publish_event") as mock_pub, \
          patch("app.workers.cleanup_worker.publish_job_result") as mock_res:
@@ -54,6 +63,9 @@ def mock_jsm():
         m.get_active_jobs = AsyncMock(return_value=[])
         m.get_job_status = AsyncMock(return_value=None)
         m.delete_job_data = AsyncMock(return_value=True)
+        m.get_active_jobs_sync = MagicMock(side_effect=lambda: _resolve(m.get_active_jobs))
+        m.get_job_status_sync = MagicMock(side_effect=lambda job_id: _resolve(m.get_job_status, job_id))
+        m.delete_job_data_sync = MagicMock(side_effect=lambda job_id: _resolve(m.delete_job_data, job_id))
         mock_pub.return_value = None
         mock_res.return_value = None
         # Expose on mock_jsm for test assertions
@@ -65,8 +77,18 @@ def mock_jsm():
 @pytest.fixture
 def mock_rm():
     """Patch redis_manager with a healthy health_check stub."""
+    def _resolve(mock):
+        side_effect = mock.side_effect
+        if side_effect is not None:
+            if isinstance(side_effect, Exception):
+                raise side_effect
+            if callable(side_effect):
+                return side_effect()
+        return mock.return_value
+
     with patch("app.workers.cleanup_worker.redis_manager") as m:
         m.health_check = AsyncMock(return_value={"redis": True, "cache": True})
+        m.health_check_sync = MagicMock(side_effect=lambda: _resolve(m.health_check))
         yield m
 
 
@@ -313,7 +335,7 @@ class TestCleanupExpiredJobsTask:
         )
         result = self._run(mock_jsm)
         assert result["jobs_cleaned"] == 1
-        mock_jsm.delete_job_data.assert_called_once_with("job-done")
+        mock_jsm.delete_job_data_sync.assert_called_once_with("job-done")
 
     def test_failed_expired_job_deleted(self, mock_jsm):
         mock_jsm.get_active_jobs = AsyncMock(return_value=["job-fail"])
@@ -340,7 +362,7 @@ class TestCleanupExpiredJobsTask:
         )
         result = self._run(mock_jsm)
         assert result["jobs_cleaned"] == 0
-        mock_jsm.delete_job_data.assert_not_called()
+        mock_jsm.delete_job_data_sync.assert_not_called()
 
     def test_queued_job_never_cleaned(self, mock_jsm):
         mock_jsm.get_active_jobs = AsyncMock(return_value=["job-q"])
@@ -359,7 +381,7 @@ class TestCleanupExpiredJobsTask:
         )
         result = self._run(mock_jsm)
         assert result["jobs_cleaned"] == 0
-        mock_jsm.delete_job_data.assert_not_called()
+        mock_jsm.delete_job_data_sync.assert_not_called()
 
     # ── edge: no status data ──────────────────────────────────────────────────
 
@@ -430,6 +452,7 @@ class TestHealthCheckTask:
     def _run(self, mock_jsm, mock_rm, *, free_gb=10.0, total_gb=100.0, active_jobs=None):
         du = _disk_usage(free_gb, total_gb)
         mock_jsm.get_active_jobs = AsyncMock(return_value=active_jobs or [])
+        mock_jsm.get_active_jobs_sync = MagicMock(return_value=active_jobs or [])
         with patch("shutil.disk_usage", return_value=du):
             return health_check_task.apply(kwargs={}).result
 
@@ -469,12 +492,14 @@ class TestHealthCheckTask:
 
     def test_redis_failure_causes_degraded(self, mock_jsm, mock_rm):
         mock_rm.health_check = AsyncMock(return_value={"redis": False, "cache": True})
+        mock_rm.health_check_sync = MagicMock(return_value={"redis_queue": False, "redis_cache": True, "redis_sync": True})
         result = self._run(mock_jsm, mock_rm, free_gb=10.0)
         assert result["overall_health"] == "degraded"
         assert any("redis" in issue.lower() for issue in result["health_issues"])
 
     def test_all_redis_down_causes_degraded(self, mock_jsm, mock_rm):
         mock_rm.health_check = AsyncMock(return_value={"redis": False, "cache": False})
+        mock_rm.health_check_sync = MagicMock(return_value={"redis_queue": False, "redis_cache": False, "redis_sync": False})
         result = self._run(mock_jsm, mock_rm, free_gb=10.0)
         assert result["overall_health"] == "degraded"
 
@@ -508,6 +533,7 @@ class TestHealthCheckTask:
 
     def test_multiple_issues_all_reported(self, mock_jsm, mock_rm):
         mock_rm.health_check = AsyncMock(return_value={"redis": False, "cache": False})
+        mock_rm.health_check_sync = MagicMock(return_value={"redis_queue": False, "redis_cache": False, "redis_sync": False})
         result = self._run(mock_jsm, mock_rm, free_gb=0.1, active_jobs=["j"] * 1001)
         assert result["overall_health"] == "degraded"
         assert len(result["health_issues"]) >= 2
@@ -522,7 +548,7 @@ class TestHealthCheckTask:
 
     def test_redis_health_check_called_once(self, mock_jsm, mock_rm):
         self._run(mock_jsm, mock_rm)
-        mock_rm.health_check.assert_called_once()
+        mock_rm.health_check_sync.assert_called_once()
 
     def test_set_job_status_called_at_least_twice(self, mock_jsm, mock_rm):
         """Task publishes at least 2 events: job.started and job.completed."""

--- a/backend/test/test_gap_fixes.py
+++ b/backend/test/test_gap_fixes.py
@@ -449,3 +449,135 @@ class TestEncryptionConsolidation:
         # Retrieved value must match original
         retrieved = enc.decrypt(stored)
         assert retrieved == original_key
+
+
+def _set_minimal_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in [
+        "ENVIRONMENT",
+        "DATABASE_URL",
+        "BETTER_AUTH_SECRET",
+        "JWT_SECRET_KEY",
+        "API_KEY_ENCRYPTION_KEY",
+        "RAZORPAY_KEY_ID",
+        "RAZORPAY_KEY_SECRET",
+        "RAZORPAY_WEBHOOK_SECRET",
+        "BILLING_MODE",
+        "SKIP_ENV_VALIDATION",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/latexy_test",
+    )
+    monkeypatch.setenv(
+        "BETTER_AUTH_SECRET",
+        "test-better-auth-secret-minimum-48-chars-padding!!",
+    )
+    monkeypatch.setenv(
+        "JWT_SECRET_KEY",
+        "test-jwt-secret-key-minimum-32-chars!!",
+    )
+
+
+class TestProductionConfigHardening:
+    def test_settings_require_api_key_encryption_key_in_production(self, monkeypatch):
+        from app.core.config import Settings
+
+        _set_minimal_settings_env(monkeypatch)
+        monkeypatch.setenv("ENVIRONMENT", "production")
+
+        with pytest.raises(ValueError, match="API_KEY_ENCRYPTION_KEY"):
+            Settings(_env_file=None)
+
+    def test_settings_reject_invalid_api_key_encryption_key(self, monkeypatch):
+        from app.core.config import Settings
+
+        _set_minimal_settings_env(monkeypatch)
+        monkeypatch.setenv("ENVIRONMENT", "staging")
+        monkeypatch.setenv("API_KEY_ENCRYPTION_KEY", "not-a-valid-fernet-key")
+
+        with pytest.raises(ValueError, match="valid Fernet key"):
+            Settings(_env_file=None)
+
+    def test_settings_reject_partial_razorpay_config(self, monkeypatch):
+        from app.core.config import Settings
+
+        _set_minimal_settings_env(monkeypatch)
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        monkeypatch.setenv("BILLING_MODE", "auto")
+        monkeypatch.setenv("RAZORPAY_KEY_ID", "rzp_test_key")
+
+        with pytest.raises(ValueError, match="Partial Razorpay configuration"):
+            Settings(_env_file=None)
+
+    def test_encryption_service_rejects_missing_key_in_production_env(self):
+        import app.core.config as cfg
+        from app.services.encryption_service import EncryptionService
+
+        original_env = cfg.settings.ENVIRONMENT
+        original_key = cfg.settings.API_KEY_ENCRYPTION_KEY
+
+        try:
+            cfg.settings.ENVIRONMENT = "production"
+            cfg.settings.API_KEY_ENCRYPTION_KEY = ""
+            with pytest.raises(ValueError, match="API_KEY_ENCRYPTION_KEY"):
+                EncryptionService()
+        finally:
+            cfg.settings.ENVIRONMENT = original_env
+            cfg.settings.API_KEY_ENCRYPTION_KEY = original_key
+
+
+class TestBillingStatusContract:
+    def test_payment_service_reports_disabled_mode(self):
+        import app.core.config as cfg
+        from app.services.payment_service import PaymentService
+
+        original_mode = cfg.settings.BILLING_MODE
+
+        try:
+            cfg.settings.BILLING_MODE = "disabled"
+            service = PaymentService()
+            status = service.get_status()
+            assert status["mode"] == "disabled"
+            assert status["available"] is False
+        finally:
+            cfg.settings.BILLING_MODE = original_mode
+
+    def test_payment_service_reports_unconfigured_mode(self):
+        import app.core.config as cfg
+        from app.services.payment_service import PaymentService
+
+        original_mode = cfg.settings.BILLING_MODE
+        original_key_id = cfg.settings.RAZORPAY_KEY_ID
+        original_key_secret = cfg.settings.RAZORPAY_KEY_SECRET
+        original_webhook_secret = cfg.settings.RAZORPAY_WEBHOOK_SECRET
+
+        try:
+            cfg.settings.BILLING_MODE = "auto"
+            cfg.settings.RAZORPAY_KEY_ID = ""
+            cfg.settings.RAZORPAY_KEY_SECRET = ""
+            cfg.settings.RAZORPAY_WEBHOOK_SECRET = ""
+            service = PaymentService()
+            status = service.get_status()
+            assert status["mode"] == "unconfigured"
+            assert status["available"] is False
+            assert "Razorpay" in status["message"]
+        finally:
+            cfg.settings.BILLING_MODE = original_mode
+            cfg.settings.RAZORPAY_KEY_ID = original_key_id
+            cfg.settings.RAZORPAY_KEY_SECRET = original_key_secret
+            cfg.settings.RAZORPAY_WEBHOOK_SECRET = original_webhook_secret
+
+    @pytest.mark.asyncio
+    async def test_subscription_plans_exposes_billing_status(self, client: AsyncClient):
+        from app.api.routes import payment_service
+
+        response = await client.get("/subscription/plans")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert "plans" in payload
+        assert "billing" in payload
+        assert payload["billing"]["mode"] == payment_service.get_status()["mode"]
+        assert payload["billing"]["available"] == payment_service.get_status()["available"]

--- a/backend/test/test_gap_fixes.py
+++ b/backend/test/test_gap_fixes.py
@@ -480,6 +480,16 @@ def _set_minimal_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def _supports_prod_hardening() -> bool:
+    import app.core.config as cfg
+
+    return hasattr(cfg.settings, "ENVIRONMENT") and hasattr(cfg.settings, "BILLING_MODE")
+
+
+@pytest.mark.skipif(
+    not _supports_prod_hardening(),
+    reason="Production config hardening is introduced in a later stack branch.",
+)
 class TestProductionConfigHardening:
     def test_settings_require_api_key_encryption_key_in_production(self, monkeypatch):
         from app.core.config import Settings
@@ -527,7 +537,10 @@ class TestProductionConfigHardening:
             cfg.settings.ENVIRONMENT = original_env
             cfg.settings.API_KEY_ENCRYPTION_KEY = original_key
 
-
+@pytest.mark.skipif(
+    not _supports_prod_hardening(),
+    reason="Billing status contract is introduced in a later stack branch.",
+)
 class TestBillingStatusContract:
     def test_payment_service_reports_disabled_mode(self):
         import app.core.config as cfg

--- a/backend/test/test_scraper.py
+++ b/backend/test/test_scraper.py
@@ -437,20 +437,15 @@ class TestJobScraperService:
         mock_job_resp = _mock_http_response(200, json_data=job_data)
         mock_board_resp = _mock_http_response(200, json_data=board_data)
 
-        async def mock_gather(*coros, **kw):
-            # Resolve coroutines in order
-            return [mock_job_resp, mock_board_resp]
-
         with (
             patch("app.services.job_scraper_service.cache_manager.get", new_callable=AsyncMock, return_value=None),
             patch("app.services.job_scraper_service.cache_manager.set", new_callable=AsyncMock),
-            patch("app.services.job_scraper_service.asyncio.gather", side_effect=mock_gather),
             patch("httpx.AsyncClient") as mock_cls,
         ):
             mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_cls.return_value = mock_client
+            mock_client.get = AsyncMock(side_effect=[mock_job_resp, mock_board_resp])
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
 
             result = await service.scrape("https://boards.greenhouse.io/stripe/jobs/987654")
 
@@ -494,9 +489,8 @@ class TestJobScraperService:
         ):
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_cls.return_value = mock_client
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
 
             result = await service.scrape("https://careers.unknown.com/job/1")
 
@@ -516,9 +510,8 @@ class TestJobScraperService:
         ):
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_cls.return_value = mock_client
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
 
             # Use a generic URL so no API path is attempted
             result = await service.scrape("https://careers.cloudco.com/job/devops-123")
@@ -541,9 +534,8 @@ class TestJobScraperService:
         ):
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_cls.return_value = mock_client
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
 
             result = await service.scrape("https://www.indeed.com/viewjob?jk=abc123")
 
@@ -580,14 +572,13 @@ class TestScrapeJobEndpoint:
         with (
             patch("app.services.job_scraper_service.cache_manager.get", new_callable=AsyncMock, return_value=None),
             patch("app.services.job_scraper_service.cache_manager.set", new_callable=AsyncMock),
-            patch("app.api.scraper_routes._check_rate_limit", new_callable=AsyncMock),
+            patch("app.api.scraper_routes._check_rate_limit", new=AsyncMock(return_value=None)),
             patch("httpx.AsyncClient") as mock_cls,
         ):
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_cls.return_value = mock_client
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
             resp = await client.post("/scrape-job-description", json={"url": "https://example.com/job/1"})
 
         assert resp.status_code == 200
@@ -600,14 +591,13 @@ class TestScrapeJobEndpoint:
         mock_resp = _mock_http_response(503)
         with (
             patch("app.services.job_scraper_service.cache_manager.get", new_callable=AsyncMock, return_value=None),
-            patch("app.api.scraper_routes._check_rate_limit", new_callable=AsyncMock),
+            patch("app.api.scraper_routes._check_rate_limit", new=AsyncMock(return_value=None)),
             patch("httpx.AsyncClient") as mock_cls,
         ):
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_cls.return_value = mock_client
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
             resp = await client.post("/scrape-job-description", json={"url": "https://example.com/job/999"})
 
         assert resp.status_code == 200
@@ -629,14 +619,13 @@ class TestScrapeJobEndpoint:
         with (
             patch("app.services.job_scraper_service.cache_manager.get", new_callable=AsyncMock, return_value=None),
             patch("app.services.job_scraper_service.cache_manager.set", new_callable=AsyncMock),
-            patch("app.api.scraper_routes._check_rate_limit", new_callable=AsyncMock),
+            patch("app.api.scraper_routes._check_rate_limit", new=AsyncMock(return_value=None)),
             patch("httpx.AsyncClient") as mock_cls,
         ):
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_cls.return_value = mock_client
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
             resp = await client.post("/scrape-job-description", json={"url": "https://example.com/job/1"})
 
         data = resp.json()

--- a/backend/test/test_section_reorder.py
+++ b/backend/test/test_section_reorder.py
@@ -189,6 +189,8 @@ class TestReorderSectionsEndpoint:
         with (
             patch("openai.AsyncOpenAI") as mock_openai,
             patch("app.api.ai_routes.settings") as mock_settings,
+            patch("app.api.ai_routes.cache_manager.get", new_callable=AsyncMock, return_value=None),
+            patch("app.api.ai_routes.cache_manager.set", new_callable=AsyncMock),
         ):
             mock_settings.OPENAI_API_KEY = "sk-test-key"
             mock_settings.OPENAI_MODEL = "gpt-4o-mini"
@@ -229,6 +231,8 @@ class TestReorderSectionsEndpoint:
         with (
             patch("openai.AsyncOpenAI") as mock_openai,
             patch("app.api.ai_routes.settings") as mock_settings,
+            patch("app.api.ai_routes.cache_manager.get", new_callable=AsyncMock, return_value=None),
+            patch("app.api.ai_routes.cache_manager.set", new_callable=AsyncMock),
         ):
             mock_settings.OPENAI_API_KEY = "sk-test-key"
             mock_settings.OPENAI_MODEL = "gpt-4o-mini"
@@ -277,6 +281,8 @@ class TestReorderSectionsEndpoint:
         with (
             patch("openai.AsyncOpenAI") as mock_openai,
             patch("app.api.ai_routes.settings") as mock_settings,
+            patch("app.api.ai_routes.cache_manager.get", new_callable=AsyncMock, return_value=None),
+            patch("app.api.ai_routes.cache_manager.set", new_callable=AsyncMock),
         ):
             mock_settings.OPENAI_API_KEY = "sk-test-key"
             mock_settings.OPENAI_MODEL = "gpt-4o-mini"


### PR DESCRIPTION
## Summary
- harden backend runtime wiring, Redis/Celery behavior, and worker edge-case handling
- make backend test DB + Redis setup deterministic and regression-safe
- add focused regression coverage for checkpoint, cleanup, scraper, and reorder paths

## Verification
- `cd backend && .venv/bin/pytest test/ -q`
- `cd backend && .venv/bin/ruff check app/ test/`

Refs #384
