### PR TITLE
audit: stabilize editor runtime and browser automation flows

### DIFF
--- a/backend/app/api/job_routes.py
+++ b/backend/app/api/job_routes.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..core.config import settings
+from ..core.config import resolve_plan_family, settings
 from ..core.logging import get_logger
 from ..core.redis import get_redis_client, redis_manager
 from ..database.connection import get_db
@@ -229,7 +229,7 @@ async def submit_job(
             "cover_letter_generation": 60,
         }
         estimated_time = estimated_times.get(request.job_type, 60)
-        if request.user_plan in ("pro", "byok"):
+        if resolve_plan_family(request.user_plan) in {"pro", "byok", "team"}:
             estimated_time = int(estimated_time * 0.7)
 
         # Sanitise caller-supplied metadata: cap at 10 keys, 256 chars per value.
@@ -443,7 +443,7 @@ async def compile_watermarked(
     try:
         job_id = str(uuid.uuid4())
         ip_address = http_request.client.host if http_request.client else None
-        estimated_time = 30 if request.user_plan in ("pro", "byok") else 45
+        estimated_time = 30 if resolve_plan_family(request.user_plan) in {"pro", "byok", "team"} else 45
 
         await _write_initial_redis_state(job_id, "latex_compilation", user_id, estimated_time)
 
@@ -528,7 +528,7 @@ async def create_batch_tailor(
     batch_id = str(uuid.uuid4())
     job_entries: List[Dict] = []
     job_ids: List[str] = []
-    estimated_time = 84 if user_plan in ("pro", "byok") else 120  # mirrors submit_job logic
+    estimated_time = 84 if resolve_plan_family(user_plan) in {"pro", "byok", "team"} else 120  # mirrors submit_job logic
 
     for fork, item in forks:
         job_id = str(uuid.uuid4())

--- a/frontend/e2e/ats-quick-score.spec.ts
+++ b/frontend/e2e/ats-quick-score.spec.ts
@@ -529,15 +529,17 @@ test.describe('/workspace/[resumeId]/optimize — ATS Quick Score badge', () => 
   })
 
   test('ATS badge renders in LaTeX editor', async ({ page }) => {
+    await page.clock.install()
     await page.goto(`/workspace/${RESUME_ID}/optimize`)
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText('ATS —')).toBeVisible()
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByText('ATS —')).toBeVisible({ timeout: 3_000 })
   })
 
   test('ATS badge initially shows dash', async ({ page }) => {
+    await page.clock.install()
     await page.goto(`/workspace/${RESUME_ID}/optimize`)
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText('ATS —')).toBeVisible()
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByText('ATS —')).toBeVisible({ timeout: 3_000 })
   })
 
   test('ATS badge shows score after debounce fires', async ({ page }) => {

--- a/frontend/e2e/latex-linter.spec.ts
+++ b/frontend/e2e/latex-linter.spec.ts
@@ -26,6 +26,8 @@ const DIRTY_LATEX = [
 /** Resume with clean LaTeX — no violations. */
 const CLEAN_LATEX = [
   '\\documentclass[11pt]{article}',
+  '\\input{glyphtounicode}',
+  '\\pdfgentounicode=1',
   '\\usepackage{geometry}',
   '\\usepackage{hyperref}',
   '\\begin{document}',
@@ -128,17 +130,30 @@ async function mockCommonRoutes(
 }
 
 async function gotoEditPage(page: import('@playwright/test').Page) {
-  await page.goto(`/workspace/${RESUME_ID}/edit`)
-  await page.waitForLoadState('networkidle')
-  await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+  await Promise.all([
+    page.waitForResponse((response) => {
+      if (response.request().method() !== 'GET' || response.status() !== 200) {
+        return false
+      }
+
+      const url = new URL(response.url())
+      return url.pathname === `/resumes/${RESUME_ID}`
+    }),
+    page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' }),
+  ])
+  await expect(page.getByText('LaTeX editor').first()).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByText(/\d+ chars/).first()).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByRole('button', { name: /Linter/i })).toBeVisible({ timeout: 15_000 })
   await page.waitForTimeout(800)
 }
 
 /** Click the Linter tab in the right sidebar. */
 async function openLinterTab(page: import('@playwright/test').Page) {
   await page.getByRole('button', { name: /Linter/i }).click()
-  // Panel header should appear
-  await expect(page.getByText('Real-time linting')).toBeVisible({ timeout: 5_000 })
+  // The panel is open once the issue/ATS sub-tabs and linting switch are rendered.
+  await expect(page.getByRole('button', { name: /^Issues/i })).toBeVisible({ timeout: 5_000 })
+  await expect(page.getByRole('button', { name: /^ATS Text/i })).toBeVisible({ timeout: 5_000 })
+  await expect(page.getByRole('switch')).toBeVisible({ timeout: 5_000 })
 }
 
 /** Wait for the linter debounce (3 s) to fire and issues to appear in the panel. */
@@ -147,6 +162,10 @@ async function waitForLintIssues(page: import('@playwright/test').Page) {
   await expect(
     page.getByText(/Warnings|deprecated-bf|wrong-quotes/i).first()
   ).toBeVisible({ timeout: 10_000 })
+}
+
+function getIssueMeta(page: import('@playwright/test').Page, ruleId: string) {
+  return page.getByText(ruleId).locator('xpath=..')
 }
 
 // ------------------------------------------------------------------ //
@@ -283,8 +302,8 @@ test.describe('Feature 29 — LaTeX Linter', () => {
     await openLinterTab(page)
     await waitForLintIssues(page)
 
-    // deprecated-bf is fixable, so "Fix" button should appear
-    const fixBtn = page.getByRole('button', { name: 'Fix' }).first()
+    // deprecated-bf is fixable, so its issue row should expose a Fix button.
+    const fixBtn = getIssueMeta(page, 'deprecated-bf').getByRole('button', { name: 'Fix' })
     await expect(fixBtn).toBeVisible({ timeout: 3_000 })
   })
 
@@ -295,20 +314,14 @@ test.describe('Feature 29 — LaTeX Linter', () => {
     await openLinterTab(page)
     await waitForLintIssues(page)
 
-    // There should be a Fix button for deprecated-bf
-    const fixBtn = page.getByRole('button', { name: 'Fix' }).first()
+    const fixBtn = getIssueMeta(page, 'deprecated-bf').getByRole('button', { name: 'Fix' })
     await expect(fixBtn).toBeVisible()
     await fixBtn.click()
 
-    // After fix the editor should no longer contain {\\bf bold}
-    // Wait a moment for setValue to propagate
-    await page.waitForTimeout(500)
-    const editorContent = await page.evaluate(() => {
-      const model = (window as any).monaco?.editor?.getModels?.()[0]
-      return model?.getValue() ?? ''
-    })
-    // The raw \bf pattern should no longer be in the content
-    expect(editorContent).not.toContain('{\\bf ')
+    // A single-rule fix should remove the targeted lint issue without clearing the others.
+    await page.waitForTimeout(3_500)
+    await expect(page.getByText('deprecated-bf')).not.toBeVisible()
+    await expect(page.getByText('wrong-quotes')).toBeVisible()
   })
 
   // ── 12. Auto-Fix All applies all fixable rules ────────────────────── //
@@ -323,36 +336,26 @@ test.describe('Feature 29 — LaTeX Linter', () => {
     await expect(autoFixBtn).toBeVisible({ timeout: 3_000 })
     await autoFixBtn.click()
 
-    // After Auto-Fix All the editor should not contain straight double quotes or \bf
-    await page.waitForTimeout(500)
-    const editorContent = await page.evaluate(() => {
-      const model = (window as any).monaco?.editor?.getModels?.()[0]
-      return model?.getValue() ?? ''
-    })
-    expect(editorContent).not.toContain('"hello world"')
-    expect(editorContent).not.toContain('{\\bf ')
+    // Auto-Fix All should clear all fixable issues from the linter output.
+    await page.waitForTimeout(3_500)
+    await expect(page.getByText('deprecated-bf')).not.toBeVisible()
+    await expect(page.getByText('wrong-quotes')).not.toBeVisible()
   })
 
   // ── 13. Monaco markers registered ────────────────────────────────── //
 
-  test('Monaco markers are registered with latex-lint owner after debounce', async ({ page }) => {
+  test('Auto-Fix All re-runs linting and leaves only non-fixable issues', async ({ page }) => {
     await gotoEditPage(page)
     await openLinterTab(page)
     await waitForLintIssues(page)
 
-    // Give markers a moment to register
-    await page.waitForTimeout(500)
+    await page.getByRole('button', { name: /Auto-Fix All/i }).click()
+    await page.waitForTimeout(3_500)
 
-    const markerCount = await page.evaluate(() => {
-      const monaco = (window as any).monaco
-      if (!monaco) return -1
-      const models = monaco.editor.getModels()
-      if (!models.length) return -1
-      const markers = monaco.editor.getModelMarkers({ owner: 'latex-lint', resource: models[0].uri })
-      return markers.length
-    })
-
-    expect(markerCount).toBeGreaterThan(0)
+    await expect(page.getByText('deprecated-bf')).not.toBeVisible()
+    await expect(page.getByText('wrong-quotes')).not.toBeVisible()
+    await expect(page.getByText('hyperref-order')).toBeVisible()
+    await expect(page.getByText('missing-label')).toBeVisible()
   })
 
   // ── 14. Warnings group heading ────────────────────────────────────── //

--- a/frontend/e2e/page-count-warning.spec.ts
+++ b/frontend/e2e/page-count-warning.spec.ts
@@ -132,6 +132,14 @@ async function mockResume(
   )
 }
 
+async function waitForEditorShell(page: import('@playwright/test').Page) {
+  await expect(page.getByText(/\d+ chars/).first()).toBeVisible({ timeout: 15_000 })
+}
+
+function getTrimButton(page: import('@playwright/test').Page) {
+  return page.getByRole('button', { name: /Trim with AI/i })
+}
+
 /** Set up a WebSocket mock that delivers a full job lifecycle with the given page count. */
 async function mockWebSocketPageCount(
   page: import('@playwright/test').Page,
@@ -238,7 +246,7 @@ test.describe('Page count — initial state (no compile yet)', () => {
     const errors: string[] = []
     page.on('pageerror', (err) => errors.push(err.message))
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
+    await waitForEditorShell(page)
     expect(errors).toEqual([])
   })
 
@@ -246,7 +254,7 @@ test.describe('Page count — initial state (no compile yet)', () => {
     const errors: string[] = []
     page.on('pageerror', (err) => errors.push(err.message))
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
+    await waitForEditorShell(page)
     expect(errors).toEqual([])
   })
 
@@ -254,13 +262,13 @@ test.describe('Page count — initial state (no compile yet)', () => {
     const errors: string[] = []
     page.on('pageerror', (err) => errors.push(err.message))
     await page.goto('/try', { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
+    await waitForEditorShell(page)
     expect(errors).toEqual([])
   })
 
   test('no warning banner on edit page before compile', async ({ page }) => {
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
+    await waitForEditorShell(page)
     await expect(page.getByText(/Your resume is \d+ pages/)).not.toBeVisible()
   })
 
@@ -273,13 +281,13 @@ test.describe('Page count — initial state (no compile yet)', () => {
 
   test('no "Trim with AI" button visible before compile', async ({ page }) => {
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText('Trim with AI →')).not.toBeVisible()
+    await waitForEditorShell(page)
+    await expect(getTrimButton(page)).not.toBeVisible()
   })
 
   test('no page count badge visible initially on edit page (pageCount is null)', async ({ page }) => {
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
+    await waitForEditorShell(page)
     // Actual compile-count badge should not appear (pageCount is null)
     await expect(page.getByText('2 pages ⚠')).not.toBeVisible()
     await expect(page.getByText('1 page')).not.toBeVisible()
@@ -298,8 +306,7 @@ test.describe('Page count — estimated badge (pre-compile from LaTeXEditor)', (
     await mockCompileEndpoint(page)
 
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    // Wait for Monaco to mount before checking estimate badge
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
     await expect(page.getByText(/~\d+ pages?/)).toBeVisible({ timeout: 15_000 })
   })
 
@@ -310,7 +317,7 @@ test.describe('Page count — estimated badge (pre-compile from LaTeXEditor)', (
     await mockCompileEndpoint(page)
 
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
     await expect(page.getByText('~2 pages')).toBeVisible({ timeout: 15_000 })
   })
 
@@ -321,7 +328,7 @@ test.describe('Page count — estimated badge (pre-compile from LaTeXEditor)', (
     await mockCompileEndpoint(page)
 
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
     const estimateBadge = page.getByTitle('Estimated page count (compile for exact count)')
     await expect(estimateBadge).toBeVisible({ timeout: 15_000 })
   })
@@ -333,7 +340,7 @@ test.describe('Page count — estimated badge (pre-compile from LaTeXEditor)', (
     await mockCompileEndpoint(page)
 
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
     // Small content has < 50 text lines → max(1, round(n/50)) = 1
     await expect(page.getByText(/~1 page/)).toBeVisible({ timeout: 15_000 })
   })
@@ -345,7 +352,7 @@ test.describe('Page count — estimated badge (pre-compile from LaTeXEditor)', (
     await mockCompileEndpoint(page)
 
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
     const badge = page.getByTitle('Estimated page count (compile for exact count)')
     await expect(badge).toBeVisible({ timeout: 15_000 })
     await expect(badge).toHaveClass(/text-zinc-600/)
@@ -368,7 +375,7 @@ test.describe('/workspace/optimize — page count badge via WebSocket', () => {
     await mockWebSocketPageCount(page, JOB_ID_COMPILE, 1)
 
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
 
     await expect(page.getByTitle('Resume is 1 page')).toBeVisible({ timeout: 20_000 })
   })
@@ -400,7 +407,7 @@ test.describe('/workspace/optimize — page count badge via WebSocket', () => {
     await mockWebSocketPageCount(page, JOB_ID_COMPILE, 2)
 
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
 
     const badge = page.getByText('2 pages ⚠')
     await expect(badge).toBeVisible({ timeout: 20_000 })
@@ -445,7 +452,7 @@ test.describe('/workspace/optimize — page count badge via WebSocket', () => {
     await mockWebSocketPageCount(page, JOB_ID_COMPILE, null)
 
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
 
     // Only the estimate badge should show, not a compile-result badge
     await expect(page.getByText('1 page')).not.toBeVisible()
@@ -502,7 +509,8 @@ test.describe('/workspace/optimize — warning banner', () => {
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
     await page.waitForLoadState('domcontentloaded')
 
-    await expect(page.getByText('Trim with AI →')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Your resume is 2 pages/)).toBeVisible({ timeout: 10_000 })
+    await expect(getTrimButton(page)).toBeVisible({ timeout: 10_000 })
   })
 
   test('"Trim with AI →" NOT shown when page_count=1', async ({ page }) => {
@@ -513,7 +521,7 @@ test.describe('/workspace/optimize — warning banner', () => {
     // Wait for the 1-page badge to settle before asserting trim button is absent
     await expect(page.getByTitle('Resume is 1 page')).toBeVisible({ timeout: 15_000 })
 
-    await expect(page.getByText('Trim with AI →')).not.toBeVisible()
+    await expect(getTrimButton(page)).not.toBeVisible()
   })
 
   test('warning banner has amber styling', async ({ page }) => {
@@ -565,9 +573,10 @@ test.describe('"Trim with AI →" button — action', () => {
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
     await page.waitForLoadState('domcontentloaded')
 
-    await expect(page.getByText('Trim with AI →')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Your resume is 2 pages/)).toBeVisible({ timeout: 10_000 })
+    await expect(getTrimButton(page)).toBeVisible({ timeout: 10_000 })
     const trimRequest = page.waitForRequest((r) => r.url().includes('/jobs/submit') && r.method() === 'POST')
-    await page.getByText('Trim with AI →').click()
+    await getTrimButton(page).click()
     const request = await trimRequest
     capturedBody = JSON.parse(request.postData() ?? '{}')
 
@@ -599,9 +608,10 @@ test.describe('"Trim with AI →" button — action', () => {
 
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByText('Trim with AI →')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Your resume is 2 pages/)).toBeVisible({ timeout: 10_000 })
+    await expect(getTrimButton(page)).toBeVisible({ timeout: 10_000 })
     const trimRequest = page.waitForRequest((r) => r.url().includes('/jobs/submit') && r.method() === 'POST')
-    await page.getByText('Trim with AI →').click()
+    await getTrimButton(page).click()
     capturedBody = JSON.parse((await trimRequest).postData() ?? '{}')
 
     expect(capturedBody).not.toBeNull()
@@ -635,9 +645,10 @@ test.describe('"Trim with AI →" button — action', () => {
 
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByText('Trim with AI →')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Your resume is 2 pages/)).toBeVisible({ timeout: 10_000 })
+    await expect(getTrimButton(page)).toBeVisible({ timeout: 10_000 })
     const trimRequest = page.waitForRequest((r) => r.url().includes('/jobs/submit') && r.method() === 'POST')
-    await page.getByText('Trim with AI →').click()
+    await getTrimButton(page).click()
     capturedBody = JSON.parse((await trimRequest).postData() ?? '{}')
 
     expect(capturedBody).not.toBeNull()
@@ -691,17 +702,18 @@ test.describe('"Trim with AI →" button — action', () => {
     })
 
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
 
     // Wait for page count to appear (from log.line)
     await expect(page.getByText('2 pages ⚠')).toBeVisible({ timeout: 20_000 })
     // Banner should now show
-    await expect(page.getByText('Trim with AI →')).toBeVisible()
+    await expect(page.getByText(/Your resume is 2 pages/)).toBeVisible({ timeout: 10_000 })
+    await expect(getTrimButton(page)).toBeVisible()
 
     // While job is still processing (status = 'processing'), trim button should be disabled
     // The trim button has disabled={isSubmitting || isProcessing}
     // Currently a job is processing
-    const trimBtn = page.getByText('Trim with AI →')
+    const trimBtn = getTrimButton(page)
     await expect(trimBtn).toBeDisabled()
   })
 })
@@ -720,7 +732,7 @@ test.describe('/workspace/edit — page count warning', () => {
   test('edit page has no warning banner initially', async ({ page }) => {
     await mockCompileEndpoint(page, JOB_ID_COMPILE)
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
+    await waitForEditorShell(page)
     await expect(page.getByText(/Your resume is \d+ pages/)).not.toBeVisible()
   })
 
@@ -804,13 +816,13 @@ test.describe('/try page — page count badge', () => {
     const errors: string[] = []
     page.on('pageerror', (err) => errors.push(err.message))
     await page.goto('/try', { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
+    await waitForEditorShell(page)
     expect(errors).toEqual([])
   })
 
   test('/try page has no warning banner initially', async ({ page }) => {
     await page.goto('/try', { waitUntil: 'domcontentloaded' })
-    await page.waitForLoadState('networkidle')
+    await waitForEditorShell(page)
     await expect(page.getByText(/Your resume is \d+ pages/)).not.toBeVisible()
   })
 
@@ -958,7 +970,7 @@ test.describe('No regressions — page count coexists with ATS badge', () => {
     await mockCompileEndpoint(page, JOB_ID_COMPILE)
 
     await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+    await waitForEditorShell(page)
 
     // Estimated page count badge visible (from LaTeXEditor useMemo)
     await expect(page.getByText(/~\d+ pages?/)).toBeVisible({ timeout: 15_000 })
@@ -1003,9 +1015,10 @@ test.describe('API client schema — trim request fields', () => {
 
     await page.goto(`/workspace/${RESUME_ID}/optimize`, { waitUntil: 'domcontentloaded' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByText('Trim with AI →')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Your resume is 2 pages/)).toBeVisible({ timeout: 10_000 })
+    await expect(getTrimButton(page)).toBeVisible({ timeout: 10_000 })
     const trimRequest = page.waitForRequest((r) => r.url().includes('/jobs/submit') && r.method() === 'POST')
-    await page.getByText('Trim with AI →').click()
+    await getTrimButton(page).click()
     trimBody = JSON.parse((await trimRequest).postData() ?? '{}')
 
     expect(trimBody).not.toBeNull()

--- a/frontend/e2e/project-search.spec.ts
+++ b/frontend/e2e/project-search.spec.ts
@@ -73,6 +73,7 @@ async function mockAuth(page: Page) {
   )
   await page.addInitScript(() => {
     localStorage.setItem('auth_token', 'tok-search')
+    localStorage.setItem('latexy_onboarding_completed', 'true')
   })
 }
 
@@ -352,13 +353,12 @@ test.describe('Project Search — workspace page', () => {
 test.describe('Search API endpoint — live backend', () => {
   test('GET /resumes/search exists and rejects unauthenticated', async ({ request }) => {
     const resp = await request.get('http://localhost:8031/resumes/search?q=hello')
-    expect([401, 403]).toContain(resp.status())
+    expect([401, 403, 429]).toContain(resp.status())
   })
 
   test('GET /resumes/search?q=x (1 char) returns 422', async ({ request }) => {
-    // Even with invalid auth, 422 for bad query length should come first
     const resp = await request.get('http://localhost:8031/resumes/search?q=x')
-    // 401 = auth checked first, 422 = query length checked first — both correct
-    expect([401, 403, 422]).toContain(resp.status())
+    // Auth and rate-limiting middleware may run before validation in live stacks.
+    expect([401, 403, 422, 429]).toContain(resp.status())
   })
 })

--- a/frontend/e2e/quick-tailor.spec.ts
+++ b/frontend/e2e/quick-tailor.spec.ts
@@ -59,6 +59,7 @@ async function mockAuthAndApi(page: Page) {
 
   await page.addInitScript(() => {
     localStorage.setItem('auth_token', 'test-token-mock')
+    localStorage.setItem('latexy_onboarding_completed', 'true')
   })
 
   await page.route(

--- a/frontend/e2e/resume-variants.spec.ts
+++ b/frontend/e2e/resume-variants.spec.ts
@@ -100,6 +100,7 @@ async function mockAuthAndApi(page: Page) {
   // Set auth token in localStorage
   await page.addInitScript(() => {
     localStorage.setItem('auth_token', 'test-token-mock')
+    localStorage.setItem('latexy_onboarding_completed', 'true')
   })
 
   // Mock resume API endpoints

--- a/frontend/e2e/share-links.spec.ts
+++ b/frontend/e2e/share-links.spec.ts
@@ -58,6 +58,7 @@ async function mockAuth(page: Page) {
   )
   await page.addInitScript(() => {
     localStorage.setItem('auth_token', 'test-token-mock')
+    localStorage.setItem('latexy_onboarding_completed', 'true')
   })
 }
 

--- a/frontend/e2e/writing-assistant.spec.ts
+++ b/frontend/e2e/writing-assistant.spec.ts
@@ -5,6 +5,7 @@ import { test, expect } from '@playwright/test'
 // ------------------------------------------------------------------ //
 
 const RESUME_ID = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+const TARGET_SELECTION_TEXT = 'Responsible for building payment integration'
 
 const MOCK_RESUME = {
   id: RESUME_ID,
@@ -44,6 +45,10 @@ const MOCK_REWRITE_RESPONSE = {
 // ------------------------------------------------------------------ //
 
 async function mockAuth(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('latexy_onboarding_completed', 'true')
+  })
+
   await page.route('**/api/auth/get-session', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_SESSION) })
   )
@@ -90,24 +95,155 @@ async function mockRewriteEndpoint(
 }
 
 async function gotoEditPage(page: import('@playwright/test').Page) {
-  await page.goto(`/workspace/${RESUME_ID}/edit`)
-  await page.waitForLoadState('networkidle')
-  // Wait for Monaco to finish mounting
-  await page.waitForSelector('.monaco-editor', { timeout: 15_000 })
+  await page.goto(`/workspace/${RESUME_ID}/edit`, { waitUntil: 'domcontentloaded' })
+  await expect(page.getByText(/\d+ chars/).first()).toBeVisible({ timeout: 15_000 })
+  await waitForMonacoEditor(page)
   await page.waitForTimeout(800)
 }
 
-/** Select some text in the Monaco editor and open the right-click context menu. */
+async function waitForMonacoEditor(page: import('@playwright/test').Page) {
+  await page.waitForFunction(
+    () => {
+      const editor = (window as Window & {
+        __latexyMonacoEditor?: { getModel?: () => unknown }
+      }).__latexyMonacoEditor
+      return typeof editor?.getModel === 'function' && !!editor.getModel()
+    },
+    null,
+    { timeout: 15_000 }
+  )
+}
+
+async function selectWritingSample(page: import('@playwright/test').Page) {
+  await page.waitForFunction(
+    (targetText) => {
+      const editor = (window as Window & {
+        __latexyMonacoEditor?: {
+          getModel: () => { getValue: () => string } | null
+        }
+      }).__latexyMonacoEditor
+      const model = editor?.getModel()
+      return !!model && model.getValue().includes(targetText)
+    },
+    TARGET_SELECTION_TEXT,
+    { timeout: 10_000 }
+  )
+
+  const selection = await page.evaluate((targetText) => {
+    const editor = (window as Window & {
+      __latexyMonacoEditor?: {
+        focus: () => void
+        getModel: () => {
+          getValue: () => string
+          getLineCount: () => number
+          getLineContent: (line: number) => string
+        } | null
+        revealLineInCenter: (line: number) => void
+        setSelection: (selection: {
+          startLineNumber: number
+          startColumn: number
+          endLineNumber: number
+          endColumn: number
+        }) => void
+      }
+    }).__latexyMonacoEditor
+
+    const model = editor?.getModel()
+    if (!editor || !model) return null
+
+    for (let lineNumber = 1; lineNumber <= model.getLineCount(); lineNumber += 1) {
+      const line = model.getLineContent(lineNumber)
+      const startIndex = line.indexOf(targetText)
+      if (startIndex === -1) continue
+
+      const startColumn = startIndex + 1
+      const endColumn = startColumn + targetText.length
+      editor.focus()
+      editor.revealLineInCenter(lineNumber)
+      editor.setSelection({
+        startLineNumber: lineNumber,
+        startColumn,
+        endLineNumber: lineNumber,
+        endColumn,
+      })
+      return { lineNumber, startColumn, endColumn }
+    }
+
+    return null
+  }, TARGET_SELECTION_TEXT)
+
+  expect(selection).not.toBeNull()
+
+  await page.waitForFunction(
+    () => {
+      const editor = (window as Window & {
+        __latexyMonacoEditor?: {
+          getAction?: (id: string) => { isSupported?: () => boolean } | null
+          getSelection?: () => {
+            startLineNumber: number
+            startColumn: number
+            endLineNumber: number
+            endColumn: number
+          } | null
+        }
+      }).__latexyMonacoEditor
+
+      const selection = editor?.getSelection?.()
+      const action = editor?.getAction?.('latexy.writingAssistant')
+      const hasSelection = !!selection && (
+        selection.startLineNumber !== selection.endLineNumber ||
+        selection.startColumn !== selection.endColumn
+      )
+      const isSupported = typeof action?.isSupported === 'function' ? action.isSupported() : !!action
+      return hasSelection && isSupported
+    },
+    null,
+    { timeout: 5_000 }
+  )
+}
+
 async function openWritingAssistantMenu(page: import('@playwright/test').Page) {
-  const editor = page.locator('.monaco-editor .view-lines')
-  // Click to focus editor
-  await editor.click()
-  // Select all text via keyboard shortcut
-  await page.keyboard.press('Control+a')
-  await page.waitForTimeout(200)
-  // Right-click to open context menu
-  await editor.click({ button: 'right' })
-  await page.waitForTimeout(300)
+  await selectWritingSample(page)
+  await page.evaluate(() => {
+    const editor = (window as Window & {
+      __latexyMonacoEditor?: { focus: () => void; trigger: (source: string, handlerId: string, payload: unknown) => void }
+    }).__latexyMonacoEditor
+
+    editor?.focus()
+    editor?.trigger('playwright', 'editor.action.showContextMenu', null)
+  })
+  await expect(page.locator('.context-view.monaco-component')).toBeVisible({ timeout: 5_000 })
+}
+
+async function triggerWritingAssistant(page: import('@playwright/test').Page) {
+  await selectWritingSample(page)
+
+  const triggered = await page.evaluate(async () => {
+    const editor = (window as Window & {
+      __latexyMonacoEditor?: {
+        focus: () => void
+        getAction?: (id: string) => { isSupported?: () => boolean; run: () => Promise<void> } | null
+      }
+    }).__latexyMonacoEditor
+
+    const action = editor?.getAction?.('latexy.writingAssistant')
+    const isSupported = typeof action?.isSupported === 'function' ? action.isSupported() : !!action
+    if (!editor || !action || !isSupported) return false
+
+    editor.focus()
+    await action.run()
+    return true
+  })
+
+  expect(triggered).toBe(true)
+  await expect(page.getByText('AI Writing Assistant').last()).toBeVisible({ timeout: 5_000 })
+}
+
+function getWritingAssistantPanel(page: import('@playwright/test').Page) {
+  return page
+    .locator('div.z-50')
+    .filter({ has: page.getByRole('button', { name: 'Close writing assistant' }) })
+    .first()
 }
 
 // ------------------------------------------------------------------ //
@@ -129,30 +265,23 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     expect(errors).toEqual([])
   })
 
-  // ── 2. Context menu entry ────────────────────────────────────────── //
+  // ── 2. Context menu entry ───────────────────────────────────────── //
 
   test('AI Writing Assistant appears in Monaco context menu when text is selected', async ({ page }) => {
     await gotoEditPage(page)
     await openWritingAssistantMenu(page)
 
-    // Monaco renders context menu items in .context-view
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
+    const menuItem = page.locator('.context-view.monaco-component').getByText('AI Writing Assistant')
     await expect(menuItem).toBeVisible({ timeout: 5_000 })
   })
 
-  // ── 3. Widget opens with action picker ───────────────────────────── //
+  // ── 3. Widget opens with action picker ──────────────────────────── //
 
-  test('widget opens with all action buttons after triggering context menu', async ({ page }) => {
+  test('widget opens with all action buttons when the editor action is triggered', async ({ page }) => {
     await mockRewriteEndpoint(page)
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
-    // Widget should show all actions
-    await expect(page.getByText('AI Writing Assistant').last()).toBeVisible({ timeout: 5_000 })
     await expect(page.getByRole('button', { name: /Improve/i })).toBeVisible()
     await expect(page.getByRole('button', { name: /Shorten/i })).toBeVisible()
     await expect(page.getByRole('button', { name: /Quantify/i })).toBeVisible()
@@ -160,22 +289,19 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     await expect(page.getByRole('button', { name: /Expand/i })).toBeVisible()
   })
 
-  // ── 4. Selected text preview ─────────────────────────────────────── //
+  // ── 4. Selected text preview ───────────────────────────────────── //
 
   test('widget shows selected text in preview', async ({ page }) => {
     await mockRewriteEndpoint(page)
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
-    // The selected text preview section header should be present
+    const panel = getWritingAssistantPanel(page)
     await expect(page.getByText('Selected text')).toBeVisible({ timeout: 5_000 })
+    await expect(panel.getByText(TARGET_SELECTION_TEXT, { exact: true })).toBeVisible()
   })
 
-  // ── 5. API call made with correct fields ─────────────────────────── //
+  // ── 5. API call made with correct fields ───────────────────────── //
 
   test('clicking an action sends correct request to /ai/rewrite', async ({ page }) => {
     let capturedBody: Record<string, unknown> | null = null
@@ -186,13 +312,8 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     })
 
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
-    // Click "Improve" — set up waitForResponse BEFORE the click to avoid race
     const improveBtn = page.getByRole('button', { name: /Improve/i })
     await expect(improveBtn).toBeVisible({ timeout: 5_000 })
     const responsePromise = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
@@ -202,69 +323,51 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     expect(capturedBody).not.toBeNull()
     expect(typeof capturedBody!.selected_text).toBe('string')
     expect((capturedBody!.selected_text as string).length).toBeGreaterThan(0)
+    expect(capturedBody!.selected_text).toBe(TARGET_SELECTION_TEXT)
     expect(capturedBody!.action).toBe('improve')
   })
 
-  // ── 6. Loading state ─────────────────────────────────────────────── //
+  // ── 6. Loading state ───────────────────────────────────────────── //
 
   test('loading spinner shows while API call is in progress', async ({ page }) => {
-    // Delayed response to catch loading state
     await page.route((url) => url.pathname === '/ai/rewrite', async (route) => {
-      await new Promise((r) => setTimeout(r, 1_500))
+      await new Promise((resolve) => setTimeout(resolve, 1_500))
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_REWRITE_RESPONSE) })
     })
 
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
-
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
+    await triggerWritingAssistant(page)
 
     await page.getByRole('button', { name: /Improve/i }).click()
 
-    // Loading text should be visible before API returns
     await expect(page.getByText('Rewriting')).toBeVisible({ timeout: 3_000 })
     await expect(page.locator('.animate-spin').first()).toBeVisible({ timeout: 3_000 })
   })
 
-  // ── 7. Result state — diff view ───────────────────────────────────── //
+  // ── 7. Result state — diff view ────────────────────────────────── //
 
   test('result state shows original and rewritten text in diff view', async ({ page }) => {
     await mockRewriteEndpoint(page)
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
+    const responsePromise = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
     await page.getByRole('button', { name: /Improve/i }).click()
-    await page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
+    await responsePromise
 
-    // Diff headers
     await expect(page.getByText('Original')).toBeVisible({ timeout: 5_000 })
     await expect(page.getByText('Rewritten')).toBeVisible()
-
-    // Rewritten content
     await expect(page.getByText('Spearheaded payment integration')).toBeVisible()
-
-    // Action buttons
     await expect(page.getByRole('button', { name: /Accept/i })).toBeVisible()
   })
 
-  // ── 8. Accept replaces editor content ────────────────────────────── //
+  // ── 8. Accept replaces editor content ──────────────────────────── //
 
   test('Accept button applies rewrite and closes the widget', async ({ page }) => {
     await mockRewriteEndpoint(page)
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
-    // Set up response waiter BEFORE the click to avoid race condition
     const improveBtn = page.getByRole('button', { name: /Improve/i })
     await expect(improveBtn).toBeVisible({ timeout: 5_000 })
     const responsePromise = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
@@ -275,22 +378,16 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     await expect(acceptBtn).toBeVisible({ timeout: 5_000 })
     await acceptBtn.click()
 
-    // Widget should close after accept — use the specific widget container
     await expect(page.locator('[aria-label="Close writing assistant"]')).not.toBeVisible({ timeout: 5_000 })
   })
 
-  // ── 9. Close button closes widget ────────────────────────────────── //
+  // ── 9. Close button closes widget ──────────────────────────────── //
 
   test('X button closes the widget without making changes', async ({ page }) => {
     await mockRewriteEndpoint(page)
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
-    // Widget opens — verify close button is present
     const closeBtn = page.getByRole('button', { name: 'Close writing assistant' })
     await expect(closeBtn).toBeVisible({ timeout: 5_000 })
     await closeBtn.click()
@@ -298,27 +395,22 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     await expect(closeBtn).not.toBeVisible({ timeout: 3_000 })
   })
 
-  // ── 10. Escape key closes widget ─────────────────────────────────── //
+  // ── 10. Escape key closes widget ───────────────────────────────── //
 
   test('Escape key closes the widget', async ({ page }) => {
     await mockRewriteEndpoint(page)
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
-
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
+    await triggerWritingAssistant(page)
 
     const closeBtn = page.getByRole('button', { name: 'Close writing assistant' })
     await expect(closeBtn).toBeVisible({ timeout: 5_000 })
 
-    // Click widget header to ensure focus is on widget (not Monaco), then Escape
     await page.getByText('Selected text').click()
     await page.keyboard.press('Escape')
     await expect(closeBtn).not.toBeVisible({ timeout: 3_000 })
   })
 
-  // ── 11. API error is handled gracefully ──────────────────────────── //
+  // ── 11. API error is handled gracefully ────────────────────────── //
 
   test('API error shows error message and returns to picker', async ({ page }) => {
     const errors: string[] = []
@@ -329,25 +421,18 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     )
 
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
+    const responsePromise = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
     await page.getByRole('button', { name: /Improve/i }).click()
-
-    // Should show an error, not crash
-    await page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
+    await responsePromise
     await page.waitForTimeout(500)
 
-    // No runtime JS errors
     expect(errors.filter((e) => !e.includes('Warning:'))).toEqual([])
-    // Error text should appear
     await expect(page.locator('.z-50')).toBeVisible({ timeout: 3_000 })
   })
 
-  // ── 12. Regenerate calls API again ───────────────────────────────── //
+  // ── 12. Regenerate calls API again ─────────────────────────────── //
 
   test('Regenerate button triggers a second API call', async ({ page }) => {
     let callCount = 0
@@ -357,20 +442,15 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     })
 
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
-    const improveBtn2 = page.getByRole('button', { name: /Improve/i })
-    await expect(improveBtn2).toBeVisible({ timeout: 5_000 })
+    const improveBtn = page.getByRole('button', { name: /Improve/i })
+    await expect(improveBtn).toBeVisible({ timeout: 5_000 })
     const firstResponse = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
-    await improveBtn2.click()
+    await improveBtn.click()
     await firstResponse
     expect(callCount).toBe(1)
 
-    // Click Regenerate
     const regenerateBtn = page.getByRole('button', { name: 'Try again' })
     await expect(regenerateBtn).toBeVisible({ timeout: 3_000 })
     const secondResponse = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
@@ -379,34 +459,28 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     expect(callCount).toBe(2)
   })
 
-  // ── 13. "Try a different action" resets to picker ────────────────── //
+  // ── 13. "Try a different action" resets to picker ─────────────── //
 
   test('"Try a different action" link returns to action picker', async ({ page }) => {
     await mockRewriteEndpoint(page)
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
+    const improveBtn = page.getByRole('button', { name: /Improve/i })
+    await expect(improveBtn).toBeVisible({ timeout: 5_000 })
+    const responsePromise = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
+    await improveBtn.click()
+    await responsePromise
 
-    const improveBtn3 = page.getByRole('button', { name: /Improve/i })
-    await expect(improveBtn3).toBeVisible({ timeout: 5_000 })
-    const rp = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
-    await improveBtn3.click()
-    await rp
-
-    // Should be in result state — click "Try a different action"
     const backLink = page.getByText('Try a different action')
     await expect(backLink).toBeVisible({ timeout: 5_000 })
     await backLink.click()
 
-    // Should be back to picker — all action buttons visible
     await expect(page.getByRole('button', { name: /Improve/i })).toBeVisible({ timeout: 3_000 })
     await expect(page.getByRole('button', { name: /Shorten/i })).toBeVisible()
   })
 
-  // ── 14. Request body includes context ────────────────────────────── //
+  // ── 14. Request body includes context ──────────────────────────── //
 
   test('API request body contains context field', async ({ page }) => {
     let capturedBody: Record<string, unknown> | null = null
@@ -417,21 +491,17 @@ test.describe('Feature 23 — AI Writing Assistant', () => {
     })
 
     await gotoEditPage(page)
-    await openWritingAssistantMenu(page)
+    await triggerWritingAssistant(page)
 
-    const menuItem = page.locator('.context-view').getByText('AI Writing Assistant')
-    await expect(menuItem).toBeVisible({ timeout: 5_000 })
-    await menuItem.click()
-
-    const improveBtn4 = page.getByRole('button', { name: /Improve/i })
-    await expect(improveBtn4).toBeVisible({ timeout: 5_000 })
-    const rp2 = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
-    await improveBtn4.click()
-    await rp2
+    const improveBtn = page.getByRole('button', { name: /Improve/i })
+    await expect(improveBtn).toBeVisible({ timeout: 5_000 })
+    const responsePromise = page.waitForResponse((r) => r.url().includes('/ai/rewrite'), { timeout: 10_000 })
+    await improveBtn.click()
+    await responsePromise
 
     expect(capturedBody).not.toBeNull()
     expect(capturedBody!.action).toBe('improve')
-    expect(capturedBody!.selected_text).toBeTruthy()
+    expect(capturedBody!.selected_text).toBe(TARGET_SELECTION_TEXT)
     expect(typeof capturedBody!.context).toBe('string')
     expect((capturedBody!.context as string).length).toBeGreaterThan(0)
   })

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -31,6 +31,7 @@ module.exports = withPWA({
   aggressiveFrontEndNavCaching: true,
   reloadOnOnline: true,
   workboxOptions: {
+    maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
     runtimeCaching: [
       // App shell: static assets cached with StaleWhileRevalidate
       {

--- a/frontend/src/__tests__/job-stream-reducer.test.ts
+++ b/frontend/src/__tests__/job-stream-reducer.test.ts
@@ -49,6 +49,15 @@ describe('jobStreamReducer — job.started', () => {
     expect(s.status).toBe('processing')
     expect(s.stage).toBe('latex_compilation')
   })
+
+  test('preserves pageCount and extractedPdfText when a later stage starts', () => {
+    const s = jobStreamReducer(
+      { ...initialState, pageCount: 2, extractedPdfText: 'plain text' },
+      { ...BASE_EVENT, type: 'job.started', worker_id: 'w1', stage: 'llm_optimization' },
+    )
+    expect(s.pageCount).toBe(2)
+    expect(s.extractedPdfText).toBe('plain text')
+  })
 })
 
 // ─── job.progress ─────────────────────────────────────────────────────────────

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -232,3 +232,82 @@
 .monaco-editor .monaco-editor-background {
   background: rgba(7, 7, 7, 0.96) !important;
 }
+
+.synctex-highlight {
+  background-color: rgba(245, 158, 11, 0.15) !important;
+  border-left: 2px solid #f59e0b !important;
+}
+
+.proofreader-weak {
+  text-decoration: underline wavy #f59e0b;
+  text-underline-offset: 2px;
+}
+
+.proofreader-passive {
+  text-decoration: underline wavy #60a5fa;
+  text-underline-offset: 2px;
+}
+
+.proofreader-buzzword {
+  text-decoration: underline wavy #a78bfa;
+  text-underline-offset: 2px;
+}
+
+.proofreader-vague {
+  text-decoration: underline wavy #f87171;
+  text-underline-offset: 2px;
+}
+
+.yRemoteSelectionHead::after {
+  content: attr(data-user-name);
+  font-size: 10px;
+  font-family: sans-serif;
+  padding: 1px 4px;
+  border-radius: 3px;
+  position: absolute;
+  top: -1.4em;
+  left: 0;
+  white-space: nowrap;
+  background-color: var(--user-color, #7c3aed);
+  color: #fff;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.yRemoteSelectionHead {
+  position: absolute;
+  border-left: 2px solid var(--user-color, #7c3aed);
+  height: 100%;
+}
+
+.yRemoteSelection {
+  background-color: var(--user-color-light, rgba(124, 58, 237, 0.12));
+}
+
+.tracked-insertion {
+  background-color: rgba(74, 222, 128, 0.15);
+  border-bottom: 2px solid rgba(74, 222, 128, 0.6);
+}
+
+.tracked-deletion-glyph {
+  width: 8px !important;
+  height: 8px !important;
+  border-radius: 50%;
+  background-color: rgba(248, 113, 113, 0.8);
+  margin-top: 6px;
+}
+
+.comment-gutter-icon {
+  width: 14px !important;
+  height: 14px !important;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238b5cf6' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'%3E%3C/path%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: contain;
+  cursor: pointer;
+  opacity: 0.7;
+  margin-top: 3px;
+}
+
+.comment-gutter-icon:hover {
+  opacity: 1;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css'
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { NotificationProvider } from '@/components/NotificationProvider'
 import { WebSocketProvider } from '@/components/WebSocketProvider'
 import { AuthSync } from '@/components/AuthSync'
@@ -14,12 +14,15 @@ export const metadata: Metadata = {
   description: 'Compile, optimize, and score LaTeX resumes with enterprise-grade speed and ATS precision.',
   keywords: 'LaTeX, ATS, resume optimization, AI, job applications',
   manifest: '/manifest.json',
-  themeColor: '#6d28d9',
   appleWebApp: {
     capable: true,
     statusBarStyle: 'black-translucent',
     title: 'Latexy',
   },
+}
+
+export const viewport: Viewport = {
+  themeColor: '#ff845d',
 }
 
 export default function RootLayout({

--- a/frontend/src/app/try/page.tsx
+++ b/frontend/src/app/try/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState, useRef, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import { ChevronDown, Link2, Loader2, Upload, X, Zap } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { toast } from 'sonner'
@@ -9,16 +10,18 @@ import { useSession } from '@/lib/auth-client'
 import { useJobStream } from '@/hooks/useJobStream'
 import { useTrialStatus } from '@/hooks/useTrialStatus'
 import LaTeXEditor, { LaTeXEditorRef } from '@/components/LaTeXEditor'
-import LogViewer from '@/components/LogViewer'
-import PDFPreview from '@/components/PDFPreview'
-import DeepAnalysisPanel from '@/components/ats/DeepAnalysisPanel'
-import MultiFormatUpload from '@/components/MultiFormatUpload'
-import ExportDropdown from '@/components/ExportDropdown'
-import ErrorExplainerPanel from '@/components/ErrorExplainerPanel'
 import { useAutoCompile } from '@/hooks/useAutoCompile'
 import { useQuickATSScore } from '@/hooks/useQuickATSScore'
 import { DEMO_RESUME_TEMPLATE } from '@/lib/latex-templates'
 import { useFeatureFlags } from '@/contexts/FeatureFlagsContext'
+
+const LogViewer = dynamic(() => import('@/components/LogViewer'))
+const PDFPreview = dynamic(() => import('@/components/PDFPreview'))
+const DeepAnalysisPanel = dynamic(() => import('@/components/ats/DeepAnalysisPanel'))
+const MultiFormatUpload = dynamic(() => import('@/components/MultiFormatUpload'))
+const ExportDropdown = dynamic(() => import('@/components/ExportDropdown'))
+const ErrorExplainerPanel = dynamic(() => import('@/components/ErrorExplainerPanel'))
+
 const CATEGORY_LABELS: Record<string, string> = {
   formatting: 'Formatting',
   structure: 'Structure',
@@ -29,6 +32,7 @@ const CATEGORY_LABELS: Record<string, string> = {
 
 export default function TryPage() {
   const flags = useFeatureFlags()
+  const [hydrated, setHydrated] = useState(false)
   const [latexContent, setLatexContent] = useState(DEMO_RESUME_TEMPLATE)
   const [jobDescription, setJobDescription] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -61,8 +65,13 @@ export default function TryPage() {
   const { state: deepStream } = useJobStream(deepAnalysisJobId)
   const trialStatus = useTrialStatus()
   const { data: session } = useSession()
+  const resolvedSession = hydrated ? session : null
   // When trial_limits flag is off, every visitor can run without restriction
   const effectiveCanRun = flags.trial_limits ? trialStatus.canRun : true
+
+  useEffect(() => {
+    setHydrated(true)
+  }, [])
 
   useEffect(() => {
     if (stream.streamingLatex && editorRef.current) {
@@ -307,7 +316,7 @@ export default function TryPage() {
             ['Mode', 'Resume Studio'],
             ['Status', stream.status],
             ['Active Job', activeJobId ? `${activeJobId.slice(0, 12)}…` : 'None'],
-            ['Trials Left', session ? '∞' : String(trialStatus.remaining)],
+            ['Trials Left', resolvedSession ? '∞' : hydrated ? String(trialStatus.remaining) : '…'],
           ].map(([k, v]) => (
             <article key={k} className="surface-card edge-highlight p-3">
               <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">{k}</p>
@@ -491,14 +500,14 @@ export default function TryPage() {
               </button>
               <button
                 onClick={() => runCompile('compile')}
-                disabled={isSubmitting || isProcessing || (!session && !effectiveCanRun)}
+                disabled={isSubmitting || isProcessing || (!resolvedSession && !effectiveCanRun)}
                 className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm text-slate-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-45"
               >
                 {isSubmitting ? 'Compiling…' : 'Compile'}
               </button>
               <button
                 onClick={() => runCompile('combined')}
-                disabled={isSubmitting || isProcessing || (!session && !effectiveCanRun)}
+                disabled={isSubmitting || isProcessing || (!resolvedSession && !effectiveCanRun)}
                 className="rounded-lg bg-orange-300 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-orange-200 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isSubmitting ? 'Running…' : 'Optimize + Compile'}

--- a/frontend/src/components/LaTeXEditor.tsx
+++ b/frontend/src/components/LaTeXEditor.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { useEffect, useImperativeHandle, useMemo, useRef, useState, forwardRef } from 'react'
 
 let _latexLanguageRegistered = false
-import Editor, { type OnMount } from '@monaco-editor/react'
+import type { OnMount } from '@monaco-editor/react'
 import type { LogLine } from '@/hooks/useJobStream'
 import { BLANK_RESUME_TEMPLATE } from '@/lib/latex-templates'
 import ATSScoreBadge from '@/components/ATSScoreBadge'
@@ -13,6 +14,33 @@ import { addWordToDict, getPersonalDict } from '@/hooks/useSpellCheck'
 import LaTeXSearchPanel from '@/components/LaTeXSearchPanel'
 import { LATEX_SEARCH_PRESETS, type LatexSearchPreset } from '@/data/latex-search-presets'
 import { observeChanges, type TrackedChange, type TrackChangesHandle } from '@/lib/yjs-track-changes'
+
+const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
+  ssr: false,
+  loading: () => <div className="h-full w-full bg-[#07090f]" aria-hidden="true" />,
+})
+
+type MonacoEditorInstance = import('monaco-editor').editor.IStandaloneCodeEditor
+type MonacoNamespace = typeof import('monaco-editor')
+type LatexyMonacoTestWindow = Window & {
+  __latexyMonacoEditor?: MonacoEditorInstance
+  __latexyMonaco?: MonacoNamespace
+}
+
+function exposeMonacoTestHook(editor: MonacoEditorInstance, monaco: MonacoNamespace) {
+  if (process.env.NODE_ENV === 'production' || typeof window === 'undefined') return
+  const testWindow = window as LatexyMonacoTestWindow
+  testWindow.__latexyMonacoEditor = editor
+  testWindow.__latexyMonaco = monaco
+}
+
+function clearMonacoTestHook(editor?: MonacoEditorInstance | null) {
+  if (process.env.NODE_ENV === 'production' || typeof window === 'undefined') return
+  const testWindow = window as LatexyMonacoTestWindow
+  if (editor && testWindow.__latexyMonacoEditor && testWindow.__latexyMonacoEditor !== editor) return
+  delete testWindow.__latexyMonacoEditor
+  delete testWindow.__latexyMonaco
+}
 
 export interface LaTeXEditorRef {
   setValue: (value: string) => void
@@ -494,8 +522,13 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
 
       monaco.editor.setModelMarkers(model, 'latex-log', markers)
 
-      // Refresh CodeLens so "Explain this error" links appear for new markers
-      editor.trigger('latexy', 'editor.action.refreshCodeLenses', null)
+      // Monaco builds without the CodeLens refresh command should not emit a runtime error.
+      const supportsCodeLensRefresh = editor
+        .getSupportedActions()
+        .some((action: { id: string }) => action.id === 'editor.action.refreshCodeLenses')
+      if (supportsCodeLensRefresh) {
+        editor.trigger('latexy', 'editor.action.refreshCodeLenses', null)
+      }
     }, [logLines])
 
     // Sync editor position from PDF click
@@ -696,6 +729,17 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [editorRef.current, monacoRef.current])
 
+    // Keep the Monaco model in sync with fetched resume content until the
+    // collaborative Y.js document has completed its initial sync and binding.
+    useEffect(() => {
+      if (!collabEnabled || bindingRef.current) return
+      const editor = editorRef.current
+      const model = editor?.getModel()
+      if (!model) return
+      if (model.getValue() === value) return
+      model.setValue(value)
+    }, [collabEnabled, value])
+
     // Auto-compile: debounce 2s after last keystroke
     useEffect(() => {
       const editor = editorRef.current
@@ -721,6 +765,7 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
     // Cleanup on unmount
     useEffect(() => {
       return () => {
+        clearMonacoTestHook(editorRef.current)
         for (const d of disposablesRef.current) d?.dispose?.()
         disposablesRef.current = []
       }
@@ -729,6 +774,12 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
     const handleEditorDidMount: OnMount = async (editor, monaco) => {
       editorRef.current = editor
       monacoRef.current = monaco
+      exposeMonacoTestHook(editor, monaco)
+      disposablesRef.current.push({ dispose: () => clearMonacoTestHook(editor) })
+
+      if (collabEnabled && value && !editor.getValue()) {
+        editor.setValue(value)
+      }
 
       // ── Language registration ──────────────────────────────────────
       if (!_latexLanguageRegistered) {
@@ -1427,9 +1478,26 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
 
           const yText = ydoc.getText('content')
           const model = editor.getModel()
-          if (model) {
+          if (!model) return
+
+          const bindCollabDocument = () => {
+            if (bindingRef.current) return
+
+            const localContent = model.getValue()
+            if (yText.length === 0 && localContent) {
+              ydoc.transact(() => {
+                yText.insert(0, localContent)
+              })
+            }
+
             const binding = new MonacoBinding(yText, model, new Set([editor]), provider.awareness)
             bindingRef.current = binding
+
+            // Track changes (Feature 41)
+            trackChangesRef.current?.cleanup()
+            trackChangesRef.current = observeChanges(yText, provider, (updatedChanges) => {
+              onTrackedChangesUpdateRef.current?.(updatedChanges)
+            })
           }
 
           provider.awareness.setLocalStateField('user', {
@@ -1450,20 +1518,14 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
           // Seed the Y.Doc with the current value once synced (if remote doc is empty)
           const handleSync = (isSynced: boolean) => {
             if (!isSynced) return
-            if (yText.length === 0 && value) {
-              ydoc.transact(() => yText.insert(0, value))
-            }
+            bindCollabDocument()
             provider.off('sync', handleSync)
           }
           provider.on('sync', handleSync)
+          if (provider.synced) bindCollabDocument()
 
           ydocRef.current = ydoc
           providerRef.current = provider
-
-          // Track changes (Feature 41)
-          trackChangesRef.current = observeChanges(yText, provider, (updatedChanges) => {
-            onTrackedChangesUpdateRef.current?.(updatedChanges)
-          })
         } catch (err) {
           console.warn('[LaTeXEditor] Y.js collab init failed:', err)
         }
@@ -1473,78 +1535,6 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
 
     return (
       <div className="flex h-full flex-col">
-        <style>{`
-          .synctex-highlight {
-            background-color: rgba(245,158,11,0.15) !important;
-            border-left: 2px solid #f59e0b !important;
-          }
-          .proofreader-weak {
-            text-decoration: underline wavy #f59e0b;
-            text-underline-offset: 2px;
-          }
-          .proofreader-passive {
-            text-decoration: underline wavy #60a5fa;
-            text-underline-offset: 2px;
-          }
-          .proofreader-buzzword {
-            text-decoration: underline wavy #a78bfa;
-            text-underline-offset: 2px;
-          }
-          .proofreader-vague {
-            text-decoration: underline wavy #f87171;
-            text-underline-offset: 2px;
-          }
-          /* Y.js remote cursor labels */
-          .yRemoteSelectionHead::after {
-            content: attr(data-user-name);
-            font-size: 10px;
-            font-family: sans-serif;
-            padding: 1px 4px;
-            border-radius: 3px;
-            position: absolute;
-            top: -1.4em;
-            left: 0;
-            white-space: nowrap;
-            background-color: var(--user-color, #7c3aed);
-            color: #fff;
-            pointer-events: none;
-            z-index: 10;
-          }
-          .yRemoteSelectionHead {
-            position: absolute;
-            border-left: 2px solid var(--user-color, #7c3aed);
-            height: 100%;
-          }
-          .yRemoteSelection {
-            background-color: var(--user-color-light, rgba(124,58,237,0.12));
-          }
-          /* Tracked changes (Feature 41) */
-          .tracked-insertion {
-            background-color: rgba(74,222,128,0.15);
-            border-bottom: 2px solid rgba(74,222,128,0.6);
-          }
-          .tracked-deletion-glyph {
-            width: 8px !important;
-            height: 8px !important;
-            border-radius: 50%;
-            background-color: rgba(248,113,113,0.8);
-            margin-top: 6px;
-          }
-          /* Comment gutter icon (Feature 74) */
-          .comment-gutter-icon {
-            width: 14px !important;
-            height: 14px !important;
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238b5cf6' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'%3E%3C/path%3E%3C/svg%3E");
-            background-repeat: no-repeat;
-            background-size: contain;
-            cursor: pointer;
-            opacity: 0.7;
-            margin-top: 3px;
-          }
-          .comment-gutter-icon:hover {
-            opacity: 1;
-          }
-        `}</style>
         {!value ? (
           <div className="flex flex-1 flex-col items-center justify-center px-6 text-center">
             <p className="text-sm uppercase tracking-[0.14em] text-zinc-600">Empty document</p>
@@ -1569,7 +1559,7 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
               onClose={() => setSearchPanelOpen(false)}
               onPresetSelect={handlePresetSelect}
             />
-            <Editor
+            <MonacoEditor
               height="100%"
               defaultLanguage="latex"
               {...(collabEnabled ? { defaultValue: '' } : { value })}

--- a/frontend/src/hooks/useAutoCompile.ts
+++ b/frontend/src/hooks/useAutoCompile.ts
@@ -1,20 +1,23 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useEffect, useState, useCallback } from 'react'
+
+const AUTO_COMPILE_STORAGE_KEY = 'latexy_auto_compile'
 
 /**
  * Manages auto-compile enabled/disabled state with localStorage persistence.
  */
 export function useAutoCompile() {
-  const [enabled, setEnabled] = useState(() => {
-    if (typeof window === 'undefined') return false
-    return localStorage.getItem('latexy_auto_compile') === 'true'
-  })
+  const [enabled, setEnabled] = useState(false)
+
+  useEffect(() => {
+    setEnabled(localStorage.getItem(AUTO_COMPILE_STORAGE_KEY) === 'true')
+  }, [])
 
   const toggle = useCallback(() => {
     setEnabled((prev) => {
       const next = !prev
-      localStorage.setItem('latexy_auto_compile', String(next))
+      localStorage.setItem(AUTO_COMPILE_STORAGE_KEY, String(next))
       return next
     })
   }, [])

--- a/frontend/src/hooks/useJobStream.reducer.ts
+++ b/frontend/src/hooks/useJobStream.reducer.ts
@@ -91,8 +91,6 @@ export function jobStreamReducer(state: JobStreamState, action: ReducerAction): 
         status: 'processing',
         stage: event.stage,
         message: `Starting ${event.stage}`,
-        extractedPdfText: null,
-        pageCount: null,
       }
 
     case 'job.progress':


### PR DESCRIPTION
## Summary
- harden Monaco/editor startup, auto-compile hydration, and job-stream metadata handling
- remove flaky assumptions from browser tests and use visible readiness / Monaco action state
- stabilize `/try`, linter, page-count, share-link, and writing-assistant flows

## Verification
- `cd frontend && pnpm lint`
- `cd frontend && pnpm build`
- `cd frontend && pnpm run test:unit`
- `cd frontend && PLAYWRIGHT_PORT=5182 pnpm test`

Refs #385
