### PR TITLE
feat: add admin resume template CRUD and backend coverage

### DIFF
--- a/backend/app/api/template_routes.py
+++ b/backend/app/api/template_routes.py
@@ -8,17 +8,23 @@ Endpoints:
   GET  /templates/{id}/thumbnail   — PNG thumbnail from MinIO
   GET  /templates/{id}/pdf         — compiled PDF from MinIO
   POST /templates/{id}/use         — authenticated; create a Resume from this template
+  POST /templates                  — admin; create a template
+  PUT  /templates/{id}             — admin; replace template fields
+  PATCH /templates/{id}/activate   — admin; mark active
+  PATCH /templates/{id}/deactivate — admin; mark inactive
+  DELETE /templates/{id}           — admin; delete template
 """
 
 import uuid as _uuid
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..core.config import settings
 from ..core.logging import get_logger
 from ..database.connection import get_db
 from ..database.models import Resume, ResumeTemplate
@@ -84,6 +90,17 @@ class UseTemplateRequest(BaseModel):
     title: Optional[str] = None
 
 
+class TemplateAdminUpsertRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = Field(default=None, max_length=1000)
+    category: str = Field(..., min_length=1, max_length=100)
+    tags: List[str] = Field(default_factory=list)
+    thumbnail_url: Optional[str] = Field(default=None, max_length=1000)
+    latex_content: str = Field(..., min_length=1)
+    is_active: bool = True
+    sort_order: int = 0
+
+
 # ------------------------------------------------------------------ #
 #  Helpers                                                            #
 # ------------------------------------------------------------------ #
@@ -99,6 +116,22 @@ def _validate_uuid(value: str) -> str:
 
 def _category_label(category: str) -> str:
     return CATEGORY_LABELS.get(category, category.replace("_", " ").title())
+
+
+def _require_valid_category(category: str) -> str:
+    normalized = category.strip()
+    if normalized not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail=f"Unknown category: '{category}'")
+    return normalized
+
+
+async def require_template_admin(
+    admin_secret: Optional[str] = Header(default=None, alias="X-Admin-Secret"),
+):
+    if not settings.ADMIN_SECRET_KEY:
+        raise HTTPException(status_code=503, detail="Admin template management is not configured")
+    if admin_secret != settings.ADMIN_SECRET_KEY:
+        raise HTTPException(status_code=403, detail="Invalid admin secret")
 
 
 def _to_response(t: ResumeTemplate, request: Request) -> TemplateResponse:
@@ -292,3 +325,101 @@ async def use_template(
 
     logger.info("User %s created resume %s from template %s (%s)", user_id, resume.id, template_id, t.name)
     return {"resume_id": resume.id, "title": resume.title}
+
+
+@router.post("", response_model=TemplateDetailResponse, status_code=status.HTTP_201_CREATED)
+async def create_template(
+    body: TemplateAdminUpsertRequest,
+    request: Request,
+    _: None = Depends(require_template_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    template = ResumeTemplate(
+        name=body.name.strip(),
+        description=body.description.strip() if body.description else None,
+        category=_require_valid_category(body.category),
+        tags=[tag.strip() for tag in body.tags if tag.strip()],
+        thumbnail_url=body.thumbnail_url.strip() if body.thumbnail_url else None,
+        latex_content=body.latex_content,
+        is_active=body.is_active,
+        sort_order=body.sort_order,
+    )
+    db.add(template)
+    await db.commit()
+    await db.refresh(template)
+    return _to_detail(template, request)
+
+
+@router.put("/{template_id}", response_model=TemplateDetailResponse)
+async def update_template(
+    template_id: str,
+    body: TemplateAdminUpsertRequest,
+    request: Request,
+    _: None = Depends(require_template_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    _validate_uuid(template_id)
+    template = await db.get(ResumeTemplate, template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    template.name = body.name.strip()
+    template.description = body.description.strip() if body.description else None
+    template.category = _require_valid_category(body.category)
+    template.tags = [tag.strip() for tag in body.tags if tag.strip()]
+    template.thumbnail_url = body.thumbnail_url.strip() if body.thumbnail_url else None
+    template.latex_content = body.latex_content
+    template.is_active = body.is_active
+    template.sort_order = body.sort_order
+    await db.commit()
+    await db.refresh(template)
+    return _to_detail(template, request)
+
+
+@router.patch("/{template_id}/activate", response_model=TemplateDetailResponse)
+async def activate_template(
+    template_id: str,
+    request: Request,
+    _: None = Depends(require_template_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    _validate_uuid(template_id)
+    template = await db.get(ResumeTemplate, template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+    template.is_active = True
+    await db.commit()
+    await db.refresh(template)
+    return _to_detail(template, request)
+
+
+@router.patch("/{template_id}/deactivate", response_model=TemplateDetailResponse)
+async def deactivate_template(
+    template_id: str,
+    request: Request,
+    _: None = Depends(require_template_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    _validate_uuid(template_id)
+    template = await db.get(ResumeTemplate, template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+    template.is_active = False
+    await db.commit()
+    await db.refresh(template)
+    return _to_detail(template, request)
+
+
+@router.delete("/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_template(
+    template_id: str,
+    _: None = Depends(require_template_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    _validate_uuid(template_id)
+    template = await db.get(ResumeTemplate, template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+    await db.delete(template)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/test/test_template_routes.py
+++ b/backend/test/test_template_routes.py
@@ -16,6 +16,7 @@ import uuid
 import pytest
 from httpx import AsyncClient
 
+from app.core.config import settings
 from app.database.models import ResumeTemplate
 
 # ---------------------------------------------------------------------------
@@ -241,6 +242,10 @@ async def _create_auth_headers(db_session) -> dict:
     return {"Authorization": f"Bearer {token}"}
 
 
+def _admin_headers() -> dict:
+    return {"X-Admin-Secret": "test-template-admin-secret"}
+
+
 @pytest.mark.asyncio
 class TestUseTemplate:
     async def test_creates_resume_and_returns_id(self, client: AsyncClient, db_session):
@@ -334,6 +339,96 @@ class TestUseTemplate:
             headers=headers,
         )
         assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestTemplateAdminEndpoints:
+    async def test_create_template_requires_admin_secret(self, client: AsyncClient):
+        previous_secret = settings.ADMIN_SECRET_KEY
+        settings.ADMIN_SECRET_KEY = "test-template-admin-secret"
+        try:
+            resp = await client.post(
+                "/templates",
+                json={
+                    "name": "Admin Created Template",
+                    "description": "Created through admin route",
+                    "category": "finance",
+                    "tags": ["finance", "admin"],
+                    "latex_content": _VALID_LATEX,
+                    "sort_order": 12,
+                },
+            )
+        finally:
+            settings.ADMIN_SECRET_KEY = previous_secret
+        assert resp.status_code == 403
+
+    async def test_create_update_activate_deactivate_and_delete_template(self, client: AsyncClient, db_session):
+        previous_secret = settings.ADMIN_SECRET_KEY
+        settings.ADMIN_SECRET_KEY = "test-template-admin-secret"
+        try:
+            create_resp = await client.post(
+                "/templates",
+                headers=_admin_headers(),
+                json={
+                    "name": "Admin Lifecycle Template",
+                    "description": "Lifecycle test",
+                    "category": "finance",
+                    "tags": ["finance", "lifecycle"],
+                    "latex_content": _VALID_LATEX,
+                    "sort_order": 4,
+                },
+            )
+            assert create_resp.status_code == 201
+            created = create_resp.json()
+            assert created["name"] == "Admin Lifecycle Template"
+            template_id = created["id"]
+
+            update_resp = await client.put(
+                f"/templates/{template_id}",
+                headers=_admin_headers(),
+                json={
+                    "name": "Admin Lifecycle Template Updated",
+                    "description": "Updated",
+                    "category": "marketing",
+                    "tags": ["marketing"],
+                    "latex_content": _VALID_LATEX_2,
+                    "thumbnail_url": "https://example.com/template.png",
+                    "sort_order": 8,
+                    "is_active": True,
+                },
+            )
+            assert update_resp.status_code == 200
+            updated = update_resp.json()
+            assert updated["name"] == "Admin Lifecycle Template Updated"
+            assert updated["category"] == "marketing"
+
+            deactivate_resp = await client.patch(
+                f"/templates/{template_id}/deactivate",
+                headers=_admin_headers(),
+            )
+            assert deactivate_resp.status_code == 200
+            template = await db_session.get(ResumeTemplate, template_id)
+            assert template is not None
+            assert template.is_active is False
+
+            activate_resp = await client.patch(
+                f"/templates/{template_id}/activate",
+                headers=_admin_headers(),
+            )
+            assert activate_resp.status_code == 200
+            await db_session.refresh(template)
+            assert template.is_active is True
+
+            delete_resp = await client.delete(
+                f"/templates/{template_id}",
+                headers=_admin_headers(),
+            )
+            assert delete_resp.status_code == 204
+
+            gone = await db_session.get(ResumeTemplate, template_id)
+            assert gone is None
+        finally:
+            settings.ADMIN_SECRET_KEY = previous_secret
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add admin-only template CRUD routes behind `ADMIN_SECRET_KEY`
- add backend route coverage for template management
- reconcile template-related checklist tracking with the verified implementation

## Verification
- `cd backend && .venv/bin/pytest test/test_template_routes.py -q`

Refs #388
