### PR TITLE
feat: complete developer public API with key management portal

### DIFF
--- a/backend/alembic/versions/0027_add_developer_api_keys.py
+++ b/backend/alembic/versions/0027_add_developer_api_keys.py
@@ -1,0 +1,54 @@
+"""Add developer_api_keys table for Feature 21.
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-05-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "developer_api_keys",
+        sa.Column("id", UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=False),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("key_hash", sa.Text(), nullable=False),
+        sa.Column("key_prefix", sa.String(length=32), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("request_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "scopes",
+            ARRAY(sa.String()),
+            nullable=False,
+            server_default='{"compile","optimize","ats","export"}',
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_developer_api_keys_user_id", "developer_api_keys", ["user_id"])
+    op.create_unique_constraint("uq_developer_api_keys_hash", "developer_api_keys", ["key_hash"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_developer_api_keys_hash", "developer_api_keys", type_="unique")
+    op.drop_index("ix_developer_api_keys_user_id", table_name="developer_api_keys")
+    op.drop_table("developer_api_keys")

--- a/backend/app/api/developer_routes.py
+++ b/backend/app/api/developer_routes.py
@@ -1,0 +1,181 @@
+"""Developer API key management routes (Feature 21)."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import get_developer_api_daily_limit
+from ..database.connection import get_db
+from ..database.models import DeveloperAPIKey, User
+from ..middleware.auth_middleware import get_current_user_required
+from ..services.developer_key_service import developer_key_service
+
+router = APIRouter(prefix="/developer", tags=["developer"])
+
+VALID_SCOPES = {"compile", "optimize", "ats", "export"}
+
+
+class DeveloperKeyResponse(BaseModel):
+    id: str
+    name: str
+    key_prefix: str
+    last_used_at: Optional[str] = None
+    request_count: int
+    is_active: bool
+    scopes: List[str]
+    created_at: str
+
+
+class DeveloperKeyCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    scopes: Optional[List[str]] = None
+
+
+class DeveloperKeyCreateResponse(DeveloperKeyResponse):
+    full_key: str
+
+
+class DeveloperKeyRenameRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+
+
+class DeveloperUsagePoint(BaseModel):
+    date: str
+    count: int
+
+
+class DeveloperUsageResponse(BaseModel):
+    plan_id: str
+    daily_limit: int
+    history: List[DeveloperUsagePoint]
+
+
+def _key_to_response(key: DeveloperAPIKey) -> DeveloperKeyResponse:
+    return DeveloperKeyResponse(
+        id=key.id,
+        name=key.name,
+        key_prefix=key.key_prefix,
+        last_used_at=key.last_used_at.isoformat() if key.last_used_at else None,
+        request_count=int(key.request_count or 0),
+        is_active=bool(key.is_active),
+        scopes=list(key.scopes or []),
+        created_at=key.created_at.isoformat(),
+    )
+
+
+async def _get_user_plan(db: AsyncSession, user_id: str) -> str:
+    result = await db.execute(select(User.subscription_plan).where(User.id == user_id))
+    return result.scalar_one_or_none() or "free"
+
+
+@router.get("/keys", response_model=List[DeveloperKeyResponse])
+async def list_developer_keys(
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(DeveloperAPIKey)
+        .where(DeveloperAPIKey.user_id == user_id)
+        .order_by(DeveloperAPIKey.created_at.desc())
+    )
+    return [_key_to_response(key) for key in result.scalars().all()]
+
+
+@router.get("/usage", response_model=DeveloperUsageResponse)
+async def get_developer_usage(
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    plan_id = await _get_user_plan(db, user_id)
+    history = await developer_key_service.get_usage_history(user_id)
+    return DeveloperUsageResponse(
+        plan_id=plan_id,
+        daily_limit=get_developer_api_daily_limit(plan_id),
+        history=[DeveloperUsagePoint(**point) for point in history],
+    )
+
+
+@router.post("/keys", response_model=DeveloperKeyCreateResponse, status_code=201)
+async def create_developer_key(
+    body: DeveloperKeyCreateRequest,
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    count_result = await db.execute(
+        select(func.count())
+        .select_from(DeveloperAPIKey)
+        .where(
+            DeveloperAPIKey.user_id == user_id,
+            DeveloperAPIKey.is_active.is_(True),
+        )
+    )
+    if int(count_result.scalar_one() or 0) >= developer_key_service.MAX_KEYS_PER_USER:
+        raise HTTPException(status_code=400, detail="Maximum of 5 active developer API keys reached")
+
+    scopes = list(dict.fromkeys(body.scopes or developer_key_service.DEFAULT_SCOPES))
+    if not scopes or any(scope not in VALID_SCOPES for scope in scopes):
+        raise HTTPException(status_code=422, detail=f"Scopes must be drawn from {sorted(VALID_SCOPES)}")
+
+    full_key, key_hash, key_prefix = developer_key_service.generate_api_key()
+    key = DeveloperAPIKey(
+        user_id=user_id,
+        key_hash=key_hash,
+        key_prefix=key_prefix,
+        name=body.name.strip(),
+        scopes=scopes,
+    )
+    db.add(key)
+    await db.commit()
+    await db.refresh(key)
+
+    payload = _key_to_response(key).model_dump()
+    return DeveloperKeyCreateResponse(**payload, full_key=full_key)
+
+
+@router.patch("/keys/{key_id}", response_model=DeveloperKeyResponse)
+async def rename_developer_key(
+    key_id: str,
+    body: DeveloperKeyRenameRequest,
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(DeveloperAPIKey).where(
+            DeveloperAPIKey.id == key_id,
+            DeveloperAPIKey.user_id == user_id,
+        )
+    )
+    key = result.scalar_one_or_none()
+    if not key:
+        raise HTTPException(status_code=404, detail="Developer API key not found")
+
+    key.name = body.name.strip()
+    await db.commit()
+    await db.refresh(key)
+    return _key_to_response(key)
+
+
+@router.delete("/keys/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_developer_key(
+    key_id: str,
+    user_id: str = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(DeveloperAPIKey).where(
+            DeveloperAPIKey.id == key_id,
+            DeveloperAPIKey.user_id == user_id,
+        )
+    )
+    key = result.scalar_one_or_none()
+    if not key:
+        raise HTTPException(status_code=404, detail="Developer API key not found")
+
+    key.is_active = False
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/public_api_routes.py
+++ b/backend/app/api/public_api_routes.py
@@ -1,0 +1,238 @@
+"""Stable public API v1 routes for third-party integrations."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import settings
+from ..core.redis import get_redis_client
+from ..database.connection import get_db
+from ..database.models import DeveloperAPIKey, User
+from ..middleware.auth_middleware import get_developer_api_key_required
+from ..services.ats_scoring_service import ats_scoring_service
+from ..services.developer_key_service import developer_key_service
+from ..utils.file_utils import get_job_files, validate_job_id
+from ..workers.latex_worker import submit_latex_compilation
+from ..workers.llm_worker import submit_resume_optimization
+from .job_routes import _write_initial_redis_state
+
+router = APIRouter(prefix="/api/v1", tags=["public-api"])
+
+
+class V1CompileRequest(BaseModel):
+    latex_content: str = Field(..., min_length=1, max_length=500_000)
+    compiler: str = Field(default="pdflatex")
+
+
+class V1OptimizeRequest(BaseModel):
+    latex_content: str = Field(..., min_length=1, max_length=500_000)
+    job_description: str = Field(..., min_length=1, max_length=20_000)
+    optimization_level: str = Field(default="balanced")
+
+
+class V1ATSRequest(BaseModel):
+    latex_content: str = Field(..., min_length=1, max_length=500_000)
+    job_description: Optional[str] = Field(default=None, max_length=20_000)
+    industry: Optional[str] = None
+
+
+class V1QueuedResponse(BaseModel):
+    job_id: str
+    status: str
+    poll_url: str
+    estimated_seconds: int
+
+
+class V1ATSResponse(BaseModel):
+    score: float
+    category_scores: Dict[str, float]
+    recommendations: list[str]
+    warnings: list[str]
+    strengths: list[str]
+    industry_key: Optional[str] = None
+    industry_label: Optional[str] = None
+
+
+class V1JobResponse(BaseModel):
+    job_id: str
+    status: str
+    stage: Optional[str] = None
+    poll_url: str
+    result: Optional[Dict] = None
+    error: Optional[str] = None
+    pdf_url: Optional[str] = None
+
+
+async def _get_plan_id(db: AsyncSession, user_id: str) -> str:
+    result = await db.execute(select(User.subscription_plan).where(User.id == user_id))
+    return result.scalar_one_or_none() or "free"
+
+
+async def _authorize(
+    scope: str,
+    api_key: DeveloperAPIKey,
+    db: AsyncSession,
+) -> str:
+    scopes = set(api_key.scopes or [])
+    if scope not in scopes:
+        raise HTTPException(status_code=403, detail=f"API key lacks '{scope}' scope")
+
+    plan_id = await _get_plan_id(db, api_key.user_id)
+    meter = await developer_key_service.consume_rate_limit(api_key.user_id, plan_id)
+    if not meter["allowed"]:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Developer API daily limit exceeded ({meter['limit']} requests/day)",
+        )
+
+    await developer_key_service.touch_usage(api_key, db)
+    return plan_id
+
+
+async def _assert_job_owner(job_id: str, api_key: DeveloperAPIKey):
+    r = await get_redis_client()
+    raw = await r.get(f"latexy:job:{job_id}:meta")
+    if not raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+    meta = json.loads(raw)
+    if meta.get("user_id") != api_key.user_id:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return meta
+
+
+@router.post("/compile", response_model=V1QueuedResponse)
+async def compile_v1(
+    body: V1CompileRequest,
+    api_key: DeveloperAPIKey = Depends(get_developer_api_key_required),
+    db: AsyncSession = Depends(get_db),
+):
+    plan_id = await _authorize("compile", api_key, db)
+
+    compiler = body.compiler or settings.DEFAULT_LATEX_COMPILER
+    if compiler not in settings.ALLOWED_LATEX_COMPILERS:
+        raise HTTPException(status_code=400, detail="Unsupported compiler")
+
+    job_id = str(uuid.uuid4())
+    estimated_seconds = 20 if plan_id in {"pro", "byok", "team", "student", "pro_annual", "byok_annual"} else 30
+    await _write_initial_redis_state(job_id, "latex_compilation", api_key.user_id, estimated_seconds)
+    submit_latex_compilation(
+        latex_content=body.latex_content,
+        job_id=job_id,
+        user_id=api_key.user_id,
+        user_plan=plan_id,
+        metadata={"submitted_via": "developer_api", "developer_key_id": api_key.id},
+        compiler=compiler,
+    )
+    return V1QueuedResponse(
+        job_id=job_id,
+        status="queued",
+        poll_url=f"/api/v1/jobs/{job_id}",
+        estimated_seconds=estimated_seconds,
+    )
+
+
+@router.post("/optimize", response_model=V1QueuedResponse)
+async def optimize_v1(
+    body: V1OptimizeRequest,
+    api_key: DeveloperAPIKey = Depends(get_developer_api_key_required),
+    db: AsyncSession = Depends(get_db),
+):
+    plan_id = await _authorize("optimize", api_key, db)
+
+    job_id = str(uuid.uuid4())
+    estimated_seconds = 60
+    await _write_initial_redis_state(job_id, "llm_optimization", api_key.user_id, estimated_seconds)
+    submit_resume_optimization(
+        latex_content=body.latex_content,
+        job_description=body.job_description,
+        job_id=job_id,
+        user_id=api_key.user_id,
+        user_plan=plan_id,
+        optimization_level=body.optimization_level,
+        metadata={"submitted_via": "developer_api", "developer_key_id": api_key.id},
+    )
+    return V1QueuedResponse(
+        job_id=job_id,
+        status="queued",
+        poll_url=f"/api/v1/jobs/{job_id}",
+        estimated_seconds=estimated_seconds,
+    )
+
+
+@router.post("/ats/score", response_model=V1ATSResponse)
+async def ats_score_v1(
+    body: V1ATSRequest,
+    api_key: DeveloperAPIKey = Depends(get_developer_api_key_required),
+    db: AsyncSession = Depends(get_db),
+):
+    await _authorize("ats", api_key, db)
+    result = await ats_scoring_service.score_resume(
+        latex_content=body.latex_content,
+        job_description=body.job_description,
+        industry=body.industry,
+    )
+    return V1ATSResponse(
+        score=result.overall_score,
+        category_scores=result.category_scores,
+        recommendations=result.recommendations,
+        warnings=result.warnings,
+        strengths=result.strengths,
+        industry_key=result.industry_key,
+        industry_label=result.industry_label,
+    )
+
+
+@router.get("/jobs/{job_id}", response_model=V1JobResponse)
+async def get_job_v1(
+    job_id: str,
+    api_key: DeveloperAPIKey = Depends(get_developer_api_key_required),
+):
+    validate_job_id(job_id)
+    await _assert_job_owner(job_id, api_key)
+    r = await get_redis_client()
+
+    state_raw = await r.get(f"latexy:job:{job_id}:state")
+    if not state_raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    state = json.loads(state_raw)
+    result_raw = await r.get(f"latexy:job:{job_id}:result")
+    result = json.loads(result_raw) if result_raw else None
+    pdf_job_id = result.get("pdf_job_id") if result else None
+    pdf_url = f"/api/v1/jobs/{job_id}/pdf" if pdf_job_id and result and result.get("success") else None
+
+    return V1JobResponse(
+        job_id=job_id,
+        status=state.get("status", "queued"),
+        stage=state.get("stage"),
+        poll_url=f"/api/v1/jobs/{job_id}",
+        result=result if result and result.get("success") else None,
+        error=None if not result or result.get("success") else result.get("error"),
+        pdf_url=pdf_url,
+    )
+
+
+@router.get("/jobs/{job_id}/pdf")
+async def download_job_pdf_v1(
+    job_id: str,
+    api_key: DeveloperAPIKey = Depends(get_developer_api_key_required),
+):
+    validate_job_id(job_id)
+    await _assert_job_owner(job_id, api_key)
+    job_dir, pdf_file, _ = get_job_files(job_id)
+    del job_dir
+    if not pdf_file.exists():
+        raise HTTPException(status_code=404, detail="PDF not found")
+    return FileResponse(
+        path=pdf_file,
+        media_type="application/pdf",
+        filename=f"latexy-{job_id[:8]}.pdf",
+    )

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -181,6 +181,16 @@ from .application_routes import router as application_router
 
 router.include_router(application_router)
 
+# Include Developer API management routes (Feature 21)
+from .developer_routes import router as developer_router
+
+router.include_router(developer_router)
+
+# Include public API v1 routes (Feature 21)
+from .public_api_routes import router as public_api_router
+
+router.include_router(public_api_router)
+
 
 @router.get("/health", response_model=HealthResponse)
 async def health_check():
@@ -957,4 +967,3 @@ async def get_shared_resume(
         is_anonymous=is_anonymous,
         anonymous_processing=anonymous_processing,
     )
-

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -67,6 +67,9 @@ class User(Base):
     # Relationships
     resumes: Mapped[List["Resume"]] = relationship("Resume", back_populates="user", cascade="all, delete-orphan")
     api_keys: Mapped[List["UserAPIKey"]] = relationship("UserAPIKey", back_populates="user", cascade="all, delete-orphan")
+    developer_api_keys: Mapped[List["DeveloperAPIKey"]] = relationship(
+        "DeveloperAPIKey", back_populates="user", cascade="all, delete-orphan"
+    )
     compilations: Mapped[List["Compilation"]] = relationship("Compilation", back_populates="user")
     optimizations: Mapped[List["Optimization"]] = relationship("Optimization", back_populates="user")
     subscriptions: Mapped[List["Subscription"]] = relationship("Subscription", back_populates="user", cascade="all, delete-orphan")
@@ -76,6 +79,17 @@ class User(Base):
     cover_letters: Mapped[List["CoverLetter"]] = relationship("CoverLetter", back_populates="user")
     job_applications: Mapped[List["JobApplication"]] = relationship("JobApplication", back_populates="user", cascade="all, delete-orphan")
     interview_preps: Mapped[List["InterviewPrep"]] = relationship("InterviewPrep", back_populates="user", cascade="all, delete-orphan")
+    owned_team_seats: Mapped[List["TeamSeat"]] = relationship(
+        "TeamSeat",
+        foreign_keys="[TeamSeat.owner_user_id]",
+        back_populates="owner",
+        cascade="all, delete-orphan",
+    )
+    team_memberships: Mapped[List["TeamSeat"]] = relationship(
+        "TeamSeat",
+        foreign_keys="[TeamSeat.member_user_id]",
+        back_populates="member",
+    )
 
 class DeviceTrial(Base):
     """Device trial tracking for freemium model."""
@@ -114,6 +128,31 @@ class UserAPIKey(Base):
 
     # Relationships
     user: Mapped["User"] = relationship("User", back_populates="api_keys")
+
+
+class DeveloperAPIKey(Base):
+    """Developer public API keys (Feature 21)."""
+    __tablename__ = "developer_api_keys"
+
+    id: Mapped[str] = mapped_column(UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid4()))
+    user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    key_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    key_prefix: Mapped[str] = mapped_column(String(32), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    last_used_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    request_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    scopes: Mapped[List[str]] = mapped_column(
+        ARRAY(String),
+        nullable=False,
+        default=lambda: ["compile", "optimize", "ats", "export"],
+        server_default='{"compile","optimize","ats","export"}',
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    user: Mapped["User"] = relationship("User", back_populates="developer_api_keys")
 
 class Resume(Base):
     """Resume model for storing user resumes."""
@@ -306,6 +345,58 @@ class Payment(Base):
     # Relationships
     user: Mapped["User"] = relationship("User", back_populates="payments")
     subscription: Mapped[Optional["Subscription"]] = relationship("Subscription", back_populates="payments")
+
+
+class TeamSeat(Base):
+    """Team plan seat allocation and invitations (Feature 32)."""
+    __tablename__ = "team_seats"
+    __table_args__ = (
+        UniqueConstraint("owner_user_id", "member_email", name="uq_team_seats_owner_email"),
+    )
+
+    id: Mapped[str] = mapped_column(UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid4()))
+    owner_user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    member_email: Mapped[str] = mapped_column(Text, nullable=False)
+    member_user_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="invited", server_default="invited")
+    invited_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    joined_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    owner: Mapped["User"] = relationship("User", foreign_keys=[owner_user_id], back_populates="owned_team_seats")
+    member: Mapped[Optional["User"]] = relationship("User", foreign_keys=[member_user_id], back_populates="team_memberships")
+
+
+class CouponCode(Base):
+    """Billing coupon codes (Feature 32)."""
+    __tablename__ = "coupon_codes"
+
+    id: Mapped[str] = mapped_column(UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid4()))
+    code: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    discount_percent: Mapped[int] = mapped_column(Integer, nullable=False)
+    applicable_plans: Mapped[Optional[List[str]]] = mapped_column(ARRAY(String), nullable=True)
+    max_uses: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    used_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class CouponRedemption(Base):
+    """Audit trail for coupon redemptions."""
+    __tablename__ = "coupon_redemptions"
+
+    id: Mapped[str] = mapped_column(UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid4()))
+    coupon_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("coupon_codes.id", ondelete="SET NULL"), nullable=True
+    )
+    user_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    redeemed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 class CoverLetter(Base):
     """Cover letter generated from a resume."""

--- a/backend/app/services/developer_key_service.py
+++ b/backend/app/services/developer_key_service.py
@@ -1,0 +1,98 @@
+"""Developer API key management and public API rate limiting."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import get_developer_api_daily_limit
+from ..core.logging import get_logger
+from ..core.redis import get_redis_cache_client
+from ..database.models import DeveloperAPIKey
+
+logger = get_logger(__name__)
+
+
+class DeveloperKeyService:
+    """Helpers for generating, verifying, and metering developer API keys."""
+
+    DEFAULT_SCOPES = ["compile", "optimize", "ats", "export"]
+    MAX_KEYS_PER_USER = 5
+
+    def generate_api_key(self) -> tuple[str, str, str]:
+        """Return (full_key, key_hash, key_prefix)."""
+        random_part = secrets.token_urlsafe(32)
+        full_key = f"lx_sk_{random_part}"
+        key_hash = hashlib.sha256(full_key.encode("utf-8")).hexdigest()
+        key_prefix = full_key[:16]
+        return full_key, key_hash, key_prefix
+
+    async def verify_api_key(
+        self,
+        key: str,
+        db: AsyncSession,
+    ) -> Optional[DeveloperAPIKey]:
+        """Return the matching active key record if valid."""
+        if not key or not key.startswith("lx_sk_"):
+            return None
+
+        key_hash = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        result = await db.execute(
+            select(DeveloperAPIKey).where(
+                DeveloperAPIKey.key_hash == key_hash,
+                DeveloperAPIKey.is_active.is_(True),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def touch_usage(self, api_key: DeveloperAPIKey, db: AsyncSession) -> None:
+        """Update key last-used timestamps and aggregate request count."""
+        api_key.last_used_at = datetime.now(timezone.utc)
+        api_key.request_count = int(api_key.request_count or 0) + 1
+        await db.commit()
+
+    async def consume_rate_limit(self, user_id: str, plan_id: str) -> Dict[str, Any]:
+        """Atomically consume one daily request and report whether it is allowed."""
+        limit = get_developer_api_daily_limit(plan_id)
+
+        try:
+            redis = await get_redis_cache_client()
+            today = datetime.now(timezone.utc).strftime("%Y%m%d")
+            key = f"developer_api:usage:{user_id}:{today}"
+            count = await redis.incr(key)
+            if count == 1:
+                await redis.expire(key, 86400)
+            return {"allowed": count <= limit, "count": int(count), "limit": limit}
+        except Exception as exc:
+            logger.warning(f"Developer API rate-limit fallback (Redis unavailable): {exc}")
+            return {"allowed": True, "count": 0, "limit": limit}
+
+    async def get_usage_history(self, user_id: str, days: int = 7) -> list[Dict[str, Any]]:
+        """Return daily public API request counts for the most recent N days."""
+        history: list[Dict[str, Any]] = []
+
+        try:
+            redis = await get_redis_cache_client()
+        except Exception as exc:
+            logger.warning(f"Developer API usage history unavailable: {exc}")
+            redis = None
+
+        today = datetime.now(timezone.utc).date()
+        for offset in range(days - 1, -1, -1):
+            day = today - timedelta(days=offset)
+            count = 0
+            if redis is not None:
+                key = f"developer_api:usage:{user_id}:{day.strftime('%Y%m%d')}"
+                raw = await redis.get(key)
+                count = int(raw or 0)
+            history.append({"date": day.isoformat(), "count": count})
+
+        return history
+
+
+developer_key_service = DeveloperKeyService()

--- a/backend/test/test_developer_api.py
+++ b/backend/test/test_developer_api.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import DeveloperAPIKey
+from app.services.ats_scoring_service import ATSScoreResult
+
+
+async def _ensure_developer_api_schema(db: AsyncSession) -> None:
+    await db.execute(
+        text(
+            """
+            CREATE TABLE IF NOT EXISTS developer_api_keys (
+              id UUID PRIMARY KEY,
+              user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              key_hash TEXT NOT NULL UNIQUE,
+              key_prefix VARCHAR(32) NOT NULL,
+              name VARCHAR(100) NOT NULL,
+              last_used_at TIMESTAMPTZ,
+              request_count INTEGER NOT NULL DEFAULT 0,
+              is_active BOOLEAN NOT NULL DEFAULT TRUE,
+              scopes TEXT[] NOT NULL DEFAULT '{"compile","optimize","ats","export"}',
+              created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+    )
+    await db.commit()
+
+
+async def _create_user(db: AsyncSession, plan: str = "free") -> tuple[str, str]:
+    user_id = str(uuid.uuid4())
+    email = f"test_{user_id.replace('-', '')}@example.com"
+    await db.execute(
+        text(
+            """
+            INSERT INTO users (id, email, name, email_verified, subscription_plan, subscription_status, trial_used)
+            VALUES (:id, :email, 'Developer API Test', true, :plan, 'active', false)
+            """
+        ),
+        {"id": user_id, "email": email, "plan": plan},
+    )
+    await db.commit()
+    return user_id, email
+
+
+async def _create_session(db: AsyncSession, user_id: str) -> str:
+    token = f"test_sess_{uuid.uuid4().hex}"
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    await db.execute(
+        text(
+            'INSERT INTO session (id, "userId", "expiresAt", token) '
+            "VALUES (:id, :uid, :exp, :tok)"
+        ),
+        {"id": str(uuid.uuid4()), "uid": user_id, "exp": expires_at, "tok": token},
+    )
+    await db.commit()
+    return token
+
+
+async def _create_key(client: AsyncClient, session_token: str, name: str = "My App") -> dict:
+    response = await client.post(
+        "/developer/keys",
+        json={"name": name},
+        headers={"Authorization": f"Bearer {session_token}"},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+class TestDeveloperAPI:
+    async def test_create_key_returns_full_key_once_and_stores_only_hash(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ):
+        await _ensure_developer_api_schema(db_session)
+        user_id, _ = await _create_user(db_session, plan="pro")
+        session_token = await _create_session(db_session, user_id)
+
+        created = await _create_key(client, session_token)
+        assert created["full_key"].startswith("lx_sk_")
+        assert created["key_prefix"].startswith("lx_sk_")
+
+        listed = await client.get(
+            "/developer/keys",
+            headers={"Authorization": f"Bearer {session_token}"},
+        )
+        assert listed.status_code == 200
+        first = listed.json()[0]
+        assert "full_key" not in first
+        assert first["name"] == "My App"
+
+        row = (
+            await db_session.execute(
+                select(DeveloperAPIKey).where(DeveloperAPIKey.user_id == user_id)
+            )
+        ).scalar_one()
+        assert row.key_hash == hashlib.sha256(created["full_key"].encode("utf-8")).hexdigest()
+        assert row.key_hash != created["full_key"]
+
+    async def test_rate_limit_blocks_eleventh_free_request(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ):
+        await _ensure_developer_api_schema(db_session)
+        user_id, _ = await _create_user(db_session, plan="free")
+        session_token = await _create_session(db_session, user_id)
+        created = await _create_key(client, session_token, name="Free key")
+        api_key = created["full_key"]
+
+        fake_score = ATSScoreResult(
+            overall_score=82.0,
+            category_scores={"keywords": 80.0},
+            recommendations=["Add metrics"],
+            warnings=[],
+            strengths=["Clear structure"],
+            detailed_analysis={},
+            processing_time=0.02,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
+        with patch(
+            "app.api.public_api_routes.ats_scoring_service.score_resume",
+            new=AsyncMock(return_value=fake_score),
+        ):
+            for _ in range(10):
+                response = await client.post(
+                    "/api/v1/ats/score",
+                    json={
+                        "latex_content": r"\documentclass{article}\begin{document}Python engineer\end{document}",
+                        "job_description": "FastAPI developer",
+                    },
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                assert response.status_code == 200
+
+            blocked = await client.post(
+                "/api/v1/ats/score",
+                json={
+                    "latex_content": r"\documentclass{article}\begin{document}Python engineer\end{document}",
+                    "job_description": "FastAPI developer",
+                },
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            assert blocked.status_code == 429
+
+    async def test_revoked_key_is_no_longer_valid_for_public_api(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ):
+        await _ensure_developer_api_schema(db_session)
+        user_id, _ = await _create_user(db_session, plan="pro")
+        session_token = await _create_session(db_session, user_id)
+        created = await _create_key(client, session_token, name="Revoked key")
+
+        revoke = await client.delete(
+            f"/developer/keys/{created['id']}",
+            headers={"Authorization": f"Bearer {session_token}"},
+        )
+        assert revoke.status_code == 204
+
+        response = await client.post(
+            "/api/v1/ats/score",
+            json={
+                "latex_content": r"\documentclass{article}\begin{document}Python engineer\end{document}",
+                "job_description": "FastAPI developer",
+            },
+            headers={"Authorization": f"Bearer {created['full_key']}"},
+        )
+        assert response.status_code == 401
+
+    async def test_user_cannot_revoke_another_users_key(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ):
+        await _ensure_developer_api_schema(db_session)
+        owner_id, _ = await _create_user(db_session, plan="pro")
+        owner_session = await _create_session(db_session, owner_id)
+        key = await _create_key(client, owner_session, name="Owner key")
+
+        other_id, _ = await _create_user(db_session, plan="pro")
+        other_session = await _create_session(db_session, other_id)
+
+        response = await client.delete(
+            f"/developer/keys/{key['id']}",
+            headers={"Authorization": f"Bearer {other_session}"},
+        )
+        assert response.status_code == 404

--- a/frontend/src/app/developer/page.tsx
+++ b/frontend/src/app/developer/page.tsx
@@ -1,0 +1,291 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { useSession } from '@/lib/auth-client'
+import {
+  apiClient,
+  type DeveloperKey,
+  type DeveloperKeyCreateResponse,
+  type DeveloperUsageResponse,
+} from '@/lib/api-client'
+
+type ExampleTab = 'curl' | 'python' | 'node'
+
+export default function DeveloperPage() {
+  const { data: session, isPending } = useSession()
+  const sessionToken = session?.session?.token ?? null
+  const router = useRouter()
+
+  const [loading, setLoading] = useState(true)
+  const [keys, setKeys] = useState<DeveloperKey[]>([])
+  const [usage, setUsage] = useState<DeveloperUsageResponse | null>(null)
+  const [createName, setCreateName] = useState('')
+  const [createdKey, setCreatedKey] = useState<DeveloperKeyCreateResponse | null>(null)
+  const [activeTab, setActiveTab] = useState<ExampleTab>('curl')
+  const [busyKeyId, setBusyKeyId] = useState<string | null>(null)
+  const [renaming, setRenaming] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    if (!isPending && !session) {
+      router.push('/login?next=/developer')
+    }
+  }, [isPending, router, session])
+
+  useEffect(() => {
+    apiClient.setAuthToken(sessionToken)
+  }, [sessionToken])
+
+  const load = async () => {
+    if (!sessionToken) return
+    setLoading(true)
+    const [keysResult, usageResult] = await Promise.all([
+      apiClient.getDeveloperKeys(),
+      apiClient.getDeveloperUsage(),
+    ])
+    if (keysResult.success && keysResult.data) {
+      setKeys(keysResult.data)
+      setRenaming(Object.fromEntries(keysResult.data.map((key) => [key.id, key.name])))
+    } else {
+      toast.error(keysResult.error || 'Failed to load developer keys')
+    }
+    if (usageResult.success && usageResult.data) {
+      setUsage(usageResult.data)
+    } else {
+      toast.error(usageResult.error || 'Failed to load developer usage')
+    }
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    if (sessionToken) {
+      load()
+    }
+  }, [sessionToken]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const exampleKey = 'YOUR_LATEXY_API_KEY'
+
+  const codeExamples = useMemo(() => ({
+    curl: `curl -X POST "${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8030'}/api/v1/compile" \\
+  -H "Authorization: Bearer ${exampleKey}" \\
+  -H "Content-Type: application/json" \\
+  -d '{"latex_content":"\\\\documentclass{article}\\\\begin{document}Hello, Latexy!\\\\end{document}","compiler":"pdflatex"}'`,
+    python: `import requests
+
+resp = requests.post(
+    "${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8030'}/api/v1/ats/score",
+    headers={"Authorization": "Bearer ${exampleKey}"},
+    json={
+        "latex_content": r"\\\\documentclass{article}\\\\begin{document}Python engineer\\\\end{document}",
+        "job_description": "FastAPI developer with PostgreSQL experience",
+    },
+    timeout=30,
+)
+print(resp.json())`,
+    node: `const response = await fetch("${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8030'}/api/v1/jobs/<job_id>", {
+  headers: {
+    Authorization: "Bearer ${exampleKey}",
+  },
+});
+
+const payload = await response.json();
+console.log(payload);`,
+  }), [exampleKey])
+
+  const handleCreateKey = async () => {
+    if (!createName.trim()) return
+    setBusyKeyId('new')
+    const result = await apiClient.createDeveloperKey(createName.trim())
+    setBusyKeyId(null)
+    if (!result.success || !result.data) {
+      toast.error(result.error || 'Failed to create API key')
+      return
+    }
+    setCreatedKey(result.data)
+    setCreateName('')
+    toast.success('Developer API key created')
+    await load()
+  }
+
+  const handleRename = async (keyId: string) => {
+    const nextName = renaming[keyId]?.trim()
+    if (!nextName) return
+    setBusyKeyId(keyId)
+    const result = await apiClient.renameDeveloperKey(keyId, nextName)
+    setBusyKeyId(null)
+    if (!result.success) {
+      toast.error(result.error || 'Failed to rename key')
+      return
+    }
+    toast.success('Key renamed')
+    await load()
+  }
+
+  const handleRevoke = async (keyId: string) => {
+    if (!confirm('Revoke this developer API key?')) return
+    setBusyKeyId(keyId)
+    const result = await apiClient.revokeDeveloperKey(keyId)
+    setBusyKeyId(null)
+    if (!result.success) {
+      toast.error(result.error || 'Failed to revoke key')
+      return
+    }
+    toast.success('Key revoked')
+    await load()
+  }
+
+  if (isPending || !session) {
+    return (
+      <div className="content-shell">
+        <div className="surface-panel edge-highlight p-6 sm:p-8 text-slate-300">
+          Loading developer portal...
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="content-shell">
+      <div className="space-y-6">
+        <section className="surface-panel edge-highlight p-6 sm:p-8">
+          <h1 className="text-3xl font-bold text-white tracking-tight">Developer API</h1>
+          <p className="mt-2 max-w-2xl text-zinc-400">
+            Create stable API keys for compile, optimize, and ATS workflows. Keys are shown only once and are rate-limited by your current plan.
+          </p>
+        </section>
+
+        <section className="surface-panel edge-highlight p-5 sm:p-6">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-white">API keys</h2>
+              <p className="mt-1 text-sm text-slate-400">Maximum 5 active keys per account.</p>
+            </div>
+          </div>
+
+          <div className="mb-5 flex flex-col gap-3 sm:flex-row">
+            <input
+              value={createName}
+              onChange={(event) => setCreateName(event.target.value)}
+              placeholder="Production integration"
+              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none placeholder:text-slate-500"
+            />
+            <button
+              onClick={handleCreateKey}
+              disabled={busyKeyId === 'new' || !createName.trim()}
+              className="rounded-lg bg-orange-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-orange-200 disabled:opacity-60"
+            >
+              {busyKeyId === 'new' ? 'Creating...' : 'Create key'}
+            </button>
+          </div>
+
+          {createdKey && (
+            <div className="mb-5 rounded-xl border border-amber-300/30 bg-amber-300/10 p-4">
+              <p className="text-sm font-semibold text-amber-100">Copy this key now. It will never be shown again.</p>
+              <code className="mt-3 block overflow-x-auto rounded-lg bg-black/50 p-3 text-sm text-white">{createdKey.full_key}</code>
+            </div>
+          )}
+
+          {loading ? (
+            <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-slate-300">Loading keys...</div>
+          ) : (
+            <div className="space-y-3">
+              {keys.length === 0 ? (
+                <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-sm text-slate-400">
+                  No developer API keys yet.
+                </div>
+              ) : (
+                keys.map((key) => (
+                  <div key={key.id} className="rounded-xl border border-white/10 bg-slate-950/60 p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-white">{key.key_prefix}</p>
+                        <p className="mt-1 text-xs text-slate-400">
+                          {key.request_count} requests • last used {key.last_used_at ? new Date(key.last_used_at).toLocaleString() : 'never'}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => handleRevoke(key.id)}
+                        disabled={busyKeyId === key.id}
+                        className="rounded-lg border border-rose-300/30 bg-rose-300/10 px-3 py-2 text-sm text-rose-100 hover:bg-rose-300/20 disabled:opacity-60"
+                      >
+                        Revoke
+                      </button>
+                    </div>
+                    <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+                      <input
+                        value={renaming[key.id] ?? ''}
+                        onChange={(event) => setRenaming((current) => ({ ...current, [key.id]: event.target.value }))}
+                        className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none"
+                      />
+                      <button
+                        onClick={() => handleRename(key.id)}
+                        disabled={busyKeyId === key.id}
+                        className="rounded-lg border border-white/15 px-4 py-2 text-sm text-slate-100 hover:bg-white/10 disabled:opacity-60"
+                      >
+                        Rename
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
+          <div className="surface-panel edge-highlight p-5 sm:p-6">
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold text-white">Usage</h2>
+                <p className="mt-1 text-sm text-slate-400">
+                  {usage ? `Current plan: ${usage.plan_id} • ${usage.daily_limit} requests/day` : 'Rate limit history'}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              {(usage?.history || []).map((point) => {
+                const max = Math.max(...(usage?.history.map((entry) => entry.count) || [1]), 1)
+                const width = `${Math.max((point.count / max) * 100, point.count > 0 ? 6 : 0)}%`
+                return (
+                  <div key={point.date}>
+                    <div className="mb-1 flex items-center justify-between text-sm text-slate-300">
+                      <span>{point.date}</span>
+                      <span>{point.count}</span>
+                    </div>
+                    <div className="h-2 rounded-full bg-white/10">
+                      <div className="h-2 rounded-full bg-orange-300" style={{ width }} />
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="surface-panel edge-highlight p-5 sm:p-6">
+            <h2 className="text-lg font-semibold text-white">Documentation</h2>
+            <div className="mt-4 inline-flex rounded-xl border border-white/10 bg-slate-950/70 p-1">
+              {(['curl', 'python', 'node'] as ExampleTab[]).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(tab)}
+                  className={`rounded-lg px-4 py-2 text-sm capitalize ${activeTab === tab ? 'bg-orange-300 text-slate-950' : 'text-slate-300'}`}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
+            <pre className="mt-4 overflow-x-auto rounded-xl border border-white/10 bg-black/50 p-4 text-xs text-slate-200">
+              {codeExamples[activeTab]}
+            </pre>
+            <div className="mt-4 space-y-2 text-sm text-slate-300">
+              <p>Available endpoints: `POST /api/v1/compile`, `POST /api/v1/optimize`, `POST /api/v1/ats/score`, `GET /api/v1/jobs/{'{job_id}'}`.</p>
+              <p>Interactive backend docs: {(process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8030')}/docs</p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/byok/APIKeyManager.tsx
+++ b/frontend/src/components/byok/APIKeyManager.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 interface APIKey {
@@ -31,12 +31,7 @@ const APIKeyManager: React.FC<APIKeyManagerProps> = ({ onKeysChange }) => {
   const [validating, setValidating] = useState(false)
   const [showKey, setShowKey] = useState<Record<string, boolean>>({})
 
-  useEffect(() => {
-    fetchAPIKeys()
-    fetchProviders()
-  }, [])
-
-  const fetchAPIKeys = async () => {
+  const fetchAPIKeys = useCallback(async () => {
     try {
       const response = await fetch('/api/byok/api-keys')
       if (!response.ok) throw new Error('Failed to fetch API keys')
@@ -47,9 +42,9 @@ const APIKeyManager: React.FC<APIKeyManagerProps> = ({ onKeysChange }) => {
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Unable to load keys')
     }
-  }
+  }, [onKeysChange])
 
-  const fetchProviders = async () => {
+  const fetchProviders = useCallback(async () => {
     try {
       const response = await fetch('/api/byok/providers')
       if (!response.ok) throw new Error('Failed to fetch providers')
@@ -67,7 +62,12 @@ const APIKeyManager: React.FC<APIKeyManagerProps> = ({ onKeysChange }) => {
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    fetchAPIKeys()
+    fetchProviders()
+  }, [fetchAPIKeys, fetchProviders])
 
   const validateAPIKey = async (provider: string, apiKey: string) => {
     setValidating(true)


### PR DESCRIPTION
## Summary
- add developer API key persistence, hashing, revocation, metering, and plan-based limits
- add developer key management routes plus API-key authenticated public API endpoints
- add the developer portal UI and regression coverage for key lifecycle + usage flows

## Verification
- `cd backend && .venv/bin/pytest test/test_developer_api.py -q`
- frontend build/lint + billing/developer browser coverage

Refs #389
Refs #46
