### PR TITLE
feat: implement academic CV to industry resume conversion workflow

### DIFF
--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -18,8 +18,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..core.config import settings
 from ..core.logging import get_logger
 from ..database.connection import get_db
-from ..database.models import Optimization, Resume, ResumeCollaborator, UsageAnalytics
+from ..database.models import Optimization, Resume, ResumeCollaborator, UsageAnalytics, User
 from ..middleware.auth_middleware import get_current_user_required
+from ..services.academic_cv_service import academic_cv_service
 
 logger = get_logger(__name__)
 
@@ -737,6 +738,28 @@ class QuickTailorResponse(BaseModel):
     job_id: str
 
 
+class AcademicCVReportResponse(BaseModel):
+    is_academic_cv: bool
+    detected_sections: List[str]
+    estimated_pages: int
+    confidence: float
+    reasons: List[str]
+
+
+class AcademicCVConvertRequest(BaseModel):
+    target_industry: str = Field(default="tech", pattern="^(tech|data_science|finance|consulting|product|other)$")
+    target_role_description: Optional[str] = Field(None, max_length=10000)
+    title: Optional[str] = Field(None, max_length=255)
+    force: bool = False
+
+
+class AcademicCVConvertResponse(BaseModel):
+    success: bool
+    variant_resume_id: str
+    job_id: str
+    report: AcademicCVReportResponse
+
+
 @router.post(
     "/{resume_id}/quick-tailor",
     response_model=QuickTailorResponse,
@@ -794,6 +817,126 @@ async def quick_tailor_resume(
         raise
 
     return QuickTailorResponse(fork_id=str(fork.id), job_id=job_id)
+
+
+@router.get("/{resume_id}/academic-cv-report", response_model=AcademicCVReportResponse)
+async def get_academic_cv_report(
+    resume_id: str,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_required),
+):
+    """Inspect a resume and report whether it looks like an academic CV."""
+    resume = await _verify_resume_ownership(db, resume_id, user_id)
+    report = academic_cv_service.detect(
+        resume.latex_content or "",
+        document_type=resume.document_type,
+    )
+    return AcademicCVReportResponse(**report.to_dict())
+
+
+@router.post(
+    "/{resume_id}/academic-cv-convert",
+    response_model=AcademicCVConvertResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def convert_academic_cv(
+    resume_id: str,
+    body: AcademicCVConvertRequest,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_required),
+):
+    """
+    Create an industry-resume variant from an academic CV and queue a combined
+    optimize+compile job for the new fork.
+    """
+    parent = await _verify_resume_ownership(db, resume_id, user_id)
+    report = academic_cv_service.detect(
+        parent.latex_content or "",
+        document_type=parent.document_type,
+    )
+    if not report.is_academic_cv and not body.force:
+        raise HTTPException(
+            status_code=400,
+            detail="Resume does not strongly resemble an academic CV. Pass force=true to continue anyway.",
+        )
+
+    label = {
+        "tech": "Industry Resume",
+        "data_science": "Data Science Resume",
+        "finance": "Finance Resume",
+        "consulting": "Consulting Resume",
+        "product": "Product Resume",
+        "other": "Industry Resume",
+    }.get(body.target_industry, "Industry Resume")
+    variant_title = body.title or f"{parent.title} — {label}"
+
+    variant = Resume(
+        id=str(uuid4()),
+        user_id=user_id,
+        title=variant_title,
+        latex_content=parent.latex_content,
+        is_template=False,
+        tags=list(parent.tags) if parent.tags else None,
+        parent_resume_id=parent.id,
+        resume_settings=dict(parent.resume_settings or {}),
+        document_type="resume",
+    )
+    db.add(variant)
+
+    analytics = UsageAnalytics(
+        id=str(uuid4()),
+        user_id=user_id,
+        action="academic_cv_converted",
+        resource_type="resume",
+        event_metadata={
+            "parent_resume_id": parent.id,
+            "variant_resume_id": variant.id,
+            "target_industry": body.target_industry,
+            "confidence": report.confidence,
+        },
+    )
+    db.add(analytics)
+    await db.commit()
+    await db.refresh(variant)
+
+    from ..workers.orchestrator import submit_optimize_and_compile
+    from .job_routes import _write_initial_redis_state
+
+    job_id = str(uuid4())
+    user_plan = "free"
+    user_result = await db.execute(select(User.subscription_plan).where(User.id == user_id))
+    stored_plan = user_result.scalar_one_or_none()
+    if isinstance(stored_plan, str) and stored_plan:
+        user_plan = stored_plan
+    instructions = academic_cv_service.build_conversion_instructions(
+        report,
+        target_industry=body.target_industry,
+        target_role_description=body.target_role_description,
+    )
+
+    try:
+        await _write_initial_redis_state(job_id, "combined", user_id, 120)
+        submit_optimize_and_compile(
+            latex_content=variant.latex_content,
+            job_description=body.target_role_description,
+            job_id=job_id,
+            user_id=user_id,
+            user_plan=user_plan,
+            optimization_level="aggressive",
+            custom_instructions=instructions,
+            resume_id=str(variant.id),
+        )
+    except Exception:
+        await db.delete(variant)
+        await db.commit()
+        raise
+
+    return AcademicCVConvertResponse(
+        success=True,
+        variant_resume_id=str(variant.id),
+        job_id=job_id,
+        report=AcademicCVReportResponse(**report.to_dict()),
+    )
 
 
 @router.get("/{resume_id}/variants", response_model=List[ResumeResponse])

--- a/backend/app/services/academic_cv_service.py
+++ b/backend/app/services/academic_cv_service.py
@@ -1,0 +1,158 @@
+"""
+Academic CV detection + conversion prompt builder.
+
+Feature 7.1 from FEATURES.md is intentionally narrower than generic resume
+optimization: it identifies academic CV signals, then produces targeted
+instructions for reframing the document into an industry resume variant.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class AcademicCVReport:
+    is_academic_cv: bool
+    detected_sections: List[str]
+    estimated_pages: int
+    confidence: float
+    reasons: List[str]
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+_SECTION_PATTERNS: dict[str, re.Pattern[str]] = {
+    "publications": re.compile(
+        r"\\section\*?\{(?:refereed\s+)?publications?|conference papers?|journal papers?\}",
+        re.I,
+    ),
+    "teaching": re.compile(r"\\section\*?\{teaching(?:\s+experience)?\}", re.I),
+    "grants": re.compile(r"\\section\*?\{grants?|fellowships?|awards?(?:\s*&\s*honors?)?\}", re.I),
+    "research": re.compile(r"\\section\*?\{research(?:\s+experience|\s+interests?)?\}", re.I),
+    "presentations": re.compile(r"\\section\*?\{conference presentations?|talks?|invited talks?\}", re.I),
+    "references": re.compile(r"\\section\*?\{references?\}", re.I),
+    "service": re.compile(r"\\section\*?\{academic service|service\}", re.I),
+}
+
+_BIBLIOGRAPHY_PATTERNS = [
+    re.compile(r"\\bibliographystyle\b", re.I),
+    re.compile(r"\\bibliography\b", re.I),
+    re.compile(r"\\printbibliography\b", re.I),
+    re.compile(r"\\cite[t|p]?\{", re.I),
+]
+
+_ACADEMIC_ROLE_RE = re.compile(
+    r"\b(phd|doctoral|postdoc|postdoctoral|research assistant|teaching assistant|lecturer|professor|dissertation)\b",
+    re.I,
+)
+
+_TARGET_INDUSTRY_LABELS = {
+    "tech": "Software Engineering / Product Technology",
+    "data_science": "Data Science / Machine Learning",
+    "finance": "Finance / Quantitative Roles",
+    "consulting": "Consulting / Strategy",
+    "product": "Product Management",
+    "other": "General Industry",
+}
+
+
+class AcademicCVService:
+    def detect(self, latex_content: str, document_type: Optional[str] = None) -> AcademicCVReport:
+        text = latex_content or ""
+        lowered = text.lower()
+
+        detected_sections: List[str] = []
+        reasons: List[str] = []
+        score = 0.0
+
+        if document_type == "academic_cv":
+            score += 0.35
+            reasons.append("document_type is academic_cv")
+
+        for key, pattern in _SECTION_PATTERNS.items():
+            if pattern.search(text):
+                detected_sections.append(key)
+                score += 0.14
+                reasons.append(f"found {key} section")
+
+        for pattern in _BIBLIOGRAPHY_PATTERNS:
+            if pattern.search(text):
+                score += 0.1
+                reasons.append("bibliography/citation markup present")
+                break
+
+        if _ACADEMIC_ROLE_RE.search(lowered):
+            score += 0.08
+            reasons.append("academic role terminology present")
+
+        estimated_pages = self.estimate_pages(text, detected_sections)
+        if estimated_pages > 2:
+            score += 0.08
+            reasons.append(f"estimated length is {estimated_pages} pages")
+
+        confidence = max(0.0, min(1.0, round(score, 2)))
+        is_academic = confidence >= 0.45 or (
+            "publications" in detected_sections
+            and any(section in detected_sections for section in ("research", "teaching", "grants"))
+        )
+
+        return AcademicCVReport(
+            is_academic_cv=is_academic,
+            detected_sections=detected_sections,
+            estimated_pages=estimated_pages,
+            confidence=confidence,
+            reasons=reasons,
+        )
+
+    def estimate_pages(self, latex_content: str, detected_sections: Optional[List[str]] = None) -> int:
+        text = latex_content or ""
+        no_comments = re.sub(r"(?m)^\s*%.*$", "", text)
+        lines = [line.strip() for line in no_comments.splitlines() if line.strip()]
+        bullet_count = len(re.findall(r"\\item\b", text))
+        section_count = len(re.findall(r"\\section\*?\{", text))
+        publication_items = len(re.findall(r"\\bibitem\b|@", text))
+        academic_bonus = 8 * len(detected_sections or [])
+
+        weighted = len(lines) + bullet_count * 1.5 + section_count * 2 + publication_items * 2 + academic_bonus
+        return max(1, min(6, int(round(weighted / 55.0))))
+
+    def build_conversion_instructions(
+        self,
+        report: AcademicCVReport,
+        target_industry: str,
+        target_role_description: Optional[str] = None,
+    ) -> str:
+        industry_label = _TARGET_INDUSTRY_LABELS.get(target_industry, _TARGET_INDUSTRY_LABELS["other"])
+        role_block = (
+            f"Target role context:\n{target_role_description.strip()}\n"
+            if target_role_description and target_role_description.strip()
+            else ""
+        )
+        detected = ", ".join(report.detected_sections) if report.detected_sections else "none"
+        target_pages = 1 if report.estimated_pages <= 4 else 2
+
+        return (
+            "Convert this academic CV into an industry-ready resume variant.\n"
+            f"Target industry: {industry_label}.\n"
+            f"Detected academic sections: {detected}.\n"
+            f"Target output length: {target_pages} page(s).\n"
+            f"{role_block}"
+            "Strict rules:\n"
+            "1. Preserve all factual claims, employers, institutions, dates, degrees, titles, and quantified results.\n"
+            "2. Reframe academic accomplishments into industry outcomes, ownership, delivery, scale, leadership, and impact.\n"
+            "3. Keep only the 2-3 strongest publications or talks if a publications/presentations section exists.\n"
+            "4. Convert teaching to mentoring, leadership, communication, and stakeholder-facing experience.\n"
+            "5. Convert grants/fellowships into quantified achievement and selectivity signals.\n"
+            "6. Reduce bibliography detail: no co-author lists, page numbers, or DOI clutter unless mission-critical.\n"
+            "7. Prefer recent/high-impact achievements; aggressively condense low-signal academic detail.\n"
+            "8. Keep the output in valid compilable LaTeX and preserve the overall template structure where practical.\n"
+            "9. Optimize for recruiter readability and ATS keyword alignment without inventing experience.\n"
+            "10. Treat this as a new industry resume variant, not an academic CV polish pass.\n"
+        )
+
+
+academic_cv_service = AcademicCVService()

--- a/backend/test/test_academic_cv_conversion.py
+++ b/backend/test/test_academic_cv_conversion.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.services.academic_cv_service import academic_cv_service
+
+ACADEMIC_CV_LATEX = r"""
+\documentclass{article}
+\begin{document}
+\section{Research Experience}
+\textbf{Research Assistant}, Example Lab
+\begin{itemize}
+  \item Built distributed training pipelines for multimodal models.
+  \item Published evaluation tooling used by 4 research groups.
+\end{itemize}
+\section{Publications}
+\begin{itemize}
+  \item Doe, J. et al. Neural Systems at ICML 2024.
+  \item Doe, J. et al. Retrieval Models at NeurIPS 2023.
+\end{itemize}
+\section{Teaching Experience}
+\begin{itemize}
+  \item Taught machine learning to 120 students across 2 semesters.
+\end{itemize}
+\section{Grants}
+\begin{itemize}
+  \item NSF Graduate Research Fellowship (\$138,000)
+\end{itemize}
+\bibliographystyle{plain}
+\end{document}
+"""
+
+PLAIN_RESUME_LATEX = r"\documentclass{article}\begin{document}\section{Experience}\begin{itemize}\item Built APIs.\end{itemize}\end{document}"
+
+
+async def _create_resume(
+    client: AsyncClient,
+    auth_headers: dict,
+    latex: str,
+    title: str = "Academic CV",
+) -> dict:
+    resp = await client.post(
+        "/resumes/",
+        headers=auth_headers,
+        json={"title": title, "latex_content": latex},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+class TestAcademicCVService:
+    async def test_detect_flags_academic_cv(self) -> None:
+        report = academic_cv_service.detect(ACADEMIC_CV_LATEX, document_type="academic_cv")
+        assert report.is_academic_cv is True
+        assert "publications" in report.detected_sections
+        assert "research" in report.detected_sections
+        assert report.confidence >= 0.45
+
+    async def test_detect_does_not_flag_simple_resume(self) -> None:
+        report = academic_cv_service.detect(PLAIN_RESUME_LATEX, document_type="resume")
+        assert report.is_academic_cv is False
+
+
+@pytest.mark.asyncio
+class TestAcademicCVRoutes:
+    async def test_report_endpoint_returns_detection(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ) -> None:
+        resume = await _create_resume(client, auth_headers, ACADEMIC_CV_LATEX)
+        resp = await client.get(f"/resumes/{resume['id']}/academic-cv-report", headers=auth_headers)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["is_academic_cv"] is True
+        assert "publications" in data["detected_sections"]
+
+    async def test_convert_endpoint_creates_variant_and_submits_job(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ) -> None:
+        resume = await _create_resume(client, auth_headers, ACADEMIC_CV_LATEX)
+        with patch("app.api.job_routes._write_initial_redis_state", new_callable=AsyncMock) as mock_write, patch(
+            "app.workers.orchestrator.submit_optimize_and_compile"
+        ) as mock_submit:
+            resp = await client.post(
+                f"/resumes/{resume['id']}/academic-cv-convert",
+                headers=auth_headers,
+                json={"target_industry": "data_science", "target_role_description": "Applied ML engineer role."},
+            )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["success"] is True
+        assert data["report"]["is_academic_cv"] is True
+        variant_id = data["variant_resume_id"]
+
+        variant_resp = await client.get(f"/resumes/{variant_id}", headers=auth_headers)
+        assert variant_resp.status_code == 200, variant_resp.text
+        variant = variant_resp.json()
+        assert variant["parent_resume_id"] == resume["id"]
+        assert variant["document_type"] == "resume"
+        assert "Data Science Resume" in variant["title"]
+
+        mock_write.assert_awaited_once()
+        mock_submit.assert_called_once()
+        kwargs = mock_submit.call_args.kwargs
+        assert kwargs["resume_id"] == variant_id
+        assert kwargs["optimization_level"] == "aggressive"
+        assert "Target industry: Data Science / Machine Learning." in kwargs["custom_instructions"]
+
+    async def test_convert_endpoint_rejects_non_academic_without_force(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ) -> None:
+        resume = await _create_resume(client, auth_headers, PLAIN_RESUME_LATEX, title="Plain Resume")
+        resp = await client.post(
+            f"/resumes/{resume['id']}/academic-cv-convert",
+            headers=auth_headers,
+            json={"target_industry": "tech"},
+        )
+        assert resp.status_code == 400
+
+    async def test_convert_endpoint_allows_force_for_non_academic(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ) -> None:
+        resume = await _create_resume(client, auth_headers, PLAIN_RESUME_LATEX, title="Plain Resume")
+        with patch("app.api.job_routes._write_initial_redis_state", new_callable=AsyncMock), patch(
+            "app.workers.orchestrator.submit_optimize_and_compile"
+        ):
+            resp = await client.post(
+                f"/resumes/{resume['id']}/academic-cv-convert",
+                headers=auth_headers,
+                json={"target_industry": "tech", "force": True},
+            )
+        assert resp.status_code == 201, resp.text

--- a/frontend/src/app/workspace/[resumeId]/edit/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/edit/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { toast } from 'sonner'
@@ -49,33 +50,16 @@ import {
   TrendingUp,
   Keyboard,
   Pencil,
+  GraduationCap,
 } from 'lucide-react'
-import { apiClient, type CheckpointEntry, type CompileSettings, type DiffWithParentResponse, type ExplainErrorResponse, type GitHubResumeStatus, type DropboxResumeStatus, type LatexCompiler, type PresenceUser, type ProofreadIssue, type ResumeResponse } from '@/lib/api-client'
+import { apiClient, type AcademicCVReport, type CheckpointEntry, type CompileSettings, type DiffWithParentResponse, type ExplainErrorResponse, type GitHubResumeStatus, type DropboxResumeStatus, type LatexCompiler, type PresenceUser, type ProofreadIssue, type ResumeResponse } from '@/lib/api-client'
 import { useSession } from '@/lib/auth-client'
 import WritingAssistantWidget from '@/components/WritingAssistantWidget'
-import ShareResumeModal from '@/components/ShareResumeModal'
 import { useJobStream, type JobStreamState } from '@/hooks/useJobStream'
 import LaTeXEditor, { type LaTeXEditorRef } from '@/components/LaTeXEditor'
-import LogViewer from '@/components/LogViewer'
-import PDFPreview from '@/components/PDFPreview'
 import LoadingSpinner from '@/components/LoadingSpinner'
-import DeepAnalysisPanel from '@/components/ats/DeepAnalysisPanel'
-import InterviewPrepPanel from '@/components/InterviewPrepPanel'
-import ExportDropdown from '@/components/ExportDropdown'
-import MultiFormatUpload from '@/components/MultiFormatUpload'
-import VersionHistoryPanel from '@/components/VersionHistoryPanel'
-import SaveCheckpointPopover from '@/components/SaveCheckpointPopover'
-import DiffViewerModal from '@/components/DiffViewerModal'
-import CompareModal from '@/components/CompareModal'
-import ErrorExplainerPanel from '@/components/ErrorExplainerPanel'
-import ReferencesPanel from '@/components/ReferencesPanel'
-import DesignPanel from '@/components/DesignPanel'
 import BulletGeneratorWidget from '@/components/BulletGeneratorWidget'
 import SummaryGeneratorWidget from '@/components/SummaryGeneratorWidget'
-import ProofreadPanel from '@/components/ProofreadPanel'
-import PackageManagerPanel from '@/components/PackageManagerPanel'
-import LinterPanel from '@/components/LinterPanel'
-import SymbolPalette from '@/components/SymbolPalette'
 import QrCodeInserter from '@/components/QrCodeInserter'
 import DateStandardizerPanel from '@/components/DateStandardizerPanel'
 import AgeAnalysisPanel from '@/components/AgeAnalysisPanel'
@@ -84,35 +68,53 @@ import SalaryEstimatorPanel from '@/components/SalaryEstimatorPanel'
 import SectionReorderPanel from '@/components/SectionReorderPanel'
 import WatermarkDownloadPopover from '@/components/WatermarkDownloadPopover'
 import CompilerSelector from '@/components/CompilerSelector'
-import CompileSettingsModal from '@/components/CompileSettingsModal'
-import CollaboratorPanel from '@/components/CollaboratorPanel'
-import ChangesPanel from '@/components/ChangesPanel'
-import LaTeXDocPanel from '@/components/LaTeXDocPanel'
 import TemplateCustomizerPanel from '@/components/TemplateCustomizerPanel'
 import type { TrackedChange } from '@/lib/yjs-track-changes'
 import { GitMerge } from 'lucide-react'
 import { useAutoCompile } from '@/hooks/useAutoCompile'
 import { useQuickATSScore } from '@/hooks/useQuickATSScore'
 import { useConfidenceScore } from '@/hooks/useConfidenceScore'
-import ConfidenceScorePanel from '@/components/ConfidenceScorePanel'
 import { useLatexLinter } from '@/hooks/useLatexLinter'
 import { useSpellCheck, addWordToDict } from '@/hooks/useSpellCheck'
 import { useFeatureFlags } from '@/contexts/FeatureFlagsContext'
-import KeyboardShortcutsPanel from '@/components/KeyboardShortcutsPanel'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
 import MobileEditor from '@/components/MobileEditor'
 import OfflineBanner, { useOnlineStatus } from '@/components/OfflineBanner'
 import { saveDraft, getPendingDrafts, deleteDraft, pendingDraftCount } from '@/lib/offline-drafts'
 import { enqueueCompile, getQueuedCompiles, dequeueCompile } from '@/lib/compile-queue'
-import WYSIWYGEditor from '@/components/WYSIWYGEditor'
 import { parseResume } from '@/lib/wysiwyg/latex-parser'
 import { serializeResume } from '@/lib/wysiwyg/latex-serializer'
 import type { ResumeDoc } from '@/lib/wysiwyg/document-model'
-import SnippetMarketplace from '@/components/SnippetMarketplace'
-import MacroLibraryPanel from '@/components/MacroLibraryPanel'
-import TikZEditor from '@/components/TikZEditor'
-import SlideViewer from '@/components/SlideViewer'
-import CompileErrorHistory from '@/components/CompileErrorHistory'
+const ShareResumeModal = dynamic(() => import('@/components/ShareResumeModal'))
+const LogViewer = dynamic(() => import('@/components/LogViewer'))
+const PDFPreview = dynamic(() => import('@/components/PDFPreview'))
+const DeepAnalysisPanel = dynamic(() => import('@/components/ats/DeepAnalysisPanel'))
+const InterviewPrepPanel = dynamic(() => import('@/components/InterviewPrepPanel'))
+const ExportDropdown = dynamic(() => import('@/components/ExportDropdown'))
+const MultiFormatUpload = dynamic(() => import('@/components/MultiFormatUpload'))
+const VersionHistoryPanel = dynamic(() => import('@/components/VersionHistoryPanel'))
+const SaveCheckpointPopover = dynamic(() => import('@/components/SaveCheckpointPopover'))
+const DiffViewerModal = dynamic(() => import('@/components/DiffViewerModal'))
+const CompareModal = dynamic(() => import('@/components/CompareModal'))
+const ErrorExplainerPanel = dynamic(() => import('@/components/ErrorExplainerPanel'))
+const ReferencesPanel = dynamic(() => import('@/components/ReferencesPanel'))
+const DesignPanel = dynamic(() => import('@/components/DesignPanel'))
+const ProofreadPanel = dynamic(() => import('@/components/ProofreadPanel'))
+const PackageManagerPanel = dynamic(() => import('@/components/PackageManagerPanel'))
+const LinterPanel = dynamic(() => import('@/components/LinterPanel'))
+const SymbolPalette = dynamic(() => import('@/components/SymbolPalette'))
+const CompileSettingsModal = dynamic(() => import('@/components/CompileSettingsModal'))
+const CollaboratorPanel = dynamic(() => import('@/components/CollaboratorPanel'))
+const ChangesPanel = dynamic(() => import('@/components/ChangesPanel'))
+const LaTeXDocPanel = dynamic(() => import('@/components/LaTeXDocPanel'))
+const ConfidenceScorePanel = dynamic(() => import('@/components/ConfidenceScorePanel'))
+const KeyboardShortcutsPanel = dynamic(() => import('@/components/KeyboardShortcutsPanel'))
+const WYSIWYGEditor = dynamic(() => import('@/components/WYSIWYGEditor'))
+const SnippetMarketplace = dynamic(() => import('@/components/SnippetMarketplace'))
+const MacroLibraryPanel = dynamic(() => import('@/components/MacroLibraryPanel'))
+const TikZEditor = dynamic(() => import('@/components/TikZEditor'))
+const SlideViewer = dynamic(() => import('@/components/SlideViewer'))
+const CompileErrorHistory = dynamic(() => import('@/components/CompileErrorHistory'))
 
 
 type RightTab = 'preview' | 'ai' | 'logs' | 'history' | 'references' | 'interview' | 'design' | 'proofread' | 'packages' | 'linter' | 'symbols' | 'changes' | 'docs' | 'layout' | 'snippets' | 'macros' | 'tikz'
@@ -718,6 +720,7 @@ export default function ResumeEditPage() {
   const resumeId = params.resumeId as string
   const flags = useFeatureFlags()
   const { data: sessionData } = useSession()
+  const sessionUserId = sessionData?.user?.id ?? null
 
   // Core state
   const [title, setTitle] = useState('')
@@ -820,6 +823,11 @@ export default function ResumeEditPage() {
   const [forkPopoverOpen, setForkPopoverOpen] = useState(false)
   const [forkTitleInput, setForkTitleInput] = useState('')
   const [isForkingResume, setIsForkingResume] = useState(false)
+  const [academicReport, setAcademicReport] = useState<AcademicCVReport | null>(null)
+  const [academicConvertOpen, setAcademicConvertOpen] = useState(false)
+  const [academicTargetIndustry, setAcademicTargetIndustry] = useState<'tech' | 'data_science' | 'finance' | 'consulting' | 'product' | 'other'>('tech')
+  const [academicRoleDescription, setAcademicRoleDescription] = useState('')
+  const [isAcademicConverting, setIsAcademicConverting] = useState(false)
 
   // Error explainer
   const [explainerOpen, setExplainerOpen] = useState(false)
@@ -1011,6 +1019,9 @@ export default function ResumeEditPage() {
         setShareUrl(data.share_url ?? null)
         // Feature 86 — presentation support
         setDocumentType(data.document_type ?? 'resume')
+        if ((data.document_type ?? 'resume') !== 'presentation') {
+          apiClient.getAcademicCVReport(resumeId).then(setAcademicReport).catch(() => {})
+        }
 
         // GitHub sync state
         setGhSyncEnabled(data.github_sync_enabled ?? false)
@@ -1018,7 +1029,7 @@ export default function ResumeEditPage() {
         setDbxSyncEnabled(data.dropbox_sync_enabled ?? false)
 
         // Collaboration ownership (Feature 40)
-        setCollabIsOwner(data.user_id === sessionData?.user?.id)
+        setCollabIsOwner(data.user_id === sessionUserId)
 
         setParentResumeId(data.parent_resume_id ?? null)
         // Fetch parent title if this is a variant
@@ -1046,7 +1057,7 @@ export default function ResumeEditPage() {
       }
     }
     fetchResume()
-  }, [resumeId, router])
+  }, [resumeId, router, sessionUserId])
 
   // Stream AI tokens to Monaco in real-time (direct model mutation, no setState per token)
   useEffect(() => {
@@ -1059,6 +1070,9 @@ export default function ResumeEditPage() {
     if (aiStream.status === 'completed') {
       const finalLatex = editorRef.current?.getValue() || ''
       setLatexContent(finalLatex)
+      if (documentType !== 'presentation') {
+        apiClient.getAcademicCVReport(resumeId).then(setAcademicReport).catch(() => {})
+      }
       // Feature 1: save optimization record
       if (finalLatex && aiJobId) {
         const baselineLatex = undoStack[undoStack.length - 1]?.latex || ''
@@ -1075,7 +1089,7 @@ export default function ResumeEditPage() {
         apiClient.trackFeatureUsage('ai_optimization')
       }
     }
-  }, [aiStream.status]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [aiStream.status, documentType, resumeId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Track compilation completion for analytics
   useEffect(() => {
@@ -1086,7 +1100,7 @@ export default function ResumeEditPage() {
     } else if (compileStream.status === 'failed' && compileJobId) {
       apiClient.trackCompilation(compileJobId, 'failed')
     }
-  }, [compileStream.status, compileJobId, refetchATS])
+  }, [compileStream.status, compileJobId, documentType, refetchATS])
 
   // Load PDF after either job completes
   useEffect(() => {
@@ -1674,6 +1688,27 @@ export default function ResumeEditPage() {
     }
   }, [resumeId, forkTitleInput, isForkingResume, router])
 
+  const handleAcademicConvert = useCallback(async () => {
+    if (isAcademicConverting) return
+    setIsAcademicConverting(true)
+    try {
+      const result = await apiClient.convertAcademicCV(resumeId, {
+        target_industry: academicTargetIndustry,
+        target_role_description: academicRoleDescription.trim() || undefined,
+        force: !!academicReport && !academicReport.is_academic_cv,
+      })
+      setAcademicReport(result.report)
+      setAcademicConvertOpen(false)
+      setAcademicRoleDescription('')
+      toast.success('Industry resume variant created')
+      router.push(`/workspace/${result.variant_resume_id}/edit`)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to convert academic CV')
+    } finally {
+      setIsAcademicConverting(false)
+    }
+  }, [resumeId, academicTargetIndustry, academicRoleDescription, academicReport, isAcademicConverting, router])
+
   const isCompiling = compileStream.status === 'queued' || compileStream.status === 'processing'
   const isAiRunning = aiStream.status === 'queued' || aiStream.status === 'processing'
   const isAnyRunning = isCompiling || isAiRunning
@@ -1859,6 +1894,19 @@ export default function ResumeEditPage() {
             <TrendingUp size={12} />
             Career Path
           </Link>
+
+          <button
+            onClick={() => setAcademicConvertOpen(true)}
+            title="Convert academic CV to industry resume"
+            className={`flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition ${
+              academicReport?.is_academic_cv
+                ? 'text-cyan-200 hover:bg-cyan-500/10 hover:text-cyan-100'
+                : 'text-zinc-500 hover:bg-white/[0.05] hover:text-zinc-200'
+            }`}
+          >
+            <GraduationCap size={12} />
+            CV→Industry
+          </button>
 
           {/* Create Variant button */}
           <div className="relative">
@@ -2169,6 +2217,19 @@ export default function ResumeEditPage() {
           </div>
           {/* Offline status banner (Feature 79F) */}
           <OfflineBanner pendingCount={offlinePendingCount} />
+          {academicReport?.is_academic_cv && (
+            <div className="flex shrink-0 items-center justify-between border-b border-cyan-500/20 bg-cyan-500/10 px-4 py-1.5">
+              <span className="text-[11px] text-cyan-200">
+                Academic CV detected ({academicReport.estimated_pages} pages, {academicReport.detected_sections.join(', ') || 'academic signals'}). Convert it into an industry resume variant.
+              </span>
+              <button
+                onClick={() => setAcademicConvertOpen(true)}
+                className="ml-3 text-[11px] text-cyan-100 underline hover:text-white"
+              >
+                Convert with AI →
+              </button>
+            </div>
+          )}
           {/* Page overflow warning banner */}
           {pageCount !== null && pageCount > 1 && (
             <div className="flex shrink-0 items-center justify-between border-b border-amber-500/20 bg-amber-500/10 px-4 py-1.5">
@@ -2592,7 +2653,7 @@ export default function ResumeEditPage() {
                 onJumpToLine={(line) => editorRef.current?.highlightLine(line)}
                 onApplyFix={(issue) => {
                   if (!issue.fix) return
-                  const currentContent = editorRef.current?.getValue() ?? latexContent
+                  const currentContent = editorRef.current?.getValue() || latexContent
                   const lines = currentContent.split('\n')
                   const lineContent = lines[issue.line - 1] ?? ''
                   const fixed = issue.fix(lineContent)
@@ -2602,7 +2663,7 @@ export default function ResumeEditPage() {
                   setLatexContent(newLines.join('\n'))
                 }}
                 onAutoFixAll={() => {
-                  const currentContent = editorRef.current?.getValue() ?? latexContent
+                  const currentContent = editorRef.current?.getValue() || latexContent
                   const fixed = runLintAutoFixAll(currentContent)
                   editorRef.current?.setValue(fixed)
                   setLatexContent(fixed)
@@ -2865,6 +2926,80 @@ export default function ResumeEditPage() {
           onClose={() => setShareModalOpen(false)}
           onShareTokenChange={(token, url) => { setShareToken(token); setShareUrl(url) }}
         />
+      )}
+
+      {academicConvertOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm" onClick={() => setAcademicConvertOpen(false)}>
+          <div className="w-full max-w-2xl rounded-2xl border border-white/10 bg-[#0f1012] p-5 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-base font-semibold text-zinc-100">Academic CV → Industry Resume</h2>
+                <p className="mt-1 text-sm text-zinc-400">
+                  Create a new variant that reframes academic work into industry outcomes without overwriting the original CV.
+                </p>
+              </div>
+              <button onClick={() => setAcademicConvertOpen(false)} className="rounded-md p-1.5 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-300">
+                <X size={16} />
+              </button>
+            </div>
+
+            {academicReport && (
+              <div className="mt-4 rounded-xl border border-cyan-400/15 bg-cyan-500/[0.06] p-3 text-xs text-cyan-100/90">
+                <div>Detection confidence: {Math.round(academicReport.confidence * 100)}%</div>
+                <div className="mt-1">Signals: {academicReport.detected_sections.join(', ') || 'general academic structure'}</div>
+              </div>
+            )}
+
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="grid gap-2 text-sm text-zinc-300">
+                <span>Target industry</span>
+                <select
+                  value={academicTargetIndustry}
+                  onChange={(e) => setAcademicTargetIndustry(e.target.value as typeof academicTargetIndustry)}
+                  className="rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-cyan-300/40"
+                >
+                  <option value="tech">Software Engineering / Tech</option>
+                  <option value="data_science">Data Science / ML</option>
+                  <option value="finance">Finance / Quant</option>
+                  <option value="consulting">Consulting</option>
+                  <option value="product">Product Management</option>
+                  <option value="other">Other</option>
+                </select>
+              </label>
+              <div className="rounded-lg border border-white/8 bg-white/[0.03] p-3 text-xs text-zinc-500">
+                The output is saved as a child variant. You keep the original academic CV unchanged.
+              </div>
+            </div>
+
+            <label className="mt-4 grid gap-2 text-sm text-zinc-300">
+              <span>Optional target role or job description</span>
+              <textarea
+                value={academicRoleDescription}
+                onChange={(e) => setAcademicRoleDescription(e.target.value)}
+                rows={7}
+                placeholder="Paste a target role description to bias the conversion toward the right framing and keywords."
+                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none placeholder:text-zinc-600 focus:border-cyan-300/40"
+              />
+            </label>
+
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <button
+                onClick={() => setAcademicConvertOpen(false)}
+                className="rounded-md px-3 py-2 text-sm text-zinc-500 transition hover:text-zinc-300"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleAcademicConvert}
+                disabled={isAcademicConverting}
+                className="inline-flex items-center gap-2 rounded-md bg-cyan-500/20 px-3 py-2 text-sm font-medium text-cyan-100 ring-1 ring-cyan-400/20 transition hover:bg-cyan-500/30 disabled:opacity-50"
+              >
+                {isAcademicConverting ? <Loader2 size={14} className="animate-spin" /> : <GraduationCap size={14} />}
+                {isAcademicConverting ? 'Creating Variant…' : 'Create Industry Variant'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Keyboard shortcuts panel (Feature 61) */}


### PR DESCRIPTION
## Summary
- add academic CV detection and report/convert backend endpoints
- add editor-side detection banner, conversion modal, and variant creation workflow
- extend API client coverage and backend tests for academic conversion behavior

## Verification
- `cd backend && .venv/bin/pytest test/test_academic_cv_conversion.py -q`
- frontend build/lint

Refs #391
