### PR TITLE
Defensively parse partial frontend responses

### DIFF
--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -794,10 +794,14 @@ class ApiClient {
       | { get?: (name: string) => string | null }
       | Record<string, string>
       | undefined
+    const plainResponseHeaders =
+      typeof responseHeaders?.get === 'function'
+        ? undefined
+        : (responseHeaders as Record<string, string> | undefined)
     const contentType =
       (typeof responseHeaders?.get === 'function'
         ? responseHeaders.get('content-type')
-        : responseHeaders?.['content-type'] ?? responseHeaders?.['Content-Type']) || ''
+        : plainResponseHeaders?.['content-type'] ?? plainResponseHeaders?.['Content-Type']) || ''
     if (contentType.includes('application/json') || (!contentType && typeof res.json === 'function')) {
       return res.json() as Promise<T>
     }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -790,8 +790,15 @@ class ApiClient {
     if (res.status === 204) {
       return undefined as T
     }
-    const contentType = res.headers.get('content-type') || ''
-    if (contentType.includes('application/json')) {
+    const responseHeaders = res.headers as
+      | { get?: (name: string) => string | null }
+      | Record<string, string>
+      | undefined
+    const contentType =
+      (typeof responseHeaders?.get === 'function'
+        ? responseHeaders.get('content-type')
+        : responseHeaders?.['content-type'] ?? responseHeaders?.['Content-Type']) || ''
+    if (contentType.includes('application/json') || (!contentType && typeof res.json === 'function')) {
       return res.json() as Promise<T>
     }
     return (await res.text()) as T


### PR DESCRIPTION
## Summary
- make `ApiClient.request()` tolerant of headerless or partially mocked responses
- preserve JSON parsing when `content-type` is absent but `res.json()` exists

## Validation
- `cd frontend && pnpm run test:unit`
- `cd frontend && pnpm lint --file src/lib/api-client.ts`

Closes #477
