### PR TITLE
Reuse healthy backend in smoke harness

### DIFF
--- a/scripts/ci/full-stack-smoke.sh
+++ b/scripts/ci/full-stack-smoke.sh
@@ -29,6 +29,7 @@ export OPENAI_API_KEY="${OPENAI_API_KEY:-}"
 export NEXT_TELEMETRY_DISABLED=1
 
 backend_pid=""
+started_backend=0
 backend_alembic=()
 backend_uvicorn=()
 
@@ -41,7 +42,7 @@ else
 fi
 
 cleanup() {
-  if [[ -n "$backend_pid" ]] && kill -0 "$backend_pid" 2>/dev/null; then
+  if [[ "$started_backend" -eq 1 ]] && [[ -n "$backend_pid" ]] && kill -0 "$backend_pid" 2>/dev/null; then
     kill "$backend_pid" 2>/dev/null || true
     wait "$backend_pid" 2>/dev/null || true
   fi
@@ -49,28 +50,33 @@ cleanup() {
 
 trap cleanup EXIT
 
-echo "==> Running backend migrations"
-(
-  cd "$BACKEND_DIR"
-  "${backend_alembic[@]}" upgrade head
-)
+if curl -fsS "http://127.0.0.1:${BACKEND_PORT}/health" >/dev/null 2>&1; then
+  echo "==> Reusing existing backend on :${BACKEND_PORT}"
+else
+  echo "==> Running backend migrations"
+  (
+    cd "$BACKEND_DIR"
+    "${backend_alembic[@]}" upgrade head
+  )
 
-echo "==> Starting backend on :${BACKEND_PORT}"
-(
-  cd "$BACKEND_DIR"
-  "${backend_uvicorn[@]}" app.main:app --host 127.0.0.1 --port "$BACKEND_PORT"
-) &
-backend_pid=$!
+  echo "==> Starting backend on :${BACKEND_PORT}"
+  (
+    cd "$BACKEND_DIR"
+    "${backend_uvicorn[@]}" app.main:app --host 127.0.0.1 --port "$BACKEND_PORT"
+  ) &
+  backend_pid=$!
+  started_backend=1
 
-echo "==> Waiting for backend readiness"
-for _ in $(seq 1 60); do
-  if curl -fsS "http://127.0.0.1:${BACKEND_PORT}/health" >/dev/null; then
-    break
-  fi
-  sleep 1
-done
+  echo "==> Waiting for backend readiness"
+  for _ in $(seq 1 60); do
+    if curl -fsS "http://127.0.0.1:${BACKEND_PORT}/health" >/dev/null; then
+      break
+    fi
+    sleep 1
+  done
 
-curl -fsS "http://127.0.0.1:${BACKEND_PORT}/health" >/dev/null
+  curl -fsS "http://127.0.0.1:${BACKEND_PORT}/health" >/dev/null
+fi
 
 echo "==> Running Playwright full-stack smoke"
 (


### PR DESCRIPTION
## Summary
- reuse an existing healthy backend in the full-stack smoke harness
- only tear down a backend process that the harness itself started

## Validation
- `bash scripts/ci/full-stack-smoke.sh`

Closes #478
