### PR TITLE
Expose builder resume creation action

### DIFF
--- a/frontend/src/app/workspace/new/page.tsx
+++ b/frontend/src/app/workspace/new/page.tsx
@@ -465,8 +465,8 @@ export default function NewResumePage() {
           </section>
         )}
 
-        {/* Create button — shown for import/linkedin mode */}
-        {(mode === 'import' || mode === 'linkedin') && (
+        {/* Create button — shown for non-template creation flows */}
+        {(mode === 'import' || mode === 'linkedin' || mode === 'builder') && (
           <div className="flex items-center justify-end gap-3">
             <button
               onClick={handleCreate}


### PR DESCRIPTION
## Summary
- render the footer create action for builder imports
- align builder mode with the other non-template creation flows
- preserve the existing import and LinkedIn behavior

## Validation
- covered by the dedicated builder-import Playwright flow introduced in the follow-up PR

Closes #489
