### PR TITLE
Expand local CORS slot defaults

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
             "http://127.0.0.1:3000",
             "http://localhost:5180",
             "http://127.0.0.1:5180",
+            "http://localhost:5181",
+            "http://127.0.0.1:5181",
+            "http://localhost:5182",
+            "http://127.0.0.1:5182",
+            "http://localhost:5183",
+            "http://127.0.0.1:5183",
         ]
     )
 


### PR DESCRIPTION
## Summary
- add localhost and 127.0.0.1 CORS defaults for ports `5181` to `5183`
- preserve the existing local default origins
- align backend defaults with slot-based local frontend ports used in the repo

## Validation
- `cd backend && .venv/bin/ruff check app/core/config.py`

Closes #493
