### PR TITLE
Forward-port builder and runtime issue fixes

### DIFF
--- a/backend/alembic/versions/0027_add_developer_api_keys.py
+++ b/backend/alembic/versions/0027_add_developer_api_keys.py
@@ -5,9 +5,11 @@ Revises: 0026
 Create Date: 2026-05-19
 """
 
-from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
+
+from alembic import op
 
 revision = "0027"
 down_revision = "0026"
@@ -16,36 +18,47 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "developer_api_keys",
-        sa.Column("id", UUID(as_uuid=False), primary_key=True),
-        sa.Column(
-            "user_id",
-            UUID(as_uuid=False),
-            sa.ForeignKey("users.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("key_hash", sa.Text(), nullable=False),
-        sa.Column("key_prefix", sa.String(length=32), nullable=False),
-        sa.Column("name", sa.String(length=100), nullable=False),
-        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("request_count", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
-        sa.Column(
-            "scopes",
-            ARRAY(sa.String()),
-            nullable=False,
-            server_default='{"compile","optimize","ats","export"}',
-        ),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-    )
-    op.create_index("ix_developer_api_keys_user_id", "developer_api_keys", ["user_id"])
-    op.create_unique_constraint("uq_developer_api_keys_hash", "developer_api_keys", ["key_hash"])
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if not inspector.has_table("developer_api_keys"):
+        op.create_table(
+            "developer_api_keys",
+            sa.Column("id", UUID(as_uuid=False), primary_key=True),
+            sa.Column(
+                "user_id",
+                UUID(as_uuid=False),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("key_hash", sa.Text(), nullable=False),
+            sa.Column("key_prefix", sa.String(length=32), nullable=False),
+            sa.Column("name", sa.String(length=100), nullable=False),
+            sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("request_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column(
+                "scopes",
+                ARRAY(sa.String()),
+                nullable=False,
+                server_default='{"compile","optimize","ats","export"}',
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+        )
+        inspector = inspect(bind)
+
+    indexes = {index["name"] for index in inspector.get_indexes("developer_api_keys")}
+    if "ix_developer_api_keys_user_id" not in indexes:
+        op.create_index("ix_developer_api_keys_user_id", "developer_api_keys", ["user_id"])
+
+    uniques = {tuple(constraint["column_names"]) for constraint in inspector.get_unique_constraints("developer_api_keys")}
+    if ("key_hash",) not in uniques:
+        op.create_unique_constraint("uq_developer_api_keys_hash", "developer_api_keys", ["key_hash"])
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0028_add_subscription_extensions.py
+++ b/backend/alembic/versions/0028_add_subscription_extensions.py
@@ -6,6 +6,7 @@ Create Date: 2026-05-19
 """
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 
 from alembic import op
@@ -17,81 +18,96 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "team_seats",
-        sa.Column("id", UUID(as_uuid=False), primary_key=True),
-        sa.Column(
-            "owner_user_id",
-            UUID(as_uuid=False),
-            sa.ForeignKey("users.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("member_email", sa.Text(), nullable=False),
-        sa.Column(
-            "member_user_id",
-            UUID(as_uuid=False),
-            sa.ForeignKey("users.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column("status", sa.Text(), nullable=False, server_default="invited"),
-        sa.Column(
-            "invited_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.UniqueConstraint("owner_user_id", "member_email", name="uq_team_seats_owner_email"),
-    )
-    op.create_index("ix_team_seats_owner_user_id", "team_seats", ["owner_user_id"])
+    bind = op.get_bind()
+    inspector = inspect(bind)
 
-    op.create_table(
-        "coupon_codes",
-        sa.Column("id", UUID(as_uuid=False), primary_key=True),
-        sa.Column("code", sa.Text(), nullable=False),
-        sa.Column("discount_percent", sa.Integer(), nullable=False),
-        sa.Column("applicable_plans", ARRAY(sa.String()), nullable=True),
-        sa.Column("max_uses", sa.Integer(), nullable=True),
-        sa.Column("used_count", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-    )
-    op.create_unique_constraint("uq_coupon_codes_code", "coupon_codes", ["code"])
+    if not inspector.has_table("team_seats"):
+        op.create_table(
+            "team_seats",
+            sa.Column("id", UUID(as_uuid=False), primary_key=True),
+            sa.Column(
+                "owner_user_id",
+                UUID(as_uuid=False),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("member_email", sa.Text(), nullable=False),
+            sa.Column(
+                "member_user_id",
+                UUID(as_uuid=False),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("status", sa.Text(), nullable=False, server_default="invited"),
+            sa.Column(
+                "invited_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column("joined_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.UniqueConstraint("owner_user_id", "member_email", name="uq_team_seats_owner_email"),
+        )
+        inspector = inspect(bind)
+    team_indexes = {index["name"] for index in inspector.get_indexes("team_seats")}
+    if "ix_team_seats_owner_user_id" not in team_indexes:
+        op.create_index("ix_team_seats_owner_user_id", "team_seats", ["owner_user_id"])
 
-    op.create_table(
-        "coupon_redemptions",
-        sa.Column("id", UUID(as_uuid=False), primary_key=True),
-        sa.Column(
-            "coupon_id",
-            UUID(as_uuid=False),
-            sa.ForeignKey("coupon_codes.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column(
-            "user_id",
-            UUID(as_uuid=False),
-            sa.ForeignKey("users.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column(
-            "redeemed_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-    )
-    op.create_index("ix_coupon_redemptions_user_id", "coupon_redemptions", ["user_id"])
+    if not inspector.has_table("coupon_codes"):
+        op.create_table(
+            "coupon_codes",
+            sa.Column("id", UUID(as_uuid=False), primary_key=True),
+            sa.Column("code", sa.Text(), nullable=False),
+            sa.Column("discount_percent", sa.Integer(), nullable=False),
+            sa.Column("applicable_plans", ARRAY(sa.String()), nullable=True),
+            sa.Column("max_uses", sa.Integer(), nullable=True),
+            sa.Column("used_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+        )
+        inspector = inspect(bind)
+    coupon_uniques = {tuple(constraint["column_names"]) for constraint in inspector.get_unique_constraints("coupon_codes")}
+    if ("code",) not in coupon_uniques:
+        op.create_unique_constraint("uq_coupon_codes_code", "coupon_codes", ["code"])
+
+    if not inspector.has_table("coupon_redemptions"):
+        op.create_table(
+            "coupon_redemptions",
+            sa.Column("id", UUID(as_uuid=False), primary_key=True),
+            sa.Column(
+                "coupon_id",
+                UUID(as_uuid=False),
+                sa.ForeignKey("coupon_codes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "user_id",
+                UUID(as_uuid=False),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "redeemed_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+        )
+        inspector = inspect(bind)
+    redemption_indexes = {index["name"] for index in inspector.get_indexes("coupon_redemptions")}
+    if "ix_coupon_redemptions_user_id" not in redemption_indexes:
+        op.create_index("ix_coupon_redemptions_user_id", "coupon_redemptions", ["user_id"])
 
 
 def downgrade() -> None:

--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import StreamingResponse
 from jinja2 import Environment as _JinjaEnv
 from jinja2 import FileSystemLoader as _JinjaFSL
@@ -18,9 +18,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..core.config import settings
 from ..core.logging import get_logger
 from ..database.connection import get_db
-from ..database.models import Optimization, Resume, ResumeCollaborator, UsageAnalytics, User
+from ..database.models import Optimization, Resume, ResumeCollaborator, ResumeTemplate, UsageAnalytics, User
 from ..middleware.auth_middleware import get_current_user_required
+from ..parsers.parser_factory import parser_factory
 from ..services.academic_cv_service import academic_cv_service
+from ..services.format_detection import ResumeFormat, format_detection_service
+from ..services.resume_builder_service import SUPPORTED_BUILDER_CATEGORIES, resume_builder_service
 
 logger = get_logger(__name__)
 
@@ -33,6 +36,7 @@ class ResumeBase(BaseModel):
     latex_content: str
     is_template: bool = False
     tags: Optional[List[str]] = None
+    document_type: str = "resume"
 
 class ResumeCreate(ResumeBase):
     pass
@@ -42,6 +46,7 @@ class ResumeUpdate(BaseModel):
     latex_content: Optional[str] = None
     is_template: Optional[bool] = None
     tags: Optional[List[str]] = None
+    document_type: Optional[str] = None
 
 class ResumeResponse(ResumeBase):
     id: str
@@ -49,6 +54,11 @@ class ResumeResponse(ResumeBase):
     document_type: str = "resume"
     parent_resume_id: Optional[str] = None
     variant_count: int = 0
+    selected_template_id: Optional[str] = None
+    content_source: str = "manual_latex"
+    builder_status: str = "detached"
+    structured_content: Optional[Dict[str, Any]] = None
+    structured_version: int = 1
     # resume_settings is the ORM attribute; we expose it as "metadata" in JSON
     metadata: Optional[Dict[str, Any]] = Field(default=None, validation_alias="resume_settings")
     share_token: Optional[str] = None
@@ -91,6 +101,48 @@ class ResumeResponse(ResumeBase):
     def freshness_status(self) -> str:
         days = self.days_since_updated
         return "fresh" if days < 30 else "stale" if days < 90 else "very_stale"
+
+
+def _typed_attr(obj: Any, name: str, expected_type: type | tuple[type, ...], default: Any = None) -> Any:
+    """Return an attribute only when it is the expected concrete type.
+
+    Mock-based tests and partially-populated objects can expose MagicMock
+    placeholders for newly added optional ORM fields. Those should fall back to
+    response defaults instead of turning API serialization into a 500.
+    """
+    value = getattr(obj, name, default)
+    return value if isinstance(value, expected_type) else default
+
+
+def _resume_response_from_obj(resume: Any) -> ResumeResponse:
+    """Serialize a Resume-like object with safe fallbacks for optional fields."""
+    payload = {
+        "id": str(resume.id),
+        "user_id": str(resume.user_id),
+        "title": resume.title,
+        "latex_content": resume.latex_content,
+        "is_template": bool(getattr(resume, "is_template", False)),
+        "tags": _typed_attr(resume, "tags", list),
+        "document_type": _typed_attr(resume, "document_type", str, "resume"),
+        "parent_resume_id": _typed_attr(resume, "parent_resume_id", str),
+        "variant_count": int(getattr(resume, "variant_count", 0) or 0),
+        "selected_template_id": _typed_attr(resume, "selected_template_id", str),
+        "content_source": _typed_attr(resume, "content_source", str, "manual_latex"),
+        "builder_status": _typed_attr(resume, "builder_status", str, "detached"),
+        "structured_content": _typed_attr(resume, "structured_content", dict),
+        "structured_version": int(getattr(resume, "structured_version", 1) or 1),
+        "metadata": _typed_attr(resume, "resume_settings", dict),
+        "share_token": _typed_attr(resume, "share_token", str),
+        "share_url": _typed_attr(resume, "share_url", str),
+        "github_sync_enabled": bool(getattr(resume, "github_sync_enabled", False)),
+        "github_repo_name": _typed_attr(resume, "github_repo_name", str),
+        "github_last_sync_at": getattr(resume, "github_last_sync_at", None),
+        "created_at": resume.created_at,
+        "updated_at": resume.updated_at,
+        "archived_at": getattr(resume, "archived_at", None),
+        "pinned": bool(getattr(resume, "pinned", False)),
+    }
+    return ResumeResponse.model_validate(payload)
 
 
 ALLOWED_LATEXMK_FLAGS = [
@@ -158,6 +210,64 @@ class ResumeStats(BaseModel):
     optimized_count: int = 0
 
 
+class BuilderTemplateResponse(BaseModel):
+    id: str
+    name: str
+    description: Optional[str]
+    category: str
+    category_label: str
+    sort_order: int
+    thumbnail_url: Optional[str]
+    pdf_url: Optional[str]
+    template_family: str
+
+
+class BuilderMetricsResponse(BaseModel):
+    completeness_score: int
+    page_estimate: int
+    warnings: List[str]
+    missing_sections: List[str]
+
+
+class BuilderPreviewSectionResponse(BaseModel):
+    key: str
+    title: str
+    items: List[Any]
+
+
+class BuilderPreviewResponse(BaseModel):
+    template_family: str
+    sections: List[BuilderPreviewSectionResponse]
+
+
+class BuilderResumeCreateRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=255)
+    template_id: str
+    structured_content: Optional[Dict[str, Any]] = None
+
+
+class BuilderResumePatchRequest(BaseModel):
+    title: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    template_id: Optional[str] = None
+    structured_content: Optional[Dict[str, Any]] = None
+    force_reattach: bool = False
+
+
+class BuilderResumeResponse(BaseModel):
+    resume: ResumeResponse
+    metrics: BuilderMetricsResponse
+    preview: BuilderPreviewResponse
+    template_family: str
+
+
+class BuilderSeedUploadResponse(BaseModel):
+    success: bool
+    filename: str
+    format: str
+    structured_content: Dict[str, Any]
+    metrics: BuilderMetricsResponse
+
+
 # --- Search schemas ---
 
 class SearchMatch(BaseModel):
@@ -180,6 +290,136 @@ class SearchResponse(BaseModel):
     query: str
 
 # --- Endpoints ---
+
+_BUILDER_CATEGORY_LABELS = {
+    "ats_safe": "ATS-Safe",
+    "minimal": "Minimal / Clean",
+    "software_engineering": "Software Engineering",
+    "executive": "Executive",
+    "graduate": "Graduate / Entry-Level",
+}
+
+
+def _builder_category_label(category: str) -> str:
+    return _BUILDER_CATEGORY_LABELS.get(category, category.replace("_", " ").title())
+
+
+def _template_to_builder_response(template: ResumeTemplate, base_url: str) -> BuilderTemplateResponse:
+    root = base_url.rstrip("/")
+    return BuilderTemplateResponse(
+        id=template.id,
+        name=template.name,
+        description=template.description,
+        category=template.category,
+        category_label=_builder_category_label(template.category),
+        sort_order=template.sort_order,
+        thumbnail_url=f"{root}/templates/{template.id}/thumbnail",
+        pdf_url=f"{root}/templates/{template.id}/pdf",
+        template_family=resume_builder_service.template_family(template.category),
+    )
+
+
+async def _get_builder_template(db: AsyncSession, template_id: str) -> ResumeTemplate:
+    template = await db.get(ResumeTemplate, template_id)
+    if not template or not template.is_active:
+        raise HTTPException(status_code=404, detail="Template not found")
+    if not resume_builder_service.is_supported_category(template.category, template.document_type):
+        raise HTTPException(status_code=400, detail="Template is not supported by the guided builder")
+    return template
+
+
+def _builder_payload(resume: Resume, category: str) -> BuilderResumeResponse:
+    render = resume_builder_service.render(resume.structured_content or {}, category)
+    preview = resume_builder_service.build_preview(resume.structured_content or {}, category)
+    return BuilderResumeResponse(
+        resume=_resume_response_from_obj(resume),
+        metrics=BuilderMetricsResponse.model_validate(render.metrics.model_dump()),
+        preview=BuilderPreviewResponse.model_validate(preview),
+        template_family=render.template_family,
+    )
+
+
+@router.get("/builder/templates", response_model=List[BuilderTemplateResponse])
+async def list_builder_templates(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = (
+        select(ResumeTemplate)
+        .where(
+            ResumeTemplate.is_active.is_(True),
+            ResumeTemplate.document_type == "resume",
+            ResumeTemplate.category.in_(tuple(sorted(SUPPORTED_BUILDER_CATEGORIES))),
+        )
+        .order_by(ResumeTemplate.category, ResumeTemplate.sort_order, ResumeTemplate.name)
+    )
+    templates = (await db.execute(stmt)).scalars().all()
+    base_url = str(request.base_url)
+    return [_template_to_builder_response(template, base_url) for template in templates]
+
+
+@router.post("/builder/seed-upload", response_model=BuilderSeedUploadResponse)
+async def seed_builder_from_upload(
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_required),
+):
+    del db, user_id
+    content = await file.read()
+    filename = file.filename or "upload"
+    detected_format = format_detection_service.detect_format(
+        filename=filename,
+        mime_type=file.content_type,
+        content=content,
+    )
+    if detected_format == ResumeFormat.UNKNOWN:
+        raise HTTPException(status_code=415, detail=f"Unsupported file format: '{filename}'")
+    parser = parser_factory.get_parser(detected_format)
+    if not parser:
+        raise HTTPException(status_code=415, detail=f"No parser available for {detected_format.value}")
+    try:
+        parsed = await parser.parse(content, filename)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    structured = resume_builder_service.from_parsed_resume(parsed)
+    metrics = resume_builder_service.render(structured, "minimal").metrics
+    return BuilderSeedUploadResponse(
+        success=True,
+        filename=filename,
+        format=detected_format.value,
+        structured_content=structured,
+        metrics=BuilderMetricsResponse.model_validate(metrics.model_dump()),
+    )
+
+
+@router.post("/builder", response_model=BuilderResumeResponse, status_code=status.HTTP_201_CREATED)
+async def create_builder_resume(
+    body: BuilderResumeCreateRequest,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_required),
+):
+    template = await _get_builder_template(db, body.template_id)
+    structured = resume_builder_service.normalize(body.structured_content)
+    render = resume_builder_service.render(structured, template.category)
+
+    resume = Resume(
+        id=str(uuid4()),
+        user_id=user_id,
+        title=body.title.strip(),
+        latex_content=render.latex_content,
+        structured_content=structured,
+        structured_version=1,
+        is_template=False,
+        selected_template_id=template.id,
+        content_source="builder",
+        builder_status="active",
+        document_type="resume",
+    )
+    db.add(resume)
+    await db.commit()
+    await db.refresh(resume)
+    return _builder_payload(resume, template.category)
 
 @router.get("/stats", response_model=ResumeStats)
 async def get_resume_stats(
@@ -233,10 +473,15 @@ async def create_resume(
     user_id: str = Depends(get_current_user_required)
 ):
     """Create a new resume for the authenticated user."""
+    payload = resume_in.model_dump()
+    payload.setdefault("document_type", "resume")
     resume = Resume(
         id=str(uuid4()),
         user_id=user_id,
-        **resume_in.model_dump()
+        content_source="manual_latex",
+        builder_status="detached",
+        structured_content=None,
+        **payload
     )
     db.add(resume)
     await db.commit()
@@ -311,7 +556,7 @@ async def list_resumes(
 
     resumes_out = []
     for resume, vc in rows:
-        d = ResumeResponse.model_validate(resume).model_dump()
+        d = _resume_response_from_obj(resume).model_dump()
         d["variant_count"] = vc or 0
         resumes_out.append(d)
 
@@ -445,6 +690,64 @@ async def get_error_history(
     ]
 
 
+@router.get("/{resume_id}/builder", response_model=BuilderResumeResponse)
+async def get_builder_resume(
+    resume_id: str,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_required),
+):
+    resume = await _verify_resume_ownership(db, resume_id, user_id)
+    if not resume.selected_template_id or not resume.structured_content:
+        raise HTTPException(status_code=404, detail="Builder data not available for this resume")
+    template = await db.get(ResumeTemplate, resume.selected_template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail="Selected template not found")
+    return _builder_payload(resume, template.category)
+
+
+@router.patch("/{resume_id}/builder", response_model=BuilderResumeResponse)
+async def update_builder_resume(
+    resume_id: str,
+    body: BuilderResumePatchRequest,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_required),
+):
+    resume = await _verify_resume_ownership(db, resume_id, user_id)
+    if resume.builder_status == "detached" and not body.force_reattach:
+        raise HTTPException(
+            status_code=409,
+            detail="Builder is detached because this resume was edited in advanced mode. Pass force_reattach=true to overwrite LaTeX from builder data.",
+        )
+
+    template: Optional[ResumeTemplate] = None
+    if body.template_id:
+        template = await _get_builder_template(db, body.template_id)
+        resume.selected_template_id = template.id
+    elif resume.selected_template_id:
+        template = await db.get(ResumeTemplate, resume.selected_template_id)
+
+    if not template:
+        raise HTTPException(status_code=400, detail="Builder resume must have a supported selected template")
+
+    if body.title is not None:
+        resume.title = body.title.strip()
+    if body.structured_content is not None:
+        resume.structured_content = resume_builder_service.normalize(body.structured_content)
+        resume.structured_version = (resume.structured_version or 1) + 1
+    elif not resume.structured_content:
+        resume.structured_content = resume_builder_service.empty_document()
+
+    render = resume_builder_service.render(resume.structured_content, template.category)
+    resume.latex_content = render.latex_content
+    resume.content_source = "builder"
+    resume.builder_status = "active"
+    resume.document_type = "resume"
+    resume.updated_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(resume)
+    return _builder_payload(resume, template.category)
+
+
 @router.get("/{resume_id}", response_model=ResumeResponse)
 async def get_resume(
     resume_id: str,
@@ -461,7 +764,7 @@ async def get_resume(
     if not row:
         raise HTTPException(status_code=404, detail="Resume not found")
     resume, vc = row
-    resp = ResumeResponse.model_validate(resume)
+    resp = _resume_response_from_obj(resume)
     resp.variant_count = vc or 0
     return resp
 
@@ -482,8 +785,17 @@ async def update_resume(
         raise HTTPException(status_code=404, detail="Resume not found")
 
     update_data = resume_in.model_dump(exclude_unset=True)
+    latex_changed = (
+        "latex_content" in update_data
+        and update_data["latex_content"] is not None
+        and update_data["latex_content"] != resume.latex_content
+    )
     for key, value in update_data.items():
         setattr(resume, key, value)
+
+    if latex_changed and resume.selected_template_id and resume.structured_content:
+        resume.builder_status = "detached"
+        resume.content_source = "manual_latex"
 
     resume.updated_at = datetime.now(timezone.utc)
     await db.commit()
@@ -563,7 +875,7 @@ async def update_resume_settings(
     await db.commit()
     await db.refresh(resume)
 
-    resp = ResumeResponse.model_validate(resume)
+    resp = _resume_response_from_obj(resume)
     resp.variant_count = 0
     return resp
 
@@ -597,7 +909,7 @@ async def update_resume_tags(
     resume.tags = body.tags
     await db.commit()
     await db.refresh(resume)
-    return ResumeResponse.model_validate(resume)
+    return _resume_response_from_obj(resume)
 
 
 @router.patch("/{resume_id}/pin", response_model=ResumeResponse)
@@ -613,7 +925,7 @@ async def pin_resume(
     resume.resume_settings = settings_dict
     await db.commit()
     await db.refresh(resume)
-    return ResumeResponse.model_validate(resume)
+    return _resume_response_from_obj(resume)
 
 
 @router.patch("/{resume_id}/unpin", response_model=ResumeResponse)
@@ -629,7 +941,7 @@ async def unpin_resume(
     resume.resume_settings = settings_dict
     await db.commit()
     await db.refresh(resume)
-    return ResumeResponse.model_validate(resume)
+    return _resume_response_from_obj(resume)
 
 
 @router.patch("/{resume_id}/archive", response_model=ResumeResponse)
@@ -643,7 +955,7 @@ async def archive_resume(
     resume.archived_at = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(resume)
-    return ResumeResponse.model_validate(resume)
+    return _resume_response_from_obj(resume)
 
 
 @router.patch("/{resume_id}/unarchive", response_model=ResumeResponse)
@@ -657,7 +969,7 @@ async def unarchive_resume(
     resume.archived_at = None
     await db.commit()
     await db.refresh(resume)
-    return ResumeResponse.model_validate(resume)
+    return _resume_response_from_obj(resume)
 
 
 # ── Variant / Fork system ─────────────────────────────────────────────────
@@ -720,7 +1032,7 @@ async def fork_resume(
         except Exception as exc:
             logger.warning(f"Failed to enqueue embedding for variant {variant.id}: {exc}")
 
-    resp = ResumeResponse.model_validate(variant)
+    resp = _resume_response_from_obj(variant)
     resp.variant_count = 0
     return resp
 
@@ -958,7 +1270,7 @@ async def list_variants(
 
     out = []
     for resume, vc in rows:
-        d = ResumeResponse.model_validate(resume)
+        d = _resume_response_from_obj(resume)
         d.variant_count = vc or 0
         out.append(d)
     return out

--- a/backend/app/services/resume_builder_service.py
+++ b/backend/app/services/resume_builder_service.py
@@ -1,0 +1,630 @@
+"""Structured resume builder service."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from ..parsers.base_parser import ParsedResume
+
+SUPPORTED_BUILDER_CATEGORIES = frozenset(
+    {"ats_safe", "minimal", "software_engineering", "executive", "graduate"}
+)
+
+
+class BuilderBasics(BaseModel):
+    name: str = ""
+    label: str = ""
+    email: str = ""
+    phone: str = ""
+    location: str = ""
+    website: str = ""
+    linkedin: str = ""
+    github: str = ""
+    summary: str = ""
+
+
+class BuilderExperienceEntry(BaseModel):
+    id: str
+    title: str = ""
+    company: str = ""
+    location: str = ""
+    start_date: str = ""
+    end_date: str = ""
+    current: bool = False
+    summary: str = ""
+    bullets: List[str] = Field(default_factory=list)
+    technologies: List[str] = Field(default_factory=list)
+
+
+class BuilderEducationEntry(BaseModel):
+    id: str
+    institution: str = ""
+    degree: str = ""
+    field: str = ""
+    location: str = ""
+    start_date: str = ""
+    end_date: str = ""
+    gpa: str = ""
+    highlights: List[str] = Field(default_factory=list)
+
+
+class BuilderProjectEntry(BaseModel):
+    id: str
+    name: str = ""
+    role: str = ""
+    url: str = ""
+    start_date: str = ""
+    end_date: str = ""
+    description: str = ""
+    bullets: List[str] = Field(default_factory=list)
+    technologies: List[str] = Field(default_factory=list)
+
+
+class BuilderSkillGroup(BaseModel):
+    id: str
+    name: str = ""
+    keywords: List[str] = Field(default_factory=list)
+
+
+class BuilderCertificationEntry(BaseModel):
+    id: str
+    name: str = ""
+    issuer: str = ""
+    date: str = ""
+    url: str = ""
+
+
+class BuilderNamedEntry(BaseModel):
+    id: str
+    name: str = ""
+    detail: str = ""
+
+
+class StructuredResume(BaseModel):
+    basics: BuilderBasics = Field(default_factory=BuilderBasics)
+    experience: List[BuilderExperienceEntry] = Field(default_factory=list)
+    education: List[BuilderEducationEntry] = Field(default_factory=list)
+    projects: List[BuilderProjectEntry] = Field(default_factory=list)
+    skills: List[BuilderSkillGroup] = Field(default_factory=list)
+    certifications: List[BuilderCertificationEntry] = Field(default_factory=list)
+    awards: List[BuilderNamedEntry] = Field(default_factory=list)
+    languages: List[BuilderNamedEntry] = Field(default_factory=list)
+    interests: List[BuilderNamedEntry] = Field(default_factory=list)
+    section_order: List[str] = Field(
+        default_factory=lambda: [
+            "summary",
+            "experience",
+            "education",
+            "skills",
+            "projects",
+            "certifications",
+            "awards",
+            "languages",
+            "interests",
+        ]
+    )
+    hidden_sections: List[str] = Field(default_factory=list)
+
+    @field_validator("section_order")
+    @classmethod
+    def validate_section_order(cls, v: List[str]) -> List[str]:
+        allowed = {
+            "summary",
+            "experience",
+            "education",
+            "skills",
+            "projects",
+            "certifications",
+            "awards",
+            "languages",
+            "interests",
+        }
+        seen: list[str] = []
+        for section in v:
+            if section in allowed and section not in seen:
+                seen.append(section)
+        for section in allowed:
+            if section not in seen:
+                seen.append(section)
+        return seen
+
+    @field_validator("hidden_sections")
+    @classmethod
+    def validate_hidden_sections(cls, v: List[str]) -> List[str]:
+        return [section for section in v if section]
+
+
+class BuilderMetrics(BaseModel):
+    completeness_score: int
+    page_estimate: int
+    warnings: List[str] = Field(default_factory=list)
+    missing_sections: List[str] = Field(default_factory=list)
+
+
+class BuilderRenderResult(BaseModel):
+    latex_content: str
+    template_family: str
+    metrics: BuilderMetrics
+
+
+class ResumeBuilderService:
+    _escape_table = {
+        "\\": r"\textbackslash{}",
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+        "~": r"\textasciitilde{}",
+        "^": r"\textasciicircum{}",
+    }
+
+    def empty_document(self) -> Dict[str, Any]:
+        return StructuredResume().model_dump()
+
+    def normalize(self, raw: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        data = StructuredResume.model_validate(raw or {}).model_dump()
+        return data
+
+    def from_parsed_resume(self, parsed: ParsedResume) -> Dict[str, Any]:
+        basics = BuilderBasics(
+            name=parsed.contact.name or "",
+            email=parsed.contact.email or "",
+            phone=parsed.contact.phone or "",
+            location=parsed.contact.location or parsed.contact.address or "",
+            website=parsed.contact.website or "",
+            linkedin=parsed.contact.linkedin or "",
+            github=parsed.contact.github or "",
+            summary=parsed.summary or parsed.objective or "",
+        )
+        structured = StructuredResume(
+            basics=basics,
+            experience=[
+                BuilderExperienceEntry(
+                    id=f"exp-{idx + 1}",
+                    title=item.title,
+                    company=item.company,
+                    location=item.location or "",
+                    start_date=item.start_date or "",
+                    end_date=item.end_date or "",
+                    current=item.current,
+                    bullets=list(item.description or []),
+                    technologies=list(item.technologies or []),
+                )
+                for idx, item in enumerate(parsed.experience)
+            ],
+            education=[
+                BuilderEducationEntry(
+                    id=f"edu-{idx + 1}",
+                    institution=item.institution,
+                    degree=item.degree,
+                    field="",
+                    location=item.location or "",
+                    end_date=item.graduation_date or "",
+                    gpa=item.gpa or "",
+                    highlights=[*item.honors, *item.courses],
+                )
+                for idx, item in enumerate(parsed.education)
+            ],
+            projects=[
+                BuilderProjectEntry(
+                    id=f"proj-{idx + 1}",
+                    name=item.name,
+                    url=item.url or "",
+                    start_date=item.start_date or "",
+                    end_date=item.end_date or "",
+                    description=item.description,
+                    technologies=list(item.technologies or []),
+                )
+                for idx, item in enumerate(parsed.projects)
+            ],
+            skills=self._skills_from_parsed(parsed),
+            certifications=[
+                BuilderCertificationEntry(
+                    id=f"cert-{idx + 1}",
+                    name=item.name,
+                    issuer=item.issuer,
+                    date=item.date or "",
+                    url=item.url or "",
+                )
+                for idx, item in enumerate(parsed.certifications)
+            ],
+            awards=[
+                BuilderNamedEntry(id=f"award-{idx + 1}", name=award)
+                for idx, award in enumerate(parsed.awards)
+            ],
+            languages=[
+                BuilderNamedEntry(
+                    id=f"lang-{idx + 1}",
+                    name=item.language,
+                    detail=item.proficiency or "",
+                )
+                for idx, item in enumerate(parsed.languages)
+            ],
+            interests=[
+                BuilderNamedEntry(id=f"interest-{idx + 1}", name=item)
+                for idx, item in enumerate(parsed.interests)
+            ],
+        )
+        if parsed.contact.name and not basics.label and parsed.experience:
+            structured.basics.label = parsed.experience[0].title
+        return structured.model_dump()
+
+    def render(self, structured_raw: Dict[str, Any], category: str) -> BuilderRenderResult:
+        structured = StructuredResume.model_validate(structured_raw)
+        family = self.template_family(category)
+        metrics = self._build_metrics(structured)
+        latex = self._render_latex(structured, family)
+        return BuilderRenderResult(
+            latex_content=latex,
+            template_family=family,
+            metrics=metrics,
+        )
+
+    def build_preview(self, structured_raw: Dict[str, Any], category: str) -> Dict[str, Any]:
+        structured = StructuredResume.model_validate(structured_raw)
+        return {
+            "template_family": self.template_family(category),
+            "sections": self._preview_sections(structured),
+        }
+
+    def template_family(self, category: str) -> str:
+        if category == "executive":
+            return "executive"
+        if category == "ats_safe":
+            return "ats"
+        if category == "minimal":
+            return "minimal"
+        return "professional"
+
+    def is_supported_category(self, category: str, document_type: str = "resume") -> bool:
+        return document_type == "resume" and category in SUPPORTED_BUILDER_CATEGORIES
+
+    def _skills_from_parsed(self, parsed: ParsedResume) -> List[BuilderSkillGroup]:
+        if parsed.skills_categorized:
+            return [
+                BuilderSkillGroup(id=f"skill-{idx + 1}", name=name, keywords=keywords)
+                for idx, (name, keywords) in enumerate(parsed.skills_categorized.items())
+            ]
+        if parsed.skills:
+            return [BuilderSkillGroup(id="skill-1", name="Core Skills", keywords=parsed.skills)]
+        return []
+
+    def _build_metrics(self, structured: StructuredResume) -> BuilderMetrics:
+        score = 0
+        missing: list[str] = []
+        warnings: list[str] = []
+
+        if structured.basics.name:
+            score += 15
+        else:
+            missing.append("name")
+        if structured.basics.email:
+            score += 10
+        else:
+            missing.append("email")
+        if structured.basics.summary.strip():
+            score += 10
+        else:
+            missing.append("summary")
+        if structured.experience:
+            score += 25
+        else:
+            missing.append("experience")
+        if structured.education:
+            score += 15
+        else:
+            missing.append("education")
+        if any(group.keywords for group in structured.skills):
+            score += 15
+        else:
+            missing.append("skills")
+        if structured.projects:
+            score += 10
+
+        total_lines = 6
+        total_lines += len([1 for value in structured.basics.model_dump().values() if isinstance(value, str) and value.strip()])
+        total_lines += len(structured.basics.summary.splitlines())
+        total_lines += sum(max(3, len(entry.bullets) + 2) for entry in structured.experience)
+        total_lines += sum(max(2, len(entry.highlights) + 1) for entry in structured.education)
+        total_lines += sum(max(2, len(group.keywords) // 5 + 1) for group in structured.skills)
+        total_lines += sum(max(2, len(item.bullets) + 2) for item in structured.projects)
+        page_estimate = max(1, (total_lines + 37) // 38)
+        if page_estimate > 1:
+            warnings.append("Content likely exceeds one page in compact templates.")
+        if structured.experience and any(len(entry.bullets) > 6 for entry in structured.experience):
+            warnings.append("Some experience entries are dense; consider trimming bullets.")
+        if not structured.basics.label:
+            warnings.append("Add a headline to improve clarity at the top of the resume.")
+        return BuilderMetrics(
+            completeness_score=min(score, 100),
+            page_estimate=page_estimate,
+            warnings=warnings,
+            missing_sections=missing,
+        )
+
+    def _preview_sections(self, structured: StructuredResume) -> List[Dict[str, Any]]:
+        hidden = set(structured.hidden_sections)
+        sections: list[dict[str, Any]] = []
+        for section in structured.section_order:
+            if section in hidden:
+                continue
+            if section == "summary" and structured.basics.summary.strip():
+                sections.append({"key": "summary", "title": "Summary", "items": [structured.basics.summary.strip()]})
+            elif section == "experience" and structured.experience:
+                sections.append({
+                    "key": "experience",
+                    "title": "Experience",
+                    "items": [
+                        {
+                            "title": f"{item.title} — {item.company}".strip(" —"),
+                            "meta": self._join_meta(item.location, self._date_range(item.start_date, item.end_date, item.current)),
+                            "bullets": [b for b in item.bullets if b.strip()],
+                        }
+                        for item in structured.experience
+                    ],
+                })
+            elif section == "education" and structured.education:
+                sections.append({
+                    "key": "education",
+                    "title": "Education",
+                    "items": [
+                        {
+                            "title": f"{item.degree} — {item.institution}".strip(" —"),
+                            "meta": self._join_meta(item.location, self._date_range(item.start_date, item.end_date, False)),
+                            "bullets": [b for b in item.highlights if b.strip()],
+                        }
+                        for item in structured.education
+                    ],
+                })
+            elif section == "skills" and structured.skills:
+                sections.append({
+                    "key": "skills",
+                    "title": "Skills",
+                    "items": [{"title": item.name, "meta": ", ".join(item.keywords)} for item in structured.skills if item.keywords],
+                })
+            elif section == "projects" and structured.projects:
+                sections.append({
+                    "key": "projects",
+                    "title": "Projects",
+                    "items": [
+                        {
+                            "title": item.name,
+                            "meta": self._join_meta(item.role, item.url),
+                            "bullets": ([item.description] if item.description else []) + [b for b in item.bullets if b.strip()],
+                        }
+                        for item in structured.projects
+                    ],
+                })
+            elif section == "certifications" and structured.certifications:
+                sections.append({
+                    "key": "certifications",
+                    "title": "Certifications",
+                    "items": [{"title": item.name, "meta": self._join_meta(item.issuer, item.date)} for item in structured.certifications],
+                })
+            elif section == "awards" and structured.awards:
+                sections.append({
+                    "key": "awards",
+                    "title": "Awards",
+                    "items": [{"title": item.name, "meta": item.detail} for item in structured.awards if item.name or item.detail],
+                })
+            elif section == "languages" and structured.languages:
+                sections.append({
+                    "key": "languages",
+                    "title": "Languages",
+                    "items": [{"title": item.name, "meta": item.detail} for item in structured.languages if item.name or item.detail],
+                })
+            elif section == "interests" and structured.interests:
+                sections.append({
+                    "key": "interests",
+                    "title": "Interests",
+                    "items": [{"title": item.name, "meta": item.detail} for item in structured.interests if item.name or item.detail],
+                })
+        return sections
+
+    def _render_latex(self, structured: StructuredResume, family: str) -> str:
+        hidden = set(structured.hidden_sections)
+        header = self._render_header(structured.basics, family)
+        body: list[str] = [header]
+
+        for section in structured.section_order:
+            if section in hidden:
+                continue
+            rendered = ""
+            if section == "summary" and structured.basics.summary.strip():
+                rendered = self._section_block("Summary", [self._escape(structured.basics.summary.strip())], family)
+            elif section == "experience" and structured.experience:
+                rendered = self._experience_section(structured.experience, family)
+            elif section == "education" and structured.education:
+                rendered = self._education_section(structured.education, family)
+            elif section == "skills" and structured.skills:
+                rendered = self._skills_section(structured.skills, family)
+            elif section == "projects" and structured.projects:
+                rendered = self._projects_section(structured.projects, family)
+            elif section == "certifications" and structured.certifications:
+                rendered = self._named_list_section(
+                    "Certifications",
+                    [self._join_meta(item.name, item.issuer, item.date) for item in structured.certifications],
+                    family,
+                )
+            elif section == "awards" and structured.awards:
+                rendered = self._named_list_section(
+                    "Awards",
+                    [self._join_meta(item.name, item.detail) for item in structured.awards],
+                    family,
+                )
+            elif section == "languages" and structured.languages:
+                rendered = self._named_list_section(
+                    "Languages",
+                    [self._join_meta(item.name, item.detail) for item in structured.languages],
+                    family,
+                )
+            elif section == "interests" and structured.interests:
+                rendered = self._named_list_section(
+                    "Interests",
+                    [self._join_meta(item.name, item.detail) for item in structured.interests],
+                    family,
+                )
+            if rendered:
+                body.append(rendered)
+
+        document = [
+            r"\documentclass[11pt,letterpaper]{article}",
+            r"\usepackage[margin=0.65in]{geometry}",
+            r"\usepackage[T1]{fontenc}",
+            r"\usepackage[utf8]{inputenc}",
+            r"\usepackage{enumitem}",
+            r"\usepackage[hidelinks]{hyperref}",
+            r"\usepackage{xcolor}",
+            r"\setlist[itemize]{leftmargin=1.2em, itemsep=0.15em, topsep=0.15em}",
+            r"\pagestyle{empty}",
+            r"\setlength{\parindent}{0pt}",
+            r"\begin{document}",
+            *body,
+            r"\end{document}",
+        ]
+        return "\n".join(document)
+
+    def _render_header(self, basics: BuilderBasics, family: str) -> str:
+        name = self._escape(basics.name or "Your Name")
+        label = self._escape(basics.label)
+        parts = [part for part in [basics.email, basics.phone, basics.location, basics.website, basics.linkedin, basics.github] if part]
+        escaped_parts = [self._escape(part) for part in parts]
+        if family == "executive":
+            lines = [
+                rf"{{\Huge\bfseries {name}}}\\[4pt]",
+                rf"{{\large {label}}}\\[6pt]" if label else "",
+                r"\color{gray}",
+                r" \quad $|$ \quad ".join(escaped_parts) + r"\\[2pt]" if escaped_parts else "",
+                r"\color{black}",
+            ]
+            return "\n".join(line for line in lines if line)
+        if family == "ats":
+            lines = [rf"{{\Large\textbf{{{name}}}}}\\[2pt]"]
+            if label:
+                lines.append(self._escape(label) + r"\\[2pt]")
+            if escaped_parts:
+                lines.append(r" \quad | \quad ".join(escaped_parts) + r"\\[4pt]")
+            return "\n".join(lines)
+        lines = [
+            r"\begin{center}",
+            rf"{{\LARGE\textbf{{{name}}}}}\\[2pt]",
+            rf"{{\small {label}}}\\[2pt]" if label else "",
+            r" \quad • \quad ".join(escaped_parts) + r"\\" if escaped_parts else "",
+            r"\end{center}",
+        ]
+        return "\n".join(line for line in lines if line)
+
+    def _section_block(self, title: str, lines: List[str], family: str) -> str:
+        heading = self._section_heading(title, family)
+        return "\n".join([heading, *lines, ""])
+
+    def _section_heading(self, title: str, family: str) -> str:
+        escaped = self._escape(title)
+        if family == "executive":
+            return rf"\vspace{{0.7em}}\textcolor{{gray}}{{\textbf{{{escaped}}}}}\\[-0.3em]\hrule\vspace{{0.35em}}"
+        return rf"\section*{{{escaped}}}\vspace{{-0.4em}}\hrule\vspace{{0.25em}}"
+
+    def _experience_section(self, items: List[BuilderExperienceEntry], family: str) -> str:
+        lines = [self._section_heading("Experience", family)]
+        for item in items:
+            title = self._escape(item.title)
+            company = self._escape(item.company)
+            date_range = self._escape(self._date_range(item.start_date, item.end_date, item.current))
+            location = self._escape(item.location)
+            lines.append(rf"\textbf{{{title}}} \hfill {date_range}\\")
+            secondary = self._join_meta(company, location)
+            if secondary:
+                lines.append(rf"\textit{{{self._escape(secondary)}}}\\")
+            if item.summary.strip():
+                lines.append(self._escape(item.summary.strip()) + r"\\")
+            bullets = [bullet for bullet in item.bullets if bullet.strip()]
+            if bullets:
+                lines.append(r"\begin{itemize}")
+                lines.extend(rf"  \item {self._escape(bullet)}" for bullet in bullets)
+                lines.append(r"\end{itemize}")
+            elif item.technologies:
+                lines.append(rf"\textit{{Technologies:}} {self._escape(', '.join(item.technologies))}\\")
+            lines.append("")
+        return "\n".join(lines)
+
+    def _education_section(self, items: List[BuilderEducationEntry], family: str) -> str:
+        lines = [self._section_heading("Education", family)]
+        for item in items:
+            primary = self._join_meta(item.degree, item.field)
+            lines.append(rf"\textbf{{{self._escape(item.institution)}}} \hfill {self._escape(self._date_range(item.start_date, item.end_date, False))}\\")
+            if primary:
+                lines.append(self._escape(primary) + r"\\")
+            detail = self._join_meta(item.location, f"GPA {item.gpa}" if item.gpa else "")
+            if detail:
+                lines.append(self._escape(detail) + r"\\")
+            if item.highlights:
+                lines.append(r"\begin{itemize}")
+                lines.extend(rf"  \item {self._escape(highlight)}" for highlight in item.highlights if highlight.strip())
+                lines.append(r"\end{itemize}")
+            lines.append("")
+        return "\n".join(lines)
+
+    def _skills_section(self, items: List[BuilderSkillGroup], family: str) -> str:
+        lines = [self._section_heading("Skills", family)]
+        for group in items:
+            if not group.keywords:
+                continue
+            name = self._escape(group.name or "Skills")
+            keywords = self._escape(", ".join(group.keywords))
+            lines.append(rf"\textbf{{{name}:}} {keywords}\\")
+        lines.append("")
+        return "\n".join(lines)
+
+    def _projects_section(self, items: List[BuilderProjectEntry], family: str) -> str:
+        lines = [self._section_heading("Projects", family)]
+        for item in items:
+            lines.append(rf"\textbf{{{self._escape(item.name)}}} \hfill {self._escape(self._date_range(item.start_date, item.end_date, False))}\\")
+            secondary = self._join_meta(item.role, item.url)
+            if secondary:
+                lines.append(self._escape(secondary) + r"\\")
+            details = ([item.description] if item.description.strip() else []) + [bullet for bullet in item.bullets if bullet.strip()]
+            if details:
+                lines.append(r"\begin{itemize}")
+                lines.extend(rf"  \item {self._escape(detail)}" for detail in details)
+                lines.append(r"\end{itemize}")
+            if item.technologies:
+                lines.append(rf"\textit{{Technologies:}} {self._escape(', '.join(item.technologies))}\\")
+            lines.append("")
+        return "\n".join(lines)
+
+    def _named_list_section(self, title: str, entries: List[str], family: str) -> str:
+        values = [entry for entry in entries if entry.strip()]
+        if not values:
+            return ""
+        lines = [self._section_heading(title, family), r"\begin{itemize}"]
+        lines.extend(rf"  \item {self._escape(entry)}" for entry in values)
+        lines.append(r"\end{itemize}")
+        lines.append("")
+        return "\n".join(lines)
+
+    def _date_range(self, start_date: str, end_date: str, current: bool) -> str:
+        if start_date and (end_date or current):
+            return f"{start_date} - {'Present' if current else end_date}"
+        return start_date or end_date or ""
+
+    def _join_meta(self, *parts: str) -> str:
+        cleaned = [part.strip() for part in parts if part and part.strip()]
+        return " | ".join(cleaned)
+
+    def _escape(self, text: str) -> str:
+        if not text:
+            return ""
+        escaped = text
+        for src, target in self._escape_table.items():
+            escaped = escaped.replace(src, target)
+        escaped = re.sub(r"\s+", " ", escaped)
+        return escaped.strip()
+
+
+resume_builder_service = ResumeBuilderService()

--- a/backend/app/workers/latex_worker.py
+++ b/backend/app/workers/latex_worker.py
@@ -35,6 +35,11 @@ _ALLOWED_EXTRA_FLAGS = {
 # Note: --synctex=1, --interaction=nonstopmode, --halt-on-error are already hardcoded
 
 _MAIN_FILE_RE = re.compile(r"^[a-zA-Z0-9_-]+\.tex$")
+_HOST_PDFTOTEXT_CANDIDATES = (
+    "/opt/homebrew/bin/pdftotext",
+    "/usr/local/bin/pdftotext",
+    "/usr/bin/pdftotext",
+)
 
 # Watermark validation
 _WATERMARK_RE = re.compile(r"^[A-Za-z0-9 \-\.]+$")
@@ -70,6 +75,90 @@ def _inject_packages(latex_content: str, packages: list) -> str:
     if not lines_to_insert:
         return latex_content
     return latex_content[:insert_pos] + "\n".join(lines_to_insert) + "\n" + latex_content[insert_pos:]
+
+
+def _extract_pdf_text(pdf_file: Path, job_dir: Path, use_docker: bool) -> Optional[str]:
+    """Extract PDF text with bounded retries and a pure-Python fallback."""
+    candidate_commands: list[list[str]] = []
+    seen: set[tuple[str, ...]] = set()
+
+    host_binary = shutil.which("pdftotext")
+    for binary in [host_binary, *_HOST_PDFTOTEXT_CANDIDATES]:
+        if not binary:
+            continue
+        cmd = [binary, "-layout", str(pdf_file), "-"]
+        key = tuple(cmd)
+        if key not in seen:
+            seen.add(key)
+            candidate_commands.append(cmd)
+
+    if use_docker:
+        docker_cmd = [
+            "docker", "run", "--rm",
+            "-v", f"{job_dir}:/workspace",
+            "-w", "/workspace",
+            settings.LATEX_DOCKER_IMAGE,
+            "pdftotext", "-layout", "/workspace/resume.pdf", "-",
+        ]
+        candidate_commands.append(docker_cmd)
+
+    # Docker bind mounts can make the output PDF visible before a first read
+    # returns meaningful text. Retry a few times before giving up.
+    for attempt, delay in enumerate((0.0, 0.25, 0.75), start=1):
+        if delay:
+            time.sleep(delay)
+
+        for cmd in candidate_commands:
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "pdftotext invocation failed",
+                    extra={"command": cmd[0], "attempt": attempt, "error": str(exc)},
+                )
+                continue
+
+            if result.returncode == 0 and result.stdout.strip():
+                if attempt > 1:
+                    logger.info(
+                        "Recovered PDF text extraction after retry",
+                        extra={"command": cmd[0], "attempt": attempt},
+                    )
+                return result.stdout
+
+            logger.warning(
+                "pdftotext returned no extracted text",
+                extra={
+                    "command": cmd[0],
+                    "attempt": attempt,
+                    "returncode": result.returncode,
+                    "stderr": (result.stderr or "")[:300],
+                },
+            )
+
+    try:
+        from pdfminer.high_level import extract_text as pdfminer_extract_text
+
+        extracted = pdfminer_extract_text(str(pdf_file))
+        if extracted.strip():
+            logger.info("Recovered PDF text extraction with pdfminer fallback")
+            return extracted
+    except Exception as exc:
+        logger.warning("pdfminer extraction failed", extra={"error": str(exc)})
+
+    return None
+
+
+def _finalize_failure(job_id: str, **result: Any) -> Dict[str, Any]:
+    """Persist a terminal failure result so REST polling can resolve it."""
+    payload = {"success": False, "job_id": job_id, **result}
+    publish_job_result(job_id, payload)
+    return payload
 
 
 @celery_app.task(
@@ -137,7 +226,7 @@ def compile_latex_task(
                 "error_message": error_msg,
                 "retryable": False,
             })
-            return {"success": False, "job_id": job_id, "error": error_msg}
+            return _finalize_failure(job_id, error=error_msg)
 
         # ── Apply compile settings ───────────────────────────────────
         _cs = compile_settings or {}
@@ -157,7 +246,7 @@ def compile_latex_task(
                     "error_message": error_msg,
                     "retryable": False,
                 })
-                return {"success": False, "job_id": job_id, "error": error_msg}
+                return _finalize_failure(job_id, error=error_msg)
             latex_content = _inject_watermark(latex_content, watermark)
 
         # Determine main .tex filename (validated regex, default resume.tex)
@@ -258,7 +347,7 @@ def compile_latex_task(
             if is_cancelled(job_id):
                 proc.kill()
                 publish_event(job_id, "job.cancelled", {})
-                return {"success": False, "job_id": job_id, "cancelled": True}
+                return _finalize_failure(job_id, cancelled=True)
 
             # ── Timeout check ────────────────────────────────────────
             if time.time() - start_time > timeout:
@@ -275,7 +364,7 @@ def compile_latex_task(
                     "user_plan": user_plan,
                     "retryable": False,
                 })
-                return {"success": False, "job_id": job_id, "error": "compile_timeout"}
+                return _finalize_failure(job_id, error="compile_timeout")
 
         proc.wait()
         compilation_time = time.time() - start_time
@@ -293,29 +382,7 @@ def compile_latex_task(
             pdf_size = pdf_file.stat().st_size
 
             # ── PDF text extraction for ATS pre-flight ───────────────
-            extracted_text: Optional[str] = None
-            try:
-                if _use_docker:
-                    pt_cmd = [
-                        "docker", "run", "--rm",
-                        "-v", f"{job_dir}:/workspace",
-                        "-w", "/workspace",
-                        settings.LATEX_DOCKER_IMAGE,
-                        "pdftotext", "-layout", "/workspace/resume.pdf", "-",
-                    ]
-                else:
-                    pt_cmd = ["pdftotext", "-layout", str(pdf_file), "-"]
-
-                pt_result = subprocess.run(
-                    pt_cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                )
-                if pt_result.returncode == 0 and pt_result.stdout.strip():
-                    extracted_text = pt_result.stdout
-            except Exception as pt_exc:
-                logger.error(f"pdftotext failed for job {job_id}: {pt_exc}")
+            extracted_text = _extract_pdf_text(pdf_file, job_dir, _use_docker)
 
             # For Beamer, slide_count == page_count (one PDF page per slide)
             slide_count = page_count if is_beamer else None
@@ -378,10 +445,10 @@ def compile_latex_task(
             "error_message": error_msg,
             "retryable": False,
         })
-        result = {"success": False, "job_id": job_id, "error": error_msg}
+        result: Dict[str, Any] = {"error": error_msg}
         if first_latex_error:
             result["latex_error_line"] = first_latex_error
-        return result
+        return _finalize_failure(job_id, **result)
 
     except SoftTimeLimitExceeded:
         logger.error(f"LaTeX task {task_id} hit soft time limit for job {job_id}")
@@ -397,7 +464,7 @@ def compile_latex_task(
             "user_plan": user_plan,
             "retryable": False,
         })
-        return {"success": False, "job_id": job_id, "error": "compile_timeout"}
+        return _finalize_failure(job_id, error="compile_timeout")
 
     except Exception as exc:
         logger.error(f"LaTeX task {task_id} raised: {exc}")
@@ -410,7 +477,7 @@ def compile_latex_task(
         })
         if retryable:
             raise self.retry(countdown=60, exc=exc)
-        return {"success": False, "job_id": job_id, "error": str(exc)}
+        return _finalize_failure(job_id, error=str(exc))
 
 
 # ------------------------------------------------------------------ #

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -128,6 +128,11 @@ async def test_engine():
             ("resumes", "archived_at"),
             ("resumes", "dropbox_sync_enabled"),
             ("resumes", "document_type"),
+            ("resumes", "structured_content"),
+            ("resumes", "structured_version"),
+            ("resumes", "selected_template_id"),
+            ("resumes", "content_source"),
+            ("resumes", "builder_status"),
         }
         for table_name, column_name in required_columns:
             result = await conn.execute(

--- a/backend/test/test_latex_worker.py
+++ b/backend/test/test_latex_worker.py
@@ -232,6 +232,63 @@ class TestLatexCompilationSuccess:
         log_events = [c for c in mock_publish.call_args_list if c.args[1] == "log.line"]
         assert len(log_events) == 1
 
+    def test_success_uses_host_pdftotext_when_available(self, mock_publish, mock_job_result, mock_cancelled, mock_validate_ok):
+        run_result = MagicMock(returncode=0, stdout="Extracted text", stderr="")
+        with (
+            patch("app.workers.latex_worker.subprocess.Popen", return_value=_make_popen(0, ["Compilation OK\n"])),
+            patch("app.workers.latex_worker.shutil.which", side_effect=lambda name: "/opt/homebrew/bin/pdftotext" if name == "pdftotext" else "/usr/bin/docker"),
+            patch("app.workers.latex_worker.subprocess.run", return_value=run_result) as mock_run,
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.stat", return_value=MagicMock(st_size=12345)),
+        ):
+            result = lw.compile_latex_task(VALID_LATEX, job_id=str(uuid.uuid4()))
+
+        assert result["extracted_text"] == "Extracted text"
+        assert mock_run.call_args.args[0][0] == "/opt/homebrew/bin/pdftotext"
+
+    def test_success_falls_back_when_first_pdftotext_attempt_returns_empty(self, mock_publish, mock_job_result, mock_cancelled, mock_validate_ok):
+        run_results = [
+            MagicMock(returncode=1, stdout="", stderr="missing binary"),
+            MagicMock(returncode=0, stdout="Recovered text", stderr=""),
+        ]
+        with (
+            patch("app.workers.latex_worker.subprocess.Popen", return_value=_make_popen(0, ["Compilation OK\n"])),
+            patch("app.workers.latex_worker.shutil.which", side_effect=lambda name: "/opt/homebrew/bin/pdftotext" if name == "pdftotext" else None),
+            patch("app.workers.latex_worker._HOST_PDFTOTEXT_CANDIDATES", ()),
+            patch("app.workers.latex_worker.subprocess.run", side_effect=run_results) as mock_run,
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.stat", return_value=MagicMock(st_size=12345)),
+        ):
+            result = lw.compile_latex_task(VALID_LATEX, job_id=str(uuid.uuid4()))
+
+        assert result["extracted_text"] == "Recovered text"
+        assert mock_run.call_count >= 2
+
+    def test_success_uses_pdfminer_after_pdftotext_retries_fail(self, mock_publish, mock_job_result, mock_cancelled, mock_validate_ok):
+        run_results = [
+            MagicMock(returncode=1, stdout="", stderr="missing text"),
+            MagicMock(returncode=1, stdout="", stderr="missing text"),
+            MagicMock(returncode=1, stdout="", stderr="missing text"),
+        ]
+        with (
+            patch("app.workers.latex_worker.subprocess.Popen", return_value=_make_popen(0, ["Compilation OK\n"])),
+            patch("app.workers.latex_worker.shutil.which", side_effect=lambda name: "/opt/homebrew/bin/pdftotext" if name == "pdftotext" else None),
+            patch("app.workers.latex_worker._HOST_PDFTOTEXT_CANDIDATES", ()),
+            patch("app.workers.latex_worker.subprocess.run", side_effect=run_results),
+            patch("pdfminer.high_level.extract_text", return_value="Recovered via pdfminer"),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.stat", return_value=MagicMock(st_size=12345)),
+        ):
+            result = lw.compile_latex_task(VALID_LATEX, job_id=str(uuid.uuid4()))
+
+        assert result["extracted_text"] == "Recovered via pdfminer"
+
 
 # ── Compilation failure (non-zero exit code) ──────────────────────────────────
 
@@ -248,6 +305,20 @@ class TestLatexCompilationFailure:
 
         types = [c.args[1] for c in mock_publish.call_args_list]
         assert "job.failed" in types
+
+    def test_nonzero_exit_code_persists_failed_result(self, mock_publish, mock_job_result, mock_cancelled, mock_validate_ok):
+        with (
+            patch("app.workers.latex_worker.subprocess.Popen", return_value=_make_popen(1, ["pdflatex error\n"])),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            lw.compile_latex_task(VALID_LATEX, job_id=str(uuid.uuid4()))
+
+        assert mock_job_result.call_count == 1
+        stored = mock_job_result.call_args.args[1]
+        assert stored["success"] is False
+        assert stored["error"].startswith("pdflatex exited with code")
 
     def test_nonzero_exit_code_returns_success_false(self, mock_publish, mock_job_result, mock_cancelled, mock_validate_ok):
         with (
@@ -313,6 +384,20 @@ class TestLatexCancellation:
 
         types = [c.args[1] for c in mock_publish.call_args_list]
         assert "job.cancelled" in types
+
+    def test_cancelled_persists_failed_result(self, mock_publish, mock_job_result, mock_validate_ok):
+        with (
+            patch("app.workers.latex_worker.is_cancelled", return_value=True),
+            patch("app.workers.latex_worker.subprocess.Popen", return_value=_make_popen(0, ["output\n"])),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            lw.compile_latex_task(VALID_LATEX, job_id=str(uuid.uuid4()))
+
+        stored = mock_job_result.call_args.args[1]
+        assert stored["success"] is False
+        assert stored["cancelled"] is True
 
     def test_cancelled_kills_process(self, mock_publish, mock_job_result, mock_validate_ok):
         mock_proc = _make_popen(0, ["output\n"])

--- a/backend/test/test_resume_builder.py
+++ b/backend/test/test_resume_builder.py
@@ -1,0 +1,167 @@
+import json
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from app.database.models import ResumeTemplate
+
+_SAMPLE_JSON_RESUME = json.dumps(
+    {
+        "basics": {
+            "name": "Taylor Builder",
+            "label": "Senior Backend Engineer",
+            "email": "taylor@example.com",
+            "phone": "+1-555-0102",
+            "url": "https://example.com",
+            "summary": "Backend engineer focused on distributed systems and observability.",
+            "profiles": [
+                {"network": "LinkedIn", "url": "https://linkedin.com/in/taylor"},
+                {"network": "GitHub", "url": "https://github.com/taylor"},
+            ],
+        },
+        "work": [
+            {
+                "name": "Acme",
+                "position": "Senior Backend Engineer",
+                "startDate": "2022-01",
+                "endDate": "",
+                "summary": "Platform engineering",
+                "highlights": ["Reduced p95 latency by 40%", "Owned API platform migration"],
+            }
+        ],
+        "education": [{"institution": "State University", "studyType": "B.S.", "area": "Computer Science", "endDate": "2020"}],
+        "skills": [{"name": "Languages", "keywords": ["Python", "TypeScript", "SQL"]}],
+        "projects": [{"name": "Internal Platform", "description": "Developer experience overhaul"}],
+    }
+)
+
+
+async def _insert_builder_template(db_session, category: str = "minimal") -> ResumeTemplate:
+    template = ResumeTemplate(
+        id=str(uuid.uuid4()),
+        name=f"test_tmpl_builder_{category}_{uuid.uuid4().hex[:6]}",
+        description="Builder-compatible test template",
+        category=category,
+        tags=[category],
+        latex_content=r"\documentclass{article}\begin{document}Template\end{document}",
+        is_active=True,
+        sort_order=0,
+        document_type="resume",
+    )
+    db_session.add(template)
+    await db_session.commit()
+    await db_session.refresh(template)
+    return template
+
+
+@pytest.mark.asyncio
+class TestResumeBuilder:
+    async def test_lists_supported_templates(self, client: AsyncClient, db_session):
+        template = await _insert_builder_template(db_session, category="minimal")
+        data = (await client.get("/resumes/builder/templates")).json()
+        assert any(item["id"] == template.id for item in data)
+
+    async def test_create_builder_resume(self, client: AsyncClient, auth_headers: dict, db_session):
+        template = await _insert_builder_template(db_session, category="software_engineering")
+        resp = await client.post(
+            "/resumes/builder",
+            headers=auth_headers,
+            json={
+                "title": "Builder Resume",
+                "template_id": template.id,
+                "structured_content": {
+                    "basics": {"name": "Taylor Builder", "email": "taylor@example.com", "label": "Backend Engineer"},
+                    "experience": [
+                        {
+                            "id": "exp-1",
+                            "title": "Backend Engineer",
+                            "company": "Acme",
+                            "start_date": "2022",
+                            "current": True,
+                            "bullets": ["Built resilient APIs"],
+                        }
+                    ],
+                    "education": [{"id": "edu-1", "institution": "State University", "degree": "B.S. Computer Science"}],
+                    "skills": [{"id": "skill-1", "name": "Languages", "keywords": ["Python", "Go"]}],
+                },
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["resume"]["builder_status"] == "active"
+        assert data["resume"]["content_source"] == "builder"
+        assert data["resume"]["selected_template_id"] == template.id
+        assert data["metrics"]["completeness_score"] > 0
+        assert "Taylor Builder" in data["resume"]["latex_content"]
+
+    async def test_get_and_update_builder_resume(self, client: AsyncClient, auth_headers: dict, db_session):
+        template = await _insert_builder_template(db_session, category="minimal")
+        create_resp = await client.post(
+            "/resumes/builder",
+            headers=auth_headers,
+            json={"title": "Editable Builder", "template_id": template.id},
+        )
+        resume_id = create_resp.json()["resume"]["id"]
+
+        fetched = await client.get(f"/resumes/{resume_id}/builder", headers=auth_headers)
+        assert fetched.status_code == 200
+
+        update_resp = await client.patch(
+            f"/resumes/{resume_id}/builder",
+            headers=auth_headers,
+            json={
+                "structured_content": {
+                    "basics": {"name": "Updated Name", "email": "updated@example.com", "summary": "Updated summary"},
+                    "skills": [{"id": "skill-1", "name": "Core", "keywords": ["Python", "React"]}],
+                }
+            },
+        )
+        assert update_resp.status_code == 200
+        updated = update_resp.json()
+        assert updated["resume"]["structured_version"] >= 2
+        assert updated["resume"]["structured_content"]["basics"]["name"] == "Updated Name"
+
+    async def test_manual_editor_update_detaches_builder(self, client: AsyncClient, auth_headers: dict, db_session):
+        template = await _insert_builder_template(db_session, category="ats_safe")
+        create_resp = await client.post(
+            "/resumes/builder",
+            headers=auth_headers,
+            json={"title": "Detach Builder", "template_id": template.id},
+        )
+        resume_id = create_resp.json()["resume"]["id"]
+
+        detach_resp = await client.put(
+            f"/resumes/{resume_id}",
+            headers=auth_headers,
+            json={"latex_content": r"\documentclass{article}\begin{document}Manual\end{document}"},
+        )
+        assert detach_resp.status_code == 200
+        assert detach_resp.json()["builder_status"] == "detached"
+
+        patch_resp = await client.patch(
+            f"/resumes/{resume_id}/builder",
+            headers=auth_headers,
+            json={"structured_content": {"basics": {"name": "Blocked"}}},
+        )
+        assert patch_resp.status_code == 409
+
+        reattach = await client.patch(
+            f"/resumes/{resume_id}/builder",
+            headers=auth_headers,
+            json={"structured_content": {"basics": {"name": "Reattached"}}, "force_reattach": True},
+        )
+        assert reattach.status_code == 200
+        assert reattach.json()["resume"]["builder_status"] == "active"
+
+    async def test_seed_upload_returns_structured_content(self, client: AsyncClient, auth_headers: dict):
+        resp = await client.post(
+            "/resumes/builder/seed-upload",
+            headers=auth_headers,
+            files={"file": ("resume.json", _SAMPLE_JSON_RESUME.encode(), "application/json")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["structured_content"]["basics"]["name"] == "Taylor Builder"
+        assert data["metrics"]["completeness_score"] > 0

--- a/frontend/e2e/resume-builder.spec.ts
+++ b/frontend/e2e/resume-builder.spec.ts
@@ -1,0 +1,318 @@
+import { expect, test } from '@playwright/test'
+
+import type {
+  BuilderResumeResponse,
+  BuilderSeedUploadResponse,
+  BuilderTemplateResponse,
+  StructuredResume,
+} from '../src/lib/api-client'
+
+const BUILDER_TEMPLATES: BuilderTemplateResponse[] = [
+  {
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'ATS Guided',
+    description: 'ATS-safe single column template',
+    category: 'ats_safe',
+    category_label: 'ATS-Safe',
+    sort_order: 0,
+    thumbnail_url: null,
+    pdf_url: null,
+    template_family: 'ats',
+  },
+  {
+    id: '22222222-2222-2222-2222-222222222222',
+    name: 'Executive Guided',
+    description: 'Executive-facing builder template',
+    category: 'executive',
+    category_label: 'Executive',
+    sort_order: 100,
+    thumbnail_url: null,
+    pdf_url: null,
+    template_family: 'executive',
+  },
+]
+
+const SEEDED_STRUCTURED: StructuredResume = {
+  basics: {
+    name: 'Taylor Builder',
+    label: 'Senior Backend Engineer',
+    email: 'taylor@example.com',
+    phone: '+1-555-0102',
+    location: 'Remote',
+    website: 'https://example.com',
+    linkedin: 'linkedin.com/in/taylor',
+    github: 'github.com/taylor',
+    summary: 'Backend engineer focused on reliability, distributed systems, and observability.',
+  },
+  experience: [
+    {
+      id: 'exp-1',
+      title: 'Senior Backend Engineer',
+      company: 'Acme',
+      location: 'Remote',
+      start_date: '2022',
+      end_date: '',
+      current: true,
+      summary: '',
+      bullets: ['Reduced p95 latency by 40%', 'Led API platform migration'],
+      technologies: ['Python', 'PostgreSQL'],
+    },
+  ],
+  education: [
+    {
+      id: 'edu-1',
+      institution: 'State University',
+      degree: 'B.S. Computer Science',
+      field: '',
+      location: '',
+      start_date: '',
+      end_date: '2020',
+      gpa: '',
+      highlights: [],
+    },
+  ],
+  projects: [],
+  skills: [{ id: 'skill-1', name: 'Core Skills', keywords: ['Python', 'Go', 'Distributed Systems'] }],
+  certifications: [],
+  awards: [],
+  languages: [],
+  interests: [],
+  section_order: ['summary', 'experience', 'education', 'skills', 'projects', 'certifications', 'awards', 'languages', 'interests'],
+  hidden_sections: [],
+}
+
+function builderResponse(overrides?: Partial<BuilderResumeResponse>): BuilderResumeResponse {
+  return {
+    resume: {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      user_id: 'user-1',
+      title: 'Builder Resume',
+      latex_content: '\\documentclass{article}\\begin{document}Builder\\end{document}',
+      is_template: false,
+      parent_resume_id: null,
+      variant_count: 0,
+      selected_template_id: BUILDER_TEMPLATES[0].id,
+      content_source: 'builder',
+      builder_status: 'active',
+      structured_content: SEEDED_STRUCTURED,
+      structured_version: 1,
+      created_at: '2026-05-29T00:00:00Z',
+      updated_at: '2026-05-29T00:00:00Z',
+      document_type: 'resume',
+      metadata: {},
+    },
+    metrics: {
+      completeness_score: 84,
+      page_estimate: 1,
+      warnings: [],
+      missing_sections: [],
+    },
+    preview: {
+      template_family: 'ats',
+      sections: [
+        { key: 'summary', title: 'Summary', items: [SEEDED_STRUCTURED.basics.summary] },
+        {
+          key: 'experience',
+          title: 'Experience',
+          items: [
+            {
+              title: 'Senior Backend Engineer — Acme',
+              meta: 'Remote | 2022 - Present',
+              bullets: ['Reduced p95 latency by 40%', 'Led API platform migration'],
+            },
+          ],
+        },
+      ],
+    },
+    template_family: 'ats',
+    ...overrides,
+  }
+}
+
+async function mockSession(page: Parameters<typeof test.beforeEach>[0]['page']) {
+  await page.route('**/api/auth/get-session', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session: { id: 'sess-1', userId: 'user-1', token: 'token', expiresAt: '2099-01-01T00:00:00Z' },
+        user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      }),
+    }),
+  )
+}
+
+test.describe('Guided Resume Builder', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSession(page)
+    await page.route('**/ws/**', route => route.abort())
+  })
+
+  test('workspace/new promotes the guided builder entry', async ({ page }) => {
+    await page.goto('/workspace/new')
+    await expect(page.getByRole('heading', { name: 'Guided Builder' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Open Guided Builder' })).toHaveAttribute('href', '/workspace/builder/new')
+  })
+
+  test('builder new flow loads templates, seeds upload, and creates a draft', async ({ page }) => {
+    const seededResponse: BuilderSeedUploadResponse = {
+      success: true,
+      filename: 'resume.json',
+      format: 'json',
+      structured_content: SEEDED_STRUCTURED,
+      metrics: {
+        completeness_score: 82,
+        page_estimate: 1,
+        warnings: [],
+        missing_sections: [],
+      },
+    }
+
+    await page.route('**/resumes/builder/templates', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(BUILDER_TEMPLATES) }),
+    )
+    await page.route('**/resumes/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builder', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(builderResponse()),
+      }),
+    )
+    await page.route('**/resumes/builder/seed-upload', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(seededResponse) }),
+    )
+    await page.route('**/resumes/builder', async route => {
+      if (route.request().method() !== 'POST') return route.fallback()
+      const body = await route.request().postDataJSON()
+      expect(body.title).toBe('Taylor Core Resume')
+      expect(body.template_id).toBe(BUILDER_TEMPLATES[0].id)
+      expect(body.structured_content.basics.name).toBe('Taylor Builder')
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(builderResponse()),
+      })
+    })
+
+    await page.goto('/workspace/builder/new')
+    await expect(page.getByRole('heading', { name: 'Build from structured content' })).toBeVisible()
+    await expect(page.getByText('1. Seed')).toBeVisible()
+    await expect(page.getByRole('button', { name: /ATS-Safe ATS Guided/i })).toBeVisible()
+
+    await page.locator('input[placeholder*="Senior Backend Engineer"]').fill('Taylor Core Resume')
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'resume.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from('{"resume":"seed"}'),
+    })
+
+    await expect(page.getByText('Taylor Builder')).toBeVisible()
+    await page.getByRole('button', { name: 'Start Guided Builder' }).click()
+    await expect(page).toHaveURL(/\/workspace\/builder\/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa$/)
+  })
+
+  test('builder editor autosaves structured changes and supports template swaps', async ({ page }) => {
+    let currentTemplateId = BUILDER_TEMPLATES[0].id
+    let currentName = SEEDED_STRUCTURED.basics.name
+
+    await page.route('**/resumes/builder/templates', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(BUILDER_TEMPLATES) }),
+    )
+    await page.route('**/resumes/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builder', async route => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(builderResponse()),
+        })
+      }
+      if (route.request().method() === 'PATCH') {
+        const body = await route.request().postDataJSON()
+        currentTemplateId = body.template_id ?? currentTemplateId
+        currentName = body.structured_content?.basics?.name ?? currentName
+        const selectedTemplate = BUILDER_TEMPLATES.find(template => template.id === currentTemplateId) ?? BUILDER_TEMPLATES[0]
+        const response = builderResponse({
+          resume: {
+            ...builderResponse().resume,
+            selected_template_id: currentTemplateId,
+            structured_version: 2,
+            structured_content: {
+              ...SEEDED_STRUCTURED,
+              basics: { ...SEEDED_STRUCTURED.basics, name: currentName },
+            },
+          },
+          template_family: selectedTemplate.template_family,
+          preview: {
+            ...builderResponse().preview,
+            template_family: selectedTemplate.template_family,
+          },
+        })
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(response),
+        })
+      }
+      return route.fallback()
+    })
+
+    await page.goto('/workspace/builder/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    await expect(page.getByRole('heading', { name: 'Builder Resume' })).toBeVisible()
+    await expect(page.getByText('Resume Health')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Certifications' })).toBeVisible()
+    await expect(page.getByText('All changes saved')).toBeVisible()
+
+    await page.getByLabel('Full Name').fill('Taylor Builder Updated')
+    await expect(page.getByText('Unsaved changes')).toBeVisible()
+    await expect(page.getByText('Taylor Builder Updated')).toBeVisible()
+    await expect(page.getByText('All changes saved')).toBeVisible({ timeout: 8000 })
+
+    await page.getByRole('button', { name: 'Add certification' }).click()
+    const certificationCard = page
+      .getByRole('button', { name: 'Remove certification' })
+      .locator('xpath=ancestor::div[contains(@class, "rounded-2xl")][1]')
+    await certificationCard.locator('input').nth(0).fill('AWS Certified Developer')
+    await expect(page.getByText('AWS Certified Developer')).toBeVisible()
+
+    await page.locator('select').selectOption(BUILDER_TEMPLATES[1].id)
+    await expect(page.getByText('Unsaved changes')).toBeVisible()
+    await expect(page.getByText('All changes saved')).toBeVisible({ timeout: 8000 })
+    await expect(page.getByLabel('Template')).toHaveValue(BUILDER_TEMPLATES[1].id)
+    await expect(page.getByText('Family: executive · Executive')).toBeVisible()
+  })
+
+  test('detached builder state exposes explicit reattach action', async ({ page }) => {
+    await page.route('**/resumes/builder/templates', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(BUILDER_TEMPLATES) }),
+    )
+    await page.route('**/resumes/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builder', async route => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(builderResponse({
+            resume: {
+              ...builderResponse().resume,
+              builder_status: 'detached',
+            },
+          })),
+        })
+      }
+      if (route.request().method() === 'PATCH') {
+        const body = await route.request().postDataJSON()
+        expect(body.force_reattach).toBe(true)
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(builderResponse()),
+        })
+      }
+      return route.fallback()
+    })
+
+    await page.goto('/workspace/builder/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    await expect(page.getByText('Builder detached')).toBeVisible()
+    await page.getByRole('button', { name: /Reattach Builder/ }).click()
+    await expect(page.getByText('Builder detached')).not.toBeVisible()
+  })
+})

--- a/frontend/src/app/workspace/builder/[resumeId]/page.tsx
+++ b/frontend/src/app/workspace/builder/[resumeId]/page.tsx
@@ -1,0 +1,1301 @@
+'use client'
+
+import Link from 'next/link'
+import { useParams, useRouter } from 'next/navigation'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ArrowDown,
+  ArrowUp,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  FileText,
+  LayoutList,
+  Plus,
+  RefreshCcw,
+  Sparkles,
+  Target,
+  Wand2,
+} from 'lucide-react'
+import { toast } from 'sonner'
+
+import BuilderPreview from '@/components/builder/BuilderPreview'
+import {
+  apiClient,
+  type BuilderTemplateResponse,
+  type StructuredResume,
+} from '@/lib/api-client'
+import {
+  cloneStructuredResume,
+  createBuilderId,
+  DEFAULT_STRUCTURED_RESUME,
+  deriveBuilderMetrics,
+  deriveBuilderPreview,
+} from '@/lib/resume-builder'
+
+type SectionKey = StructuredResume['section_order'][number]
+
+type SectionConfig = {
+  key: SectionKey
+  title: string
+  description: string
+  emptyHint: string
+}
+
+const SECTION_CONFIG: SectionConfig[] = [
+  {
+    key: 'summary',
+    title: 'Profile & Summary',
+    description: 'Lock the headline, contact details, and the first five seconds of the resume.',
+    emptyHint: 'Add name, headline, and a short summary to make the preview immediately usable.',
+  },
+  {
+    key: 'experience',
+    title: 'Experience',
+    description: 'Lead with impact, measurable outcomes, and role progression.',
+    emptyHint: 'Add at least one recent role with results-oriented bullets.',
+  },
+  {
+    key: 'education',
+    title: 'Education',
+    description: 'Capture degree signal, timeline, and any highlights worth keeping.',
+    emptyHint: 'Add one education entry, even for experienced resumes.',
+  },
+  {
+    key: 'skills',
+    title: 'Skills',
+    description: 'Group keywords by capability so ATS and recruiters can skim quickly.',
+    emptyHint: 'Create at least one skill group with relevant keywords.',
+  },
+  {
+    key: 'projects',
+    title: 'Projects',
+    description: 'Use this when shipped work deserves explicit spotlight beyond job bullets.',
+    emptyHint: 'Add a project if it meaningfully strengthens the narrative.',
+  },
+  {
+    key: 'certifications',
+    title: 'Certifications',
+    description: 'Useful for cloud, security, finance, and other trust-heavy roles.',
+    emptyHint: 'Skip unless it materially supports the target job.',
+  },
+  {
+    key: 'awards',
+    title: 'Awards',
+    description: 'Keep only proof points that add signal rather than vanity.',
+    emptyHint: 'Optional section for standout recognition.',
+  },
+  {
+    key: 'languages',
+    title: 'Languages',
+    description: 'List only real working proficiency or market-relevant fluency.',
+    emptyHint: 'Useful for global, customer-facing, and multilingual roles.',
+  },
+  {
+    key: 'interests',
+    title: 'Interests',
+    description: 'Add sparingly when it makes the candidate more memorable or aligned.',
+    emptyHint: 'Usually optional. Use only if it helps the story.',
+  },
+]
+
+function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return <div className={`rounded-2xl border border-white/8 bg-black/20 p-4 ${className}`}>{children}</div>
+}
+
+function FieldLabel({ htmlFor, children }: { htmlFor?: string; children: React.ReactNode }) {
+  return (
+    <label htmlFor={htmlFor} className="mb-2 block text-xs uppercase tracking-[0.14em] text-zinc-500">
+      {children}
+    </label>
+  )
+}
+
+function TextInput(
+  props: React.InputHTMLAttributes<HTMLInputElement> & {
+    id?: string
+  },
+) {
+  return (
+    <input
+      {...props}
+      className={`w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition focus:border-orange-300/50 ${props.className ?? ''}`}
+    />
+  )
+}
+
+function TextArea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      {...props}
+      className={`w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition focus:border-orange-300/50 ${props.className ?? ''}`}
+    />
+  )
+}
+
+function SectionHeader({
+  title,
+  sectionKey,
+  description,
+  order,
+  hidden,
+  onMove,
+  onToggleHidden,
+}: {
+  title: string
+  sectionKey: SectionKey
+  description: string
+  order: string[]
+  hidden: boolean
+  onMove: (sectionKey: SectionKey, direction: -1 | 1) => void
+  onToggleHidden: (sectionKey: SectionKey) => void
+}) {
+  const idx = order.indexOf(sectionKey)
+  return (
+    <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
+      <div>
+        <p className="text-lg font-semibold text-white">{title}</p>
+        <p className="mt-1 max-w-2xl text-sm text-zinc-400">{description}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <button type="button" onClick={() => onMove(sectionKey, -1)} disabled={idx <= 0} className="btn-ghost px-2 py-2 text-xs disabled:opacity-30">
+          <ArrowUp className="h-3.5 w-3.5" />
+        </button>
+        <button type="button" onClick={() => onMove(sectionKey, 1)} disabled={idx === -1 || idx >= order.length - 1} className="btn-ghost px-2 py-2 text-xs disabled:opacity-30">
+          <ArrowDown className="h-3.5 w-3.5" />
+        </button>
+        <button type="button" onClick={() => onToggleHidden(sectionKey)} className="btn-ghost px-2 py-2 text-xs">
+          {hidden ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function StarterChip({
+  label,
+  onClick,
+}: {
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-[11px] uppercase tracking-[0.16em] text-zinc-300 transition hover:bg-white/[0.08]"
+    >
+      {label}
+    </button>
+  )
+}
+
+function joinComma(value: string[]) {
+  return value.join(', ')
+}
+
+function splitComma(value: string) {
+  return value.split(',').map(item => item.trim()).filter(Boolean)
+}
+
+function splitLines(value: string) {
+  return value.split('\n').map(item => item.trim()).filter(Boolean)
+}
+
+function sectionCount(structured: StructuredResume, section: SectionKey) {
+  switch (section) {
+    case 'summary':
+      return Number(Boolean(structured.basics.summary.trim() || structured.basics.name.trim() || structured.basics.label.trim()))
+    case 'experience':
+      return structured.experience.length
+    case 'education':
+      return structured.education.length
+    case 'skills':
+      return structured.skills.length
+    case 'projects':
+      return structured.projects.length
+    case 'certifications':
+      return structured.certifications.length
+    case 'awards':
+      return structured.awards.length
+    case 'languages':
+      return structured.languages.length
+    case 'interests':
+      return structured.interests.length
+  }
+}
+
+function sectionReady(structured: StructuredResume, section: SectionKey) {
+  switch (section) {
+    case 'summary':
+      return Boolean(structured.basics.name.trim() && structured.basics.summary.trim())
+    case 'experience':
+      return structured.experience.some(item => item.title.trim() && item.company.trim() && item.bullets.some(bullet => bullet.trim()))
+    case 'education':
+      return structured.education.some(item => item.institution.trim() && item.degree.trim())
+    case 'skills':
+      return structured.skills.some(item => item.name.trim() && item.keywords.length)
+    case 'projects':
+      return structured.projects.some(item => item.name.trim() && (item.description.trim() || item.bullets.some(bullet => bullet.trim())))
+    case 'certifications':
+      return structured.certifications.some(item => item.name.trim())
+    case 'awards':
+      return structured.awards.some(item => item.name.trim())
+    case 'languages':
+      return structured.languages.some(item => item.name.trim())
+    case 'interests':
+      return structured.interests.some(item => item.name.trim())
+  }
+}
+
+export default function BuilderResumePage() {
+  const params = useParams<{ resumeId: string }>()
+  const router = useRouter()
+  const resumeId = params.resumeId
+
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [dirty, setDirty] = useState(false)
+  const [templates, setTemplates] = useState<BuilderTemplateResponse[]>([])
+  const [title, setTitle] = useState('')
+  const [selectedTemplateId, setSelectedTemplateId] = useState('')
+  const [structured, setStructured] = useState<StructuredResume>(cloneStructuredResume(DEFAULT_STRUCTURED_RESUME))
+  const [templateFamily, setTemplateFamily] = useState('minimal')
+  const [builderStatus, setBuilderStatus] = useState<'active' | 'detached'>('active')
+  const [activeSection, setActiveSection] = useState<SectionKey>('summary')
+  const initialLoad = useRef(true)
+  const sectionRefs = useRef<Partial<Record<SectionKey, HTMLElement | null>>>({})
+
+  const liveMetrics = useMemo(() => deriveBuilderMetrics(structured), [structured])
+  const livePreview = useMemo(
+    () => deriveBuilderPreview(structured, templateFamily),
+    [structured, templateFamily],
+  )
+
+  const completenessScore = liveMetrics.completeness_score
+  const pageEstimate = liveMetrics.page_estimate
+  const warnings = liveMetrics.warnings
+  const missingSections = liveMetrics.missing_sections
+
+  const selectedTemplate = useMemo(
+    () => templates.find(template => template.id === selectedTemplateId) ?? null,
+    [selectedTemplateId, templates],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([apiClient.getBuilderResume(resumeId), apiClient.getBuilderTemplates()])
+      .then(([builder, availableTemplates]) => {
+        if (cancelled) return
+        setTemplates(availableTemplates)
+        setTitle(builder.resume.title)
+        setSelectedTemplateId(builder.resume.selected_template_id ?? availableTemplates[0]?.id ?? '')
+        setStructured(cloneStructuredResume(builder.resume.structured_content ?? DEFAULT_STRUCTURED_RESUME))
+        setTemplateFamily(builder.template_family)
+        setBuilderStatus((builder.resume.builder_status ?? 'active') as 'active' | 'detached')
+      })
+      .catch(error => {
+        toast.error(error instanceof Error ? error.message : 'Failed to load builder resume')
+        router.push('/workspace')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [resumeId, router])
+
+  useEffect(() => {
+    if (initialLoad.current) {
+      initialLoad.current = false
+      return
+    }
+    if (!dirty || builderStatus === 'detached') return
+    const timeout = window.setTimeout(async () => {
+      setSaving(true)
+      try {
+        const updated = await apiClient.updateBuilderResume(resumeId, {
+          title,
+          template_id: selectedTemplateId,
+          structured_content: structured,
+        })
+        setTemplateFamily(updated.template_family)
+        setBuilderStatus((updated.resume.builder_status ?? 'active') as 'active' | 'detached')
+        setDirty(false)
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Autosave failed')
+      } finally {
+        setSaving(false)
+      }
+    }, 600)
+    return () => window.clearTimeout(timeout)
+  }, [dirty, structured, title, selectedTemplateId, resumeId, builderStatus])
+
+  const mutateStructured = (mutator: (draft: StructuredResume) => void) => {
+    setStructured(prev => {
+      const next = cloneStructuredResume(prev)
+      mutator(next)
+      return next
+    })
+    setDirty(true)
+  }
+
+  const moveSection = (sectionKey: SectionKey, direction: -1 | 1) => {
+    mutateStructured(draft => {
+      const currentIndex = draft.section_order.indexOf(sectionKey)
+      const targetIndex = currentIndex + direction
+      if (currentIndex < 0 || targetIndex < 0 || targetIndex >= draft.section_order.length) return
+      const [item] = draft.section_order.splice(currentIndex, 1)
+      draft.section_order.splice(targetIndex, 0, item)
+    })
+  }
+
+  const toggleHidden = (sectionKey: SectionKey) => {
+    mutateStructured(draft => {
+      if (draft.hidden_sections.includes(sectionKey)) {
+        draft.hidden_sections = draft.hidden_sections.filter(section => section !== sectionKey)
+      } else {
+        draft.hidden_sections = [...draft.hidden_sections, sectionKey]
+      }
+    })
+  }
+
+  const forceReattach = async () => {
+    setSaving(true)
+    try {
+      const updated = await apiClient.updateBuilderResume(resumeId, {
+        title,
+        template_id: selectedTemplateId,
+        structured_content: structured,
+        force_reattach: true,
+      })
+      setTemplateFamily(updated.template_family)
+      setBuilderStatus('active')
+      setDirty(false)
+      toast.success('Builder reattached and LaTeX overwritten from structured data')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to reattach builder')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const jumpToSection = (section: SectionKey) => {
+    setActiveSection(section)
+    sectionRefs.current[section]?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  const visibleSections = useMemo(
+    () => structured.section_order.filter(section => !structured.hidden_sections.includes(section)),
+    [structured.section_order, structured.hidden_sections],
+  )
+
+  const healthTone = completenessScore >= 85
+    ? 'border-emerald-300/20 bg-emerald-300/[0.08] text-emerald-100'
+    : completenessScore >= 65
+      ? 'border-amber-300/20 bg-amber-300/[0.08] text-amber-100'
+      : 'border-rose-300/20 bg-rose-300/[0.08] text-rose-100'
+
+  if (loading) {
+    return <div className="content-shell py-16 text-sm text-zinc-400">Loading builder…</div>
+  }
+
+  const hidden = new Set(structured.hidden_sections)
+  const missingSet = new Set(missingSections)
+
+  return (
+    <div className="content-shell space-y-8 pb-16">
+      <header className="flex flex-wrap items-end justify-between gap-4 pt-2">
+        <div>
+          <p className="overline">Guided Builder</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">{title || 'Untitled Resume'}</h1>
+          <p className="mt-2 max-w-3xl text-sm text-zinc-400">
+            This builder is now the structured path: guide the narrative, tune density, and keep LaTeX synchronized
+            without treating the resume like a raw text file.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link href={`/workspace/${resumeId}/edit`} className="btn-ghost px-4 py-2 text-xs">
+            Open Advanced Editor
+          </Link>
+          <div className="rounded-full border border-white/10 px-3 py-2 text-xs text-zinc-400">
+            {saving ? 'Saving…' : dirty ? 'Unsaved changes' : 'All changes saved'}
+          </div>
+        </div>
+      </header>
+
+      {builderStatus === 'detached' ? (
+        <section className="surface-panel edge-highlight border border-amber-300/20 bg-amber-300/[0.05] p-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-sm font-semibold text-amber-100">Builder detached</p>
+              <p className="mt-1 text-sm text-amber-50/80">
+                This resume was edited directly in the advanced editor. Structured changes are paused until you explicitly
+                overwrite the current LaTeX from builder data.
+              </p>
+            </div>
+            <button type="button" onClick={() => void forceReattach()} className="btn-accent px-4 py-2 text-xs">
+              <RefreshCcw className="mr-2 inline h-3.5 w-3.5" />
+              Reattach Builder
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="grid gap-4 lg:grid-cols-4">
+        <Card className={healthTone}>
+          <p className="text-xs uppercase tracking-[0.14em] opacity-70">Resume Health</p>
+          <p className="mt-2 text-3xl font-semibold">{completenessScore}%</p>
+          <p className="mt-2 text-sm opacity-85">
+            {missingSections.length
+              ? `${missingSections.length} key area${missingSections.length === 1 ? '' : 's'} still weak or missing.`
+              : 'Core sections are covered and preview-ready.'}
+          </p>
+        </Card>
+        <Card>
+          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Page Strategy</p>
+          <p className="mt-2 text-3xl font-semibold text-white">{pageEstimate}</p>
+          <p className="mt-2 text-sm text-zinc-400">
+            {pageEstimate > 1 ? 'Trim bullets and optional sections to stay tighter.' : 'Compact enough for the most common one-page target.'}
+          </p>
+        </Card>
+        <Card>
+          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Visible Sections</p>
+          <p className="mt-2 text-3xl font-semibold text-white">{visibleSections.length}</p>
+          <p className="mt-2 text-sm text-zinc-400">
+            {structured.hidden_sections.length
+              ? `${structured.hidden_sections.length} section${structured.hidden_sections.length === 1 ? '' : 's'} hidden from the rendered resume.`
+              : 'All configured sections are currently visible.'}
+          </p>
+        </Card>
+        <Card>
+          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Current Template</p>
+          <p className="mt-2 text-lg font-semibold text-white">{selectedTemplate?.name || 'Template'}</p>
+          <p className="mt-2 text-sm text-zinc-400">
+            Family: {selectedTemplate?.template_family || templateFamily} · {selectedTemplate?.category_label || 'Builder'}
+          </p>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[260px_minmax(0,1fr)_420px]">
+        <aside className="space-y-4">
+          <Card className="sticky top-24">
+            <div className="flex items-center gap-2 text-sm font-semibold text-white">
+              <LayoutList className="h-4 w-4 text-orange-300" />
+              Builder Flow
+            </div>
+            <div className="mt-4 space-y-2">
+              {SECTION_CONFIG.map(section => {
+                const count = sectionCount(structured, section.key)
+                const ready = sectionReady(structured, section.key)
+                const isActive = activeSection === section.key
+                return (
+                  <button
+                    key={section.key}
+                    type="button"
+                    onClick={() => jumpToSection(section.key)}
+                    className={`w-full rounded-2xl border px-3 py-3 text-left transition ${
+                      isActive
+                        ? 'border-orange-300/30 bg-orange-300/[0.08]'
+                        : 'border-white/8 bg-black/20 hover:bg-white/[0.04]'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-white">{section.title}</p>
+                      {ready ? <CheckCircle2 className="h-4 w-4 text-emerald-300" /> : null}
+                    </div>
+                    <p className="mt-1 text-xs text-zinc-500">
+                      {hidden.has(section.key)
+                        ? 'Hidden from output'
+                        : count
+                          ? `${count} item${count === 1 ? '' : 's'} configured`
+                          : section.emptyHint}
+                    </p>
+                  </button>
+                )
+              })}
+            </div>
+
+            {missingSections.length ? (
+              <div className="mt-5 rounded-2xl border border-amber-300/15 bg-amber-300/[0.06] px-3 py-3">
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-amber-100/85">
+                  <Target className="h-3.5 w-3.5" />
+                  Next fixes
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {missingSections.map(item => {
+                    const key = item === 'name' || item === 'email' ? 'summary' : item
+                    if (!SECTION_CONFIG.some(section => section.key === key)) return null
+                    return (
+                      <StarterChip key={item} label={item.replace('_', ' ')} onClick={() => jumpToSection(key as SectionKey)} />
+                    )
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </Card>
+        </aside>
+
+        <div className="space-y-6">
+          <section className="surface-panel edge-highlight p-6">
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <FieldLabel htmlFor="builder-resume-title">Resume Title</FieldLabel>
+                  <TextInput
+                    id="builder-resume-title"
+                    type="text"
+                    value={title}
+                    onChange={event => {
+                      setTitle(event.target.value)
+                      setDirty(true)
+                    }}
+                  />
+                </div>
+                <div>
+                  <FieldLabel htmlFor="builder-template-select">Template</FieldLabel>
+                  <select
+                    id="builder-template-select"
+                    value={selectedTemplateId}
+                    onChange={event => {
+                      setSelectedTemplateId(event.target.value)
+                      setDirty(true)
+                    }}
+                    className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition focus:border-orange-300/50"
+                  >
+                    {templates.map(template => (
+                      <option key={template.id} value={template.id}>
+                        {template.name} · {template.category_label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <Card className="flex h-full flex-col justify-between">
+                <div className="flex items-center gap-2 text-sm font-semibold text-white">
+                  <Wand2 className="h-4 w-4 text-orange-300" />
+                  Builder Guidance
+                </div>
+                <div className="mt-3 space-y-2 text-sm text-zinc-300">
+                  <p>Lead with measurable impact, not responsibility lists.</p>
+                  <p>Keep the preview one page unless the role clearly benefits from a second page.</p>
+                  <p>Hide sections that don’t reinforce the target job instead of filling them with weak content.</p>
+                </div>
+              </Card>
+            </div>
+
+            {warnings.length ? (
+              <div className="mt-4 space-y-2">
+                {warnings.map(warning => (
+                  <div key={warning} className="rounded-xl border border-amber-300/20 bg-amber-300/[0.05] px-3 py-2 text-xs text-amber-50/90">
+                    {warning}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.summary = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Profile & Summary"
+              sectionKey="summary"
+              description="Control the resume header, role headline, and the core narrative recruiters see first."
+              order={structured.section_order}
+              hidden={hidden.has('summary')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="grid gap-4 md:grid-cols-2">
+              {[
+                ['Full Name', 'name'],
+                ['Headline', 'label'],
+                ['Email', 'email'],
+                ['Phone', 'phone'],
+                ['Location', 'location'],
+                ['Website', 'website'],
+                ['LinkedIn', 'linkedin'],
+                ['GitHub', 'github'],
+              ].map(([label, key]) => (
+                <div key={key}>
+                  <FieldLabel htmlFor={`builder-basics-${key}`}>{label}</FieldLabel>
+                  <TextInput
+                    id={`builder-basics-${key}`}
+                    type="text"
+                    value={structured.basics[key as keyof StructuredResume['basics']]}
+                    onChange={event => mutateStructured(draft => {
+                      draft.basics[key as keyof StructuredResume['basics']] = event.target.value
+                    })}
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="mt-5">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <FieldLabel htmlFor="builder-basics-summary">Summary</FieldLabel>
+                <div className="flex flex-wrap gap-2">
+                  <StarterChip
+                    label="Insert startup profile"
+                    onClick={() => mutateStructured(draft => {
+                      draft.basics.summary = 'Engineer who ships product-facing systems quickly, improves reliability under load, and partners tightly with product to turn ambiguity into measurable execution.'
+                    })}
+                  />
+                  <StarterChip
+                    label="Insert leadership profile"
+                    onClick={() => mutateStructured(draft => {
+                      draft.basics.summary = 'Technical leader with a track record of scaling teams, clarifying platform strategy, and driving high-leverage systems work across product and infrastructure.'
+                    })}
+                  />
+                </div>
+              </div>
+              <TextArea
+                id="builder-basics-summary"
+                value={structured.basics.summary}
+                onFocus={() => setActiveSection('summary')}
+                onChange={event => mutateStructured(draft => {
+                  draft.basics.summary = event.target.value
+                })}
+                rows={5}
+              />
+            </div>
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.experience = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Experience"
+              sectionKey="experience"
+              description="Each role should read like evidence: scope, outcomes, and technical leverage."
+              order={structured.section_order}
+              hidden={hidden.has('experience')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="space-y-4">
+              {structured.experience.map((entry, idx) => (
+                <Card key={entry.id}>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {[
+                      ['Role', 'title'],
+                      ['Company', 'company'],
+                      ['Location', 'location'],
+                      ['Start Date', 'start_date'],
+                      ['End Date', 'end_date'],
+                    ].map(([label, key]) => (
+                      <div key={key}>
+                        <FieldLabel>{label}</FieldLabel>
+                        <TextInput
+                          type="text"
+                          value={entry[key as keyof typeof entry] as string}
+                          onFocus={() => setActiveSection('experience')}
+                          onChange={event => mutateStructured(draft => {
+                            draft.experience[idx][key as keyof typeof entry] = event.target.value as never
+                          })}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <label className="mt-4 flex items-center gap-2 text-sm text-zinc-300">
+                    <input
+                      type="checkbox"
+                      checked={entry.current}
+                      onChange={event => mutateStructured(draft => {
+                        draft.experience[idx].current = event.target.checked
+                        if (event.target.checked) draft.experience[idx].end_date = ''
+                      })}
+                    />
+                    Current role
+                  </label>
+                  <div className="mt-4">
+                    <FieldLabel>Role Summary</FieldLabel>
+                    <TextArea
+                      rows={3}
+                      value={entry.summary}
+                      onFocus={() => setActiveSection('experience')}
+                      onChange={event => mutateStructured(draft => {
+                        draft.experience[idx].summary = event.target.value
+                      })}
+                    />
+                  </div>
+                  <div className="mt-4">
+                    <FieldLabel>Impact Bullets</FieldLabel>
+                    <TextArea
+                      rows={5}
+                      value={entry.bullets.join('\n')}
+                      onFocus={() => setActiveSection('experience')}
+                      onChange={event => mutateStructured(draft => {
+                        draft.experience[idx].bullets = splitLines(event.target.value)
+                      })}
+                    />
+                  </div>
+                  <div className="mt-4">
+                    <FieldLabel>Technologies</FieldLabel>
+                    <TextInput
+                      type="text"
+                      value={joinComma(entry.technologies)}
+                      placeholder="Python, PostgreSQL, Kafka, AWS"
+                      onFocus={() => setActiveSection('experience')}
+                      onChange={event => mutateStructured(draft => {
+                        draft.experience[idx].technologies = splitComma(event.target.value)
+                      })}
+                    />
+                  </div>
+                  <div className="mt-4 flex justify-end">
+                    <button type="button" onClick={() => mutateStructured(draft => {
+                      draft.experience.splice(idx, 1)
+                    })} className="btn-ghost px-4 py-2 text-xs">
+                      Remove entry
+                    </button>
+                  </div>
+                </Card>
+              ))}
+              <button type="button" onClick={() => mutateStructured(draft => {
+                draft.experience.push({
+                  id: createBuilderId('exp'),
+                  title: '',
+                  company: '',
+                  location: '',
+                  start_date: '',
+                  end_date: '',
+                  current: false,
+                  summary: '',
+                  bullets: [],
+                  technologies: [],
+                })
+              })} className="btn-accent px-4 py-2 text-xs">
+                <Plus className="mr-2 inline h-3.5 w-3.5" />
+                Add experience
+              </button>
+            </div>
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.education = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Education"
+              sectionKey="education"
+              description="Keep it compact unless education is still a primary qualification signal."
+              order={structured.section_order}
+              hidden={hidden.has('education')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="space-y-4">
+              {structured.education.map((entry, idx) => (
+                <Card key={entry.id}>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {[
+                      ['Institution', 'institution'],
+                      ['Degree', 'degree'],
+                      ['Field', 'field'],
+                      ['Location', 'location'],
+                      ['Start Date', 'start_date'],
+                      ['End Date', 'end_date'],
+                      ['GPA', 'gpa'],
+                    ].map(([label, key]) => (
+                      <div key={key}>
+                        <FieldLabel>{label}</FieldLabel>
+                        <TextInput
+                          type="text"
+                          value={entry[key as keyof typeof entry] as string}
+                          onFocus={() => setActiveSection('education')}
+                          onChange={event => mutateStructured(draft => {
+                            draft.education[idx][key as keyof typeof entry] = event.target.value as never
+                          })}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4">
+                    <FieldLabel>Highlights</FieldLabel>
+                    <TextArea
+                      rows={4}
+                      value={entry.highlights.join('\n')}
+                      placeholder="Honors, thesis, relevant coursework, leadership"
+                      onFocus={() => setActiveSection('education')}
+                      onChange={event => mutateStructured(draft => {
+                        draft.education[idx].highlights = splitLines(event.target.value)
+                      })}
+                    />
+                  </div>
+                  <div className="mt-4 flex justify-end">
+                    <button type="button" onClick={() => mutateStructured(draft => {
+                      draft.education.splice(idx, 1)
+                    })} className="btn-ghost px-4 py-2 text-xs">
+                      Remove education
+                    </button>
+                  </div>
+                </Card>
+              ))}
+              <button type="button" onClick={() => mutateStructured(draft => {
+                draft.education.push({
+                  id: createBuilderId('edu'),
+                  institution: '',
+                  degree: '',
+                  field: '',
+                  location: '',
+                  start_date: '',
+                  end_date: '',
+                  gpa: '',
+                  highlights: [],
+                })
+              })} className="btn-accent px-4 py-2 text-xs">
+                <Plus className="mr-2 inline h-3.5 w-3.5" />
+                Add education
+              </button>
+            </div>
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.skills = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Skills"
+              sectionKey="skills"
+              description="Structure keywords into groups so both ATS and humans can parse them fast."
+              order={structured.section_order}
+              hidden={hidden.has('skills')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="space-y-4">
+              {structured.skills.map((group, idx) => (
+                <Card key={group.id}>
+                  <FieldLabel>Group Name</FieldLabel>
+                  <TextInput
+                    type="text"
+                    value={group.name}
+                    onFocus={() => setActiveSection('skills')}
+                    onChange={event => mutateStructured(draft => {
+                      draft.skills[idx].name = event.target.value
+                    })}
+                  />
+                  <div className="mt-4">
+                    <FieldLabel>Keywords</FieldLabel>
+                    <TextArea
+                      rows={3}
+                      value={joinComma(group.keywords)}
+                      onFocus={() => setActiveSection('skills')}
+                      onChange={event => mutateStructured(draft => {
+                        draft.skills[idx].keywords = splitComma(event.target.value)
+                      })}
+                    />
+                  </div>
+                  <div className="mt-4 flex justify-end">
+                    <button type="button" onClick={() => mutateStructured(draft => {
+                      draft.skills.splice(idx, 1)
+                    })} className="btn-ghost px-4 py-2 text-xs">
+                      Remove skill group
+                    </button>
+                  </div>
+                </Card>
+              ))}
+              <div className="flex flex-wrap gap-2">
+                <button type="button" onClick={() => mutateStructured(draft => {
+                  draft.skills.push({ id: createBuilderId('skill'), name: 'Core Skills', keywords: [] })
+                })} className="btn-accent px-4 py-2 text-xs">
+                  <Plus className="mr-2 inline h-3.5 w-3.5" />
+                  Add skill group
+                </button>
+                <StarterChip
+                  label="Add engineering groups"
+                  onClick={() => mutateStructured(draft => {
+                    if (!draft.skills.length) {
+                      draft.skills.push(
+                        { id: createBuilderId('skill'), name: 'Languages', keywords: ['Python', 'TypeScript', 'SQL'] },
+                        { id: createBuilderId('skill'), name: 'Platform', keywords: ['AWS', 'Docker', 'Kubernetes'] },
+                      )
+                    }
+                  })}
+                />
+              </div>
+            </div>
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.projects = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Projects"
+              sectionKey="projects"
+              description="Use projects to surface work that sharpens the candidate’s story, not to pad the page."
+              order={structured.section_order}
+              hidden={hidden.has('projects')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="space-y-4">
+              {structured.projects.map((project, idx) => (
+                <Card key={project.id}>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {[
+                      ['Project Name', 'name'],
+                      ['Role', 'role'],
+                      ['URL', 'url'],
+                      ['Start Date', 'start_date'],
+                      ['End Date', 'end_date'],
+                    ].map(([label, key]) => (
+                      <div key={key}>
+                        <FieldLabel>{label}</FieldLabel>
+                        <TextInput
+                          type="text"
+                          value={project[key as keyof typeof project] as string}
+                          onFocus={() => setActiveSection('projects')}
+                          onChange={event => mutateStructured(draft => {
+                            draft.projects[idx][key as keyof typeof project] = event.target.value as never
+                          })}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4">
+                    <FieldLabel>Description</FieldLabel>
+                    <TextArea
+                      rows={3}
+                      value={project.description}
+                      onFocus={() => setActiveSection('projects')}
+                      onChange={event => mutateStructured(draft => {
+                        draft.projects[idx].description = event.target.value
+                      })}
+                    />
+                  </div>
+                  <div className="mt-4">
+                    <FieldLabel>Impact Bullets</FieldLabel>
+                    <TextArea
+                      rows={4}
+                      value={project.bullets.join('\n')}
+                      onFocus={() => setActiveSection('projects')}
+                      onChange={event => mutateStructured(draft => {
+                        draft.projects[idx].bullets = splitLines(event.target.value)
+                      })}
+                    />
+                  </div>
+                  <div className="mt-4">
+                    <FieldLabel>Technologies</FieldLabel>
+                    <TextInput
+                      type="text"
+                      value={joinComma(project.technologies)}
+                      onFocus={() => setActiveSection('projects')}
+                      onChange={event => mutateStructured(draft => {
+                        draft.projects[idx].technologies = splitComma(event.target.value)
+                      })}
+                    />
+                  </div>
+                  <div className="mt-4 flex justify-end">
+                    <button type="button" onClick={() => mutateStructured(draft => {
+                      draft.projects.splice(idx, 1)
+                    })} className="btn-ghost px-4 py-2 text-xs">
+                      Remove project
+                    </button>
+                  </div>
+                </Card>
+              ))}
+              <button type="button" onClick={() => mutateStructured(draft => {
+                draft.projects.push({
+                  id: createBuilderId('proj'),
+                  name: '',
+                  role: '',
+                  url: '',
+                  start_date: '',
+                  end_date: '',
+                  description: '',
+                  bullets: [],
+                  technologies: [],
+                })
+              })} className="btn-accent px-4 py-2 text-xs">
+                <Plus className="mr-2 inline h-3.5 w-3.5" />
+                Add project
+              </button>
+            </div>
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.certifications = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Certifications"
+              sectionKey="certifications"
+              description="Only keep credentials that materially support the target role or domain trust."
+              order={structured.section_order}
+              hidden={hidden.has('certifications')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="space-y-4">
+              {structured.certifications.map((entry, idx) => (
+                <Card key={entry.id}>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {[
+                      ['Name', 'name'],
+                      ['Issuer', 'issuer'],
+                      ['Date', 'date'],
+                      ['URL', 'url'],
+                    ].map(([label, key]) => (
+                      <div key={key}>
+                        <FieldLabel>{label}</FieldLabel>
+                        <TextInput
+                          type="text"
+                          value={entry[key as keyof typeof entry] as string}
+                          onFocus={() => setActiveSection('certifications')}
+                          onChange={event => mutateStructured(draft => {
+                            draft.certifications[idx][key as keyof typeof entry] = event.target.value as never
+                          })}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4 flex justify-end">
+                    <button type="button" onClick={() => mutateStructured(draft => {
+                      draft.certifications.splice(idx, 1)
+                    })} className="btn-ghost px-4 py-2 text-xs">
+                      Remove certification
+                    </button>
+                  </div>
+                </Card>
+              ))}
+              <button type="button" onClick={() => mutateStructured(draft => {
+                draft.certifications.push({ id: createBuilderId('cert'), name: '', issuer: '', date: '', url: '' })
+              })} className="btn-accent px-4 py-2 text-xs">
+                <Plus className="mr-2 inline h-3.5 w-3.5" />
+                Add certification
+              </button>
+            </div>
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.awards = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Awards"
+              sectionKey="awards"
+              description="Recognition should add proof, not noise."
+              order={structured.section_order}
+              hidden={hidden.has('awards')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="space-y-4">
+              {structured.awards.map((entry, idx) => (
+                <Card key={entry.id}>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <FieldLabel>Name</FieldLabel>
+                      <TextInput
+                        type="text"
+                        value={entry.name}
+                        onFocus={() => setActiveSection('awards')}
+                        onChange={event => mutateStructured(draft => {
+                          draft.awards[idx].name = event.target.value
+                        })}
+                      />
+                    </div>
+                    <div>
+                      <FieldLabel>Detail</FieldLabel>
+                      <TextInput
+                        type="text"
+                        value={entry.detail}
+                        onFocus={() => setActiveSection('awards')}
+                        onChange={event => mutateStructured(draft => {
+                          draft.awards[idx].detail = event.target.value
+                        })}
+                        />
+                      </div>
+                    </div>
+                  <div className="mt-4 flex justify-end">
+                    <button type="button" onClick={() => mutateStructured(draft => {
+                      draft.awards.splice(idx, 1)
+                    })} className="btn-ghost px-4 py-2 text-xs">
+                      Remove award
+                    </button>
+                  </div>
+                </Card>
+              ))}
+              <button type="button" onClick={() => mutateStructured(draft => {
+                draft.awards.push({ id: createBuilderId('award'), name: '', detail: '' })
+              })} className="btn-accent px-4 py-2 text-xs">
+                <Plus className="mr-2 inline h-3.5 w-3.5" />
+                Add award
+              </button>
+            </div>
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.languages = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Languages"
+              sectionKey="languages"
+              description="State the language and actual proficiency rather than broad claims."
+              order={structured.section_order}
+              hidden={hidden.has('languages')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="space-y-4">
+              {structured.languages.map((entry, idx) => (
+                <Card key={entry.id}>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <FieldLabel>Language</FieldLabel>
+                      <TextInput
+                        type="text"
+                        value={entry.name}
+                        onFocus={() => setActiveSection('languages')}
+                        onChange={event => mutateStructured(draft => {
+                          draft.languages[idx].name = event.target.value
+                        })}
+                      />
+                    </div>
+                    <div>
+                      <FieldLabel>Proficiency</FieldLabel>
+                      <TextInput
+                        type="text"
+                        value={entry.detail}
+                        placeholder="Native, fluent, professional, conversational"
+                        onFocus={() => setActiveSection('languages')}
+                        onChange={event => mutateStructured(draft => {
+                          draft.languages[idx].detail = event.target.value
+                        })}
+                        />
+                      </div>
+                    </div>
+                  <div className="mt-4 flex justify-end">
+                    <button type="button" onClick={() => mutateStructured(draft => {
+                      draft.languages.splice(idx, 1)
+                    })} className="btn-ghost px-4 py-2 text-xs">
+                      Remove language
+                    </button>
+                  </div>
+                </Card>
+              ))}
+              <button type="button" onClick={() => mutateStructured(draft => {
+                draft.languages.push({ id: createBuilderId('lang'), name: '', detail: '' })
+              })} className="btn-accent px-4 py-2 text-xs">
+                <Plus className="mr-2 inline h-3.5 w-3.5" />
+                Add language
+              </button>
+            </div>
+          </section>
+
+          <section
+            ref={node => {
+              sectionRefs.current.interests = node
+            }}
+            className="surface-panel edge-highlight scroll-mt-28 p-6"
+          >
+            <SectionHeader
+              title="Interests"
+              sectionKey="interests"
+              description="Keep this optional and only use it when it sharpens memorability or fit."
+              order={structured.section_order}
+              hidden={hidden.has('interests')}
+              onMove={moveSection}
+              onToggleHidden={toggleHidden}
+            />
+            <div className="space-y-4">
+              {structured.interests.map((entry, idx) => (
+                <Card key={entry.id}>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <FieldLabel>Interest</FieldLabel>
+                      <TextInput
+                        type="text"
+                        value={entry.name}
+                        onFocus={() => setActiveSection('interests')}
+                        onChange={event => mutateStructured(draft => {
+                          draft.interests[idx].name = event.target.value
+                        })}
+                      />
+                    </div>
+                    <div>
+                      <FieldLabel>Detail</FieldLabel>
+                      <TextInput
+                        type="text"
+                        value={entry.detail}
+                        placeholder="Context, depth, leadership, or relevance"
+                        onFocus={() => setActiveSection('interests')}
+                        onChange={event => mutateStructured(draft => {
+                          draft.interests[idx].detail = event.target.value
+                        })}
+                        />
+                      </div>
+                    </div>
+                  <div className="mt-4 flex justify-end">
+                    <button type="button" onClick={() => mutateStructured(draft => {
+                      draft.interests.splice(idx, 1)
+                    })} className="btn-ghost px-4 py-2 text-xs">
+                      Remove interest
+                    </button>
+                  </div>
+                </Card>
+              ))}
+              <button type="button" onClick={() => mutateStructured(draft => {
+                draft.interests.push({ id: createBuilderId('interest'), name: '', detail: '' })
+              })} className="btn-accent px-4 py-2 text-xs">
+                <Plus className="mr-2 inline h-3.5 w-3.5" />
+                Add interest
+              </button>
+            </div>
+          </section>
+        </div>
+
+        <div className="space-y-6">
+          <BuilderPreview
+            title={title}
+            structured={structured}
+            preview={livePreview}
+            templateFamily={templateFamily}
+            completenessScore={completenessScore}
+            pageEstimate={pageEstimate}
+            warnings={warnings}
+          />
+
+          <section className="surface-panel edge-highlight p-6">
+            <div className="flex items-center gap-2 text-sm font-semibold text-white">
+              <Sparkles className="h-4 w-4 text-orange-300" />
+              Builder Notes
+            </div>
+            <div className="mt-4 space-y-3 text-sm text-zinc-300">
+              <p>Section order and visibility update both the preview and the generated LaTeX.</p>
+              <p>Template switching stays within builder-native families so the structure remains stable.</p>
+              <p>The advanced editor is still available when you need raw control, but that detaches the builder until you reattach it.</p>
+            </div>
+            <div className="mt-5 rounded-2xl border border-white/8 bg-black/20 p-4 text-xs text-zinc-500">
+              <FileText className="mr-2 inline h-3.5 w-3.5" />
+              Current mode: {builderStatus} · {selectedTemplate?.category_label || templateFamily}
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/app/workspace/builder/new/page.tsx
+++ b/frontend/src/app/workspace/builder/new/page.tsx
@@ -1,0 +1,293 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
+import { CheckCircle2, LayoutTemplate, Sparkles, Upload, Wand2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  apiClient,
+  type BuilderMetricsResponse,
+  type BuilderTemplateResponse,
+} from '@/lib/api-client'
+import {
+  cloneStructuredResume,
+  DEFAULT_STRUCTURED_RESUME,
+  deriveBuilderMetrics,
+} from '@/lib/resume-builder'
+
+export default function NewBuilderPage() {
+  const router = useRouter()
+  const [title, setTitle] = useState('')
+  const [templates, setTemplates] = useState<BuilderTemplateResponse[]>([])
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>('')
+  const [structured, setStructured] = useState(cloneStructuredResume(DEFAULT_STRUCTURED_RESUME))
+  const [seedMetrics, setSeedMetrics] = useState<BuilderMetricsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [uploading, setUploading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    apiClient.getBuilderTemplates()
+      .then(result => {
+        if (cancelled) return
+        setTemplates(result)
+        setSelectedTemplateId(result[0]?.id ?? '')
+      })
+      .catch(() => {
+        if (!cancelled) toast.error('Failed to load builder templates')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const selectedTemplate = useMemo(
+    () => templates.find(template => template.id === selectedTemplateId) ?? null,
+    [selectedTemplateId, templates],
+  )
+  const effectiveMetrics = seedMetrics ?? deriveBuilderMetrics(structured)
+
+  const handleSeedUpload = async (file: File | null) => {
+    if (!file) return
+    setUploading(true)
+    try {
+      const seeded = await apiClient.seedBuilderFromUpload(file)
+      setStructured(cloneStructuredResume(seeded.structured_content))
+      setSeedMetrics(seeded.metrics)
+      if (!title.trim()) {
+        setTitle(file.name.replace(/\.[^.]+$/, ''))
+      }
+      toast.success('Imported resume content into the builder')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to seed builder from upload')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const handleCreate = async () => {
+    if (!title.trim()) {
+      toast.error('Enter a resume title')
+      return
+    }
+    if (!selectedTemplateId) {
+      toast.error('Select a builder template')
+      return
+    }
+    setCreating(true)
+    try {
+      const created = await apiClient.createBuilderResume({
+        title: title.trim(),
+        template_id: selectedTemplateId,
+        structured_content: structured,
+      })
+      toast.success('Builder draft created')
+      router.push(`/workspace/builder/${created.resume.id}`)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create builder draft')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="content-shell space-y-8 pb-16">
+      <header className="flex items-end justify-between gap-4 pt-2">
+        <div>
+          <p className="overline">Guided Builder</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">Build from structured content</h1>
+          <p className="mt-2 max-w-2xl text-sm text-zinc-400">
+            This path is optimized for fast resume creation: pick a builder-native template, fill structured sections,
+            and keep the advanced LaTeX editor as a fallback rather than the starting point.
+          </p>
+        </div>
+        <Link href="/workspace/new" className="btn-ghost px-4 py-2 text-xs">
+          Back to Create Resume
+        </Link>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="surface-panel edge-highlight p-6">
+          <label className="mb-2 block text-xs uppercase tracking-[0.14em] text-zinc-500">
+            Resume Title
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={event => setTitle(event.target.value)}
+            placeholder="Senior Backend Engineer — Core Resume"
+            className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-base text-white outline-none transition focus:border-orange-300/50"
+          />
+
+          <div className="mt-6 flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+            <div>
+              <p className="text-sm font-semibold text-white">Seed from an existing resume</p>
+              <p className="mt-1 text-xs text-zinc-500">
+                Upload PDF, DOCX, JSON Resume, or LinkedIn export to prefill the builder.
+              </p>
+            </div>
+            <label className="btn-ghost cursor-pointer px-4 py-2 text-xs">
+              <Upload className="mr-2 inline h-3.5 w-3.5" />
+              {uploading ? 'Importing…' : 'Upload'}
+              <input
+                type="file"
+                className="hidden"
+                accept=".json,.pdf,.doc,.docx,.txt,.md,.html,.yaml,.yml,.toml,.xml,.tex"
+                onChange={event => void handleSeedUpload(event.target.files?.[0] ?? null)}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div className="surface-panel edge-highlight p-6">
+          <div className="flex items-center gap-2 text-sm font-semibold text-white">
+            <Sparkles className="h-4 w-4 text-orange-300" />
+            Why use this builder
+          </div>
+          <div className="mt-4 grid gap-3 text-sm text-zinc-300">
+            <div className="rounded-2xl border border-white/8 bg-white/[0.03] p-4">Structured sections with live preview, autosave, and section reordering.</div>
+            <div className="rounded-2xl border border-white/8 bg-white/[0.03] p-4">Curated builder-native templates that stay stable under template swaps.</div>
+            <div className="rounded-2xl border border-white/8 bg-white/[0.03] p-4">Advanced LaTeX editor remains available after creation for power users.</div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        {[
+          {
+            title: '1. Seed',
+            description: 'Start from a past resume, LinkedIn export, or JSON Resume so you do not rebuild the basics manually.',
+          },
+          {
+            title: '2. Shape',
+            description: 'Tune the headline, impact bullets, skills, and sections with a live structured editing surface.',
+          },
+          {
+            title: '3. Ship',
+            description: 'Swap builder-safe templates, keep page density in check, and open the advanced editor only when needed.',
+          },
+        ].map(item => (
+          <div key={item.title} className="surface-panel edge-highlight p-6">
+            <div className="flex items-center gap-2 text-sm font-semibold text-white">
+              <CheckCircle2 className="h-4 w-4 text-orange-300" />
+              {item.title}
+            </div>
+            <p className="mt-3 text-sm text-zinc-400">{item.description}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="surface-panel edge-highlight p-6">
+        <div className="mb-5 flex items-center gap-2">
+          <LayoutTemplate className="h-4 w-4 text-orange-300" />
+          <h2 className="text-sm font-semibold text-white">Choose a builder-native template</h2>
+        </div>
+        {loading ? (
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, idx) => (
+              <div key={idx} className="h-48 animate-pulse rounded-2xl bg-white/5" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {templates.map(template => (
+              <button
+                key={template.id}
+                type="button"
+                onClick={() => setSelectedTemplateId(template.id)}
+                className={`rounded-2xl border p-5 text-left transition ${
+                  template.id === selectedTemplateId
+                    ? 'border-orange-300/40 bg-orange-300/[0.06]'
+                    : 'border-white/10 bg-black/20 hover:bg-white/[0.03]'
+                }`}
+              >
+                <p className="text-xs uppercase tracking-[0.16em] text-zinc-500">{template.category_label}</p>
+                <h3 className="mt-2 text-lg font-semibold text-white">{template.name}</h3>
+                <p className="mt-2 text-sm text-zinc-400">
+                  {template.description || `${template.template_family} builder layout`}
+                </p>
+                <p className="mt-4 text-xs text-zinc-500">Family: {template.template_family}</p>
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+        <div className="surface-panel edge-highlight p-6">
+          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Seed Preview</p>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <div className="rounded-2xl border border-white/8 bg-black/20 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Basics</p>
+              <p className="mt-2 text-sm text-white">{structured.basics.name || 'No name imported yet'}</p>
+              <p className="mt-1 text-xs text-zinc-400">{structured.basics.label || 'Add role headline later'}</p>
+            </div>
+            <div className="rounded-2xl border border-white/8 bg-black/20 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Sections</p>
+              <p className="mt-2 text-sm text-white">
+                {[
+                  structured.experience.length ? `${structured.experience.length} experience` : null,
+                  structured.education.length ? `${structured.education.length} education` : null,
+                  structured.skills.length ? `${structured.skills.length} skill groups` : null,
+                  structured.projects.length ? `${structured.projects.length} projects` : null,
+                ].filter(Boolean).join(' · ') || 'No imported sections yet'}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-white/8 bg-black/20 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Readiness</p>
+              <p className="mt-2 text-sm text-white">{effectiveMetrics.completeness_score}% complete</p>
+              <p className="mt-1 text-xs text-zinc-400">
+                {effectiveMetrics.missing_sections.length
+                  ? `Missing: ${effectiveMetrics.missing_sections.join(', ')}`
+                  : 'Core sections are present'}
+              </p>
+            </div>
+          </div>
+          {effectiveMetrics.warnings.length ? (
+            <div className="mt-4 space-y-2">
+              {effectiveMetrics.warnings.map(warning => (
+                <div key={warning} className="rounded-xl border border-amber-300/20 bg-amber-300/[0.05] px-3 py-2 text-xs text-amber-50/90">
+                  {warning}
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="surface-panel edge-highlight p-6">
+          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Ready</p>
+          <h2 className="mt-2 text-xl font-semibold text-white">
+            {selectedTemplate?.name || 'Select a template first'}
+          </h2>
+          <p className="mt-2 text-sm text-zinc-400">
+            The builder will create a structured draft first, then keep LaTeX in sync behind the scenes.
+          </p>
+          <div className="mt-5 rounded-2xl border border-white/8 bg-black/20 p-4 text-sm text-zinc-300">
+            <div className="flex items-center gap-2 font-semibold text-white">
+              <Wand2 className="h-4 w-4 text-orange-300" />
+              Builder first, editor second
+            </div>
+            <p className="mt-2 text-zinc-400">
+              This path is best when you want guided UX, richer section controls, safer template switching, and fewer chances
+              to break layout details manually.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleCreate()}
+            disabled={creating || loading || !selectedTemplateId}
+            className="btn-accent mt-6 w-full px-4 py-3 text-sm disabled:opacity-50"
+          >
+            {creating ? 'Creating builder draft…' : 'Start Guided Builder'}
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/app/workspace/new/page.tsx
+++ b/frontend/src/app/workspace/new/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { Search, Upload, LayoutTemplate, X, Linkedin, PackageOpen } from 'lucide-react'
+import { Search, Upload, LayoutTemplate, X, Linkedin, PackageOpen, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { apiClient } from '@/lib/api-client'
@@ -243,6 +243,23 @@ export default function NewResumePage() {
           />
         </section>
 
+        <section className="surface-panel edge-highlight flex flex-col gap-4 p-6 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Recommended</p>
+            <h2 className="mt-2 flex items-center gap-2 text-xl font-semibold text-white">
+              <Sparkles className="h-4 w-4 text-orange-300" />
+              Guided Builder
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm text-zinc-400">
+              Use the new structured builder if you want live preview, section forms, template swapping, and a safer
+              path than starting directly in LaTeX.
+            </p>
+          </div>
+          <Link href="/workspace/builder/new" className="btn-accent px-5 py-3 text-sm">
+            Open Guided Builder
+          </Link>
+        </section>
+
         {/* Mode toggle */}
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <button
@@ -300,8 +317,8 @@ export default function NewResumePage() {
           >
             <PackageOpen className="mt-0.5 h-5 w-5 shrink-0 text-violet-400/80" />
             <div>
-              <h2 className="text-sm font-semibold text-white">Import from Builder</h2>
-              <p className="mt-0.5 text-xs text-zinc-400">Kickresume, Resume.io, Novoresume, and more.</p>
+              <h2 className="text-sm font-semibold text-white">Import Builder Export</h2>
+              <p className="mt-0.5 text-xs text-zinc-400">Bring in content from Kickresume, Resume.io, Novoresume, and similar tools.</p>
             </div>
           </button>
         </div>

--- a/frontend/src/components/builder/BuilderPreview.tsx
+++ b/frontend/src/components/builder/BuilderPreview.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import type { BuilderPreviewResponse, StructuredResume } from '@/lib/api-client'
+
+interface BuilderPreviewProps {
+  title: string
+  structured: StructuredResume
+  preview: BuilderPreviewResponse | null
+  templateFamily: string
+  completenessScore: number
+  pageEstimate: number
+  warnings: string[]
+}
+
+function headerAccent(templateFamily: string) {
+  switch (templateFamily) {
+    case 'executive':
+      return 'from-zinc-100/70 via-zinc-200/35 to-transparent'
+    case 'ats':
+      return 'from-emerald-200/80 via-emerald-300/35 to-transparent'
+    case 'minimal':
+      return 'from-orange-200/70 via-orange-300/35 to-transparent'
+    default:
+      return 'from-sky-200/70 via-sky-300/35 to-transparent'
+  }
+}
+
+function statTone(value: number) {
+  if (value >= 85) return 'text-emerald-200 border-emerald-300/20 bg-emerald-300/[0.08]'
+  if (value >= 65) return 'text-amber-100 border-amber-300/20 bg-amber-300/[0.08]'
+  return 'text-rose-100 border-rose-300/20 bg-rose-300/[0.08]'
+}
+
+export default function BuilderPreview({
+  title,
+  structured,
+  preview,
+  templateFamily,
+  completenessScore,
+  pageEstimate,
+  warnings,
+}: BuilderPreviewProps) {
+  const basics = structured.basics
+  const sectionCount = preview?.sections.length ?? 0
+  const activeSections = structured.section_order.filter(section => !structured.hidden_sections.includes(section))
+
+  return (
+    <div className="surface-panel edge-highlight sticky top-24 overflow-hidden">
+      <div className="border-b border-white/10 px-5 py-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.24em] text-zinc-500">Live Preview</p>
+            <p className="mt-2 text-sm text-zinc-300">
+              Render-safe snapshot of the structured resume that will drive generated LaTeX.
+            </p>
+          </div>
+          <div className={`rounded-full border px-3 py-1 text-[11px] uppercase tracking-[0.18em] ${statTone(completenessScore)}`}>
+            {completenessScore}% ready
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-2xl border border-white/8 bg-black/20 px-3 py-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Template</p>
+            <p className="mt-2 text-sm font-semibold text-white">{templateFamily}</p>
+          </div>
+          <div className="rounded-2xl border border-white/8 bg-black/20 px-3 py-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Page Target</p>
+            <p className="mt-2 text-sm font-semibold text-white">{pageEstimate} page{pageEstimate === 1 ? '' : 's'}</p>
+          </div>
+          <div className="rounded-2xl border border-white/8 bg-black/20 px-3 py-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Visible Sections</p>
+            <p className="mt-2 text-sm font-semibold text-white">{sectionCount || activeSections.length}</p>
+          </div>
+        </div>
+
+        {activeSections.length ? (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {activeSections.map(section => (
+              <span
+                key={section}
+                className="rounded-full border border-white/8 bg-white/[0.04] px-2.5 py-1 text-[11px] uppercase tracking-[0.16em] text-zinc-400"
+              >
+                {section.replace('_', ' ')}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {!!warnings.length && (
+          <div className="mt-4 rounded-2xl border border-amber-300/15 bg-amber-300/[0.06] px-4 py-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-amber-100/75">Preview warnings</p>
+            <ul className="mt-2 space-y-1 text-xs text-amber-50/90">
+              {warnings.slice(0, 2).map(warning => (
+                <li key={warning}>• {warning}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="mt-5 rounded-[28px] border border-white/8 bg-[#f7f4ef] p-6 text-[#171717] shadow-[0_24px_80px_rgba(0,0,0,0.24)]">
+          <div className={`border-b border-black/8 bg-gradient-to-r ${headerAccent(templateFamily)} pb-4`}>
+            <h2 className="text-2xl font-semibold tracking-tight text-[#111111]">
+              {basics.name || title || 'Untitled Resume'}
+            </h2>
+            {basics.label ? <p className="mt-1 text-sm text-[#434343]">{basics.label}</p> : null}
+            <p className="mt-2 text-xs text-[#5a5a5a]">
+              {[basics.email, basics.phone, basics.location, basics.website, basics.linkedin, basics.github]
+                .filter(Boolean)
+                .join('  •  ') || 'Contact details will appear here'}
+            </p>
+          </div>
+
+          <div className="mt-5 space-y-5">
+            {preview?.sections.length ? (
+              preview.sections.map(section => (
+                <section key={section.key}>
+                  <h3 className="border-b border-black/10 pb-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#5b5b5b]">
+                    {section.title}
+                  </h3>
+                  <div className="mt-3 space-y-3 text-sm leading-6 text-[#1f1f1f]">
+                    {section.items.map((item, idx) => {
+                      if (typeof item === 'string') {
+                        return <p key={`${section.key}-${idx}`}>{item}</p>
+                      }
+                      const row = item as { title?: string; meta?: string; bullets?: string[] }
+                      return (
+                        <div key={`${section.key}-${idx}`} className="space-y-1.5">
+                          {row.title ? <p className="font-semibold text-[#111111]">{row.title}</p> : null}
+                          {row.meta ? <p className="text-xs uppercase tracking-[0.12em] text-[#686868]">{row.meta}</p> : null}
+                          {row.bullets?.length ? (
+                            <ul className="list-disc space-y-1 pl-5 text-[#262626]">
+                              {row.bullets.map((bullet, bulletIdx) => (
+                                <li key={`${section.key}-${idx}-${bulletIdx}`}>{bullet}</li>
+                              ))}
+                            </ul>
+                          ) : null}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </section>
+              ))
+            ) : (
+              <div className="rounded-2xl border border-dashed border-black/10 bg-white/50 px-4 py-6 text-center text-sm text-[#696969]">
+                Start filling the builder to generate a live preview.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -259,6 +259,11 @@ export interface ResumeResponse extends ResumeBase {
   user_id: string
   parent_resume_id?: string | null
   variant_count?: number
+  selected_template_id?: string | null
+  content_source?: string
+  builder_status?: 'active' | 'detached'
+  structured_content?: StructuredResume | null
+  structured_version?: number
   metadata?: { compiler?: string; custom_flags?: string; pinned?: boolean; [key: string]: unknown } | null
   share_token?: string | null
   share_url?: string | null
@@ -330,6 +335,114 @@ export interface AcademicCVConvertResponse {
   variant_resume_id: string
   job_id: string
   report: AcademicCVReport
+}
+
+export interface StructuredResume {
+  basics: {
+    name: string
+    label: string
+    email: string
+    phone: string
+    location: string
+    website: string
+    linkedin: string
+    github: string
+    summary: string
+  }
+  experience: Array<{
+    id: string
+    title: string
+    company: string
+    location: string
+    start_date: string
+    end_date: string
+    current: boolean
+    summary: string
+    bullets: string[]
+    technologies: string[]
+  }>
+  education: Array<{
+    id: string
+    institution: string
+    degree: string
+    field: string
+    location: string
+    start_date: string
+    end_date: string
+    gpa: string
+    highlights: string[]
+  }>
+  projects: Array<{
+    id: string
+    name: string
+    role: string
+    url: string
+    start_date: string
+    end_date: string
+    description: string
+    bullets: string[]
+    technologies: string[]
+  }>
+  skills: Array<{
+    id: string
+    name: string
+    keywords: string[]
+  }>
+  certifications: Array<{
+    id: string
+    name: string
+    issuer: string
+    date: string
+    url: string
+  }>
+  awards: Array<{ id: string; name: string; detail: string }>
+  languages: Array<{ id: string; name: string; detail: string }>
+  interests: Array<{ id: string; name: string; detail: string }>
+  section_order: string[]
+  hidden_sections: string[]
+}
+
+export interface BuilderTemplateResponse {
+  id: string
+  name: string
+  description: string | null
+  category: string
+  category_label: string
+  sort_order: number
+  thumbnail_url: string | null
+  pdf_url: string | null
+  template_family: string
+}
+
+export interface BuilderMetricsResponse {
+  completeness_score: number
+  page_estimate: number
+  warnings: string[]
+  missing_sections: string[]
+}
+
+export interface BuilderPreviewResponse {
+  template_family: string
+  sections: Array<{
+    key: string
+    title: string
+    items: unknown[]
+  }>
+}
+
+export interface BuilderResumeResponse {
+  resume: ResumeResponse
+  metrics: BuilderMetricsResponse
+  preview: BuilderPreviewResponse
+  template_family: string
+}
+
+export interface BuilderSeedUploadResponse {
+  success: boolean
+  filename: string
+  format: string
+  structured_content: StructuredResume
+  metrics: BuilderMetricsResponse
 }
 
 export interface ScoreHistoryPoint {
@@ -790,11 +903,21 @@ class ApiClient {
     if (res.status === 204) {
       return undefined as T
     }
-    const contentType = res.headers.get('content-type') || ''
+    const contentType = typeof res.headers?.get === 'function'
+      ? (res.headers.get('content-type') || '')
+      : ''
     if (contentType.includes('application/json')) {
       return res.json() as Promise<T>
     }
-    return (await res.text()) as T
+    const textBody = await res.text()
+    if (textBody) {
+      try {
+        return JSON.parse(textBody) as T
+      } catch {
+        // Fall through for plain-text responses and incomplete mock headers.
+      }
+    }
+    return textBody as T
   }
 
   // ---------------------------------------------------------------- //
@@ -892,6 +1015,58 @@ class ApiClient {
     return this.request<ResumeResponse>('/resumes/', {
       method: 'POST',
       body: JSON.stringify(resume),
+    })
+  }
+
+  async getBuilderTemplates(): Promise<BuilderTemplateResponse[]> {
+    return this.request<BuilderTemplateResponse[]>('/resumes/builder/templates')
+  }
+
+  async seedBuilderFromUpload(file: File): Promise<BuilderSeedUploadResponse> {
+    const form = new FormData()
+    form.append('file', file)
+    const headers = { ...(this.headers() as Record<string, string>) }
+    delete headers['Content-Type']
+    const res = await fetch(`${API_BASE}/resumes/builder/seed-upload`, {
+      method: 'POST',
+      body: form,
+      headers,
+      credentials: 'include',
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`HTTP ${res.status}: ${body || res.statusText}`)
+    }
+    return res.json()
+  }
+
+  async createBuilderResume(body: {
+    title: string
+    template_id: string
+    structured_content?: StructuredResume
+  }): Promise<BuilderResumeResponse> {
+    return this.request<BuilderResumeResponse>('/resumes/builder', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+  }
+
+  async getBuilderResume(resumeId: string): Promise<BuilderResumeResponse> {
+    return this.request<BuilderResumeResponse>(`/resumes/${encodeURIComponent(resumeId)}/builder`)
+  }
+
+  async updateBuilderResume(
+    resumeId: string,
+    body: {
+      title?: string
+      template_id?: string
+      structured_content?: StructuredResume
+      force_reattach?: boolean
+    }
+  ): Promise<BuilderResumeResponse> {
+    return this.request<BuilderResumeResponse>(`/resumes/${encodeURIComponent(resumeId)}/builder`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
     })
   }
 

--- a/frontend/src/lib/resume-builder.ts
+++ b/frontend/src/lib/resume-builder.ts
@@ -1,0 +1,222 @@
+import type {
+  BuilderMetricsResponse,
+  BuilderPreviewResponse,
+  StructuredResume,
+} from './api-client'
+
+export const DEFAULT_STRUCTURED_RESUME: StructuredResume = {
+  basics: {
+    name: '',
+    label: '',
+    email: '',
+    phone: '',
+    location: '',
+    website: '',
+    linkedin: '',
+    github: '',
+    summary: '',
+  },
+  experience: [],
+  education: [],
+  projects: [],
+  skills: [],
+  certifications: [],
+  awards: [],
+  languages: [],
+  interests: [],
+  section_order: [
+    'summary',
+    'experience',
+    'education',
+    'skills',
+    'projects',
+    'certifications',
+    'awards',
+    'languages',
+    'interests',
+  ],
+  hidden_sections: [],
+}
+
+export function cloneStructuredResume(value?: StructuredResume | null): StructuredResume {
+  return JSON.parse(JSON.stringify(value ?? DEFAULT_STRUCTURED_RESUME)) as StructuredResume
+}
+
+export function createBuilderId(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function joinMeta(...parts: Array<string | undefined>) {
+  return parts.map(part => part?.trim()).filter(Boolean).join(' | ')
+}
+
+function dateRange(start: string, end: string, current = false) {
+  const from = start.trim()
+  const to = current ? 'Present' : end.trim()
+  if (!from && !to) return ''
+  if (!from) return to
+  if (!to) return from
+  return `${from} - ${to}`
+}
+
+export function deriveBuilderMetrics(structured: StructuredResume): BuilderMetricsResponse {
+  let score = 0
+  const missing: string[] = []
+  const warnings: string[] = []
+
+  if (structured.basics.name.trim()) score += 15
+  else missing.push('name')
+
+  if (structured.basics.email.trim()) score += 10
+  else missing.push('email')
+
+  if (structured.basics.summary.trim()) score += 10
+  else missing.push('summary')
+
+  if (structured.experience.length) score += 25
+  else missing.push('experience')
+
+  if (structured.education.length) score += 15
+  else missing.push('education')
+
+  if (structured.skills.some(group => group.keywords.length)) score += 15
+  else missing.push('skills')
+
+  if (structured.projects.length) score += 10
+
+  let totalLines = 6
+  totalLines += Object.values(structured.basics).filter(value => typeof value === 'string' && value.trim()).length
+  totalLines += structured.basics.summary.split('\n').filter(Boolean).length
+  totalLines += structured.experience.reduce((sum, entry) => sum + Math.max(3, entry.bullets.filter(Boolean).length + 2), 0)
+  totalLines += structured.education.reduce((sum, entry) => sum + Math.max(2, entry.highlights.filter(Boolean).length + 1), 0)
+  totalLines += structured.skills.reduce((sum, group) => sum + Math.max(2, Math.ceil(group.keywords.length / 5) + 1), 0)
+  totalLines += structured.projects.reduce((sum, project) => sum + Math.max(2, project.bullets.filter(Boolean).length + 2), 0)
+
+  const pageEstimate = Math.max(1, Math.floor((totalLines + 37) / 38))
+  if (pageEstimate > 1) warnings.push('Content likely exceeds one page in compact templates.')
+  if (structured.experience.some(entry => entry.bullets.length > 6)) warnings.push('Some experience entries are dense; consider trimming bullets.')
+  if (!structured.basics.label.trim()) warnings.push('Add a headline to improve clarity at the top of the resume.')
+
+  return {
+    completeness_score: Math.min(score, 100),
+    page_estimate: pageEstimate,
+    warnings,
+    missing_sections: missing,
+  }
+}
+
+export function deriveBuilderPreview(
+  structured: StructuredResume,
+  templateFamily: string,
+): BuilderPreviewResponse {
+  const hidden = new Set(structured.hidden_sections)
+  const sections: BuilderPreviewResponse['sections'] = []
+
+  for (const section of structured.section_order) {
+    if (hidden.has(section)) continue
+
+    if (section === 'summary' && structured.basics.summary.trim()) {
+      sections.push({
+        key: 'summary',
+        title: 'Summary',
+        items: [structured.basics.summary.trim()],
+      })
+    } else if (section === 'experience' && structured.experience.length) {
+      sections.push({
+        key: 'experience',
+        title: 'Experience',
+        items: structured.experience
+          .filter(item => item.title.trim() || item.company.trim() || item.bullets.some(Boolean))
+          .map(item => ({
+            title: `${item.title} — ${item.company}`.trim().replace(/^—\s*/, '').replace(/\s+—$/, ''),
+            meta: joinMeta(item.location, dateRange(item.start_date, item.end_date, item.current)),
+            bullets: [item.summary, ...item.bullets].filter(value => value.trim()),
+          })),
+      })
+    } else if (section === 'education' && structured.education.length) {
+      sections.push({
+        key: 'education',
+        title: 'Education',
+        items: structured.education
+          .filter(item => item.institution.trim() || item.degree.trim())
+          .map(item => ({
+            title: `${item.degree} — ${item.institution}`.trim().replace(/^—\s*/, '').replace(/\s+—$/, ''),
+            meta: joinMeta(item.location, dateRange(item.start_date, item.end_date)),
+            bullets: item.highlights.filter(value => value.trim()),
+          })),
+      })
+    } else if (section === 'skills' && structured.skills.length) {
+      sections.push({
+        key: 'skills',
+        title: 'Skills',
+        items: structured.skills
+          .filter(item => item.name.trim() || item.keywords.length)
+          .map(item => ({
+            title: item.name,
+            meta: item.keywords.join(', '),
+          })),
+      })
+    } else if (section === 'projects' && structured.projects.length) {
+      sections.push({
+        key: 'projects',
+        title: 'Projects',
+        items: structured.projects
+          .filter(item => item.name.trim() || item.description.trim() || item.bullets.some(Boolean))
+          .map(item => ({
+            title: item.name,
+            meta: joinMeta(item.role, item.url, dateRange(item.start_date, item.end_date)),
+            bullets: [item.description, ...item.bullets].filter(value => value.trim()),
+          })),
+      })
+    } else if (section === 'certifications' && structured.certifications.length) {
+      sections.push({
+        key: 'certifications',
+        title: 'Certifications',
+        items: structured.certifications
+          .filter(item => item.name.trim() || item.issuer.trim() || item.date.trim())
+          .map(item => ({
+            title: item.name,
+            meta: joinMeta(item.issuer, item.date, item.url),
+          })),
+      })
+    } else if (section === 'awards' && structured.awards.length) {
+      sections.push({
+        key: 'awards',
+        title: 'Awards',
+        items: structured.awards
+          .filter(item => item.name.trim() || item.detail.trim())
+          .map(item => ({
+            title: item.name,
+            meta: item.detail,
+          })),
+      })
+    } else if (section === 'languages' && structured.languages.length) {
+      sections.push({
+        key: 'languages',
+        title: 'Languages',
+        items: structured.languages
+          .filter(item => item.name.trim() || item.detail.trim())
+          .map(item => ({
+            title: item.name,
+            meta: item.detail,
+          })),
+      })
+    } else if (section === 'interests' && structured.interests.length) {
+      sections.push({
+        key: 'interests',
+        title: 'Interests',
+        items: structured.interests
+          .filter(item => item.name.trim() || item.detail.trim())
+          .map(item => ({
+            title: item.name,
+            meta: item.detail,
+          })),
+      })
+    }
+  }
+
+  return {
+    template_family: templateFamily,
+    sections,
+  }
+}

--- a/scripts/ci/full-stack-smoke.sh
+++ b/scripts/ci/full-stack-smoke.sh
@@ -29,6 +29,7 @@ export OPENAI_API_KEY="${OPENAI_API_KEY:-}"
 export NEXT_TELEMETRY_DISABLED=1
 
 backend_pid=""
+started_backend="false"
 backend_alembic=()
 backend_uvicorn=()
 
@@ -41,7 +42,7 @@ else
 fi
 
 cleanup() {
-  if [[ -n "$backend_pid" ]] && kill -0 "$backend_pid" 2>/dev/null; then
+  if [[ "$started_backend" == "true" ]] && [[ -n "$backend_pid" ]] && kill -0 "$backend_pid" 2>/dev/null; then
     kill "$backend_pid" 2>/dev/null || true
     wait "$backend_pid" 2>/dev/null || true
   fi
@@ -49,18 +50,23 @@ cleanup() {
 
 trap cleanup EXIT
 
-echo "==> Running backend migrations"
-(
-  cd "$BACKEND_DIR"
-  "${backend_alembic[@]}" upgrade head
-)
+if curl -fsS "http://127.0.0.1:${BACKEND_PORT}/health" >/dev/null 2>&1; then
+  echo "==> Reusing existing backend on :${BACKEND_PORT}"
+else
+  echo "==> Running backend migrations"
+  (
+    cd "$BACKEND_DIR"
+    "${backend_alembic[@]}" upgrade head
+  )
 
-echo "==> Starting backend on :${BACKEND_PORT}"
-(
-  cd "$BACKEND_DIR"
-  "${backend_uvicorn[@]}" app.main:app --host 127.0.0.1 --port "$BACKEND_PORT"
-) &
-backend_pid=$!
+  echo "==> Starting backend on :${BACKEND_PORT}"
+  (
+    cd "$BACKEND_DIR"
+    "${backend_uvicorn[@]}" app.main:app --host 127.0.0.1 --port "$BACKEND_PORT"
+  ) &
+  backend_pid=$!
+  started_backend="true"
+fi
 
 echo "==> Waiting for backend readiness"
 for _ in $(seq 1 60); do

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -72,6 +72,29 @@ cleanup() {
   echo "  Stop infra with: ./scripts/dev.sh stop infra"
 }
 
+kill_matching_processes() {
+  local pattern="$1"
+  local pids
+  pids="$(pgrep -f "$pattern" 2>/dev/null || true)"
+  [[ -z "$pids" ]] && return 0
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    kill "$pid" 2>/dev/null || true
+  done <<< "$pids"
+
+  sleep 1
+
+  local survivors
+  survivors="$(pgrep -f "$pattern" 2>/dev/null || true)"
+  [[ -z "$survivors" ]] && return 0
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    kill -9 "$pid" 2>/dev/null || true
+  done <<< "$survivors"
+}
+
 # ── stop ─────────────────────────────────────────────────────────────────────
 
 stop_app() {
@@ -98,6 +121,16 @@ stop_app() {
   local fp=$((5179 + slot))
   lsof -ti:"$bp" 2>/dev/null | xargs kill 2>/dev/null || true
   lsof -ti:"$fp" 2>/dev/null | xargs kill 2>/dev/null || true
+
+  # Clean up any stale Latexy-local processes left behind by prior runs or
+  # interrupted shells. These can otherwise keep consuming Celery jobs with an
+  # older code version and make validation results inconsistent.
+  kill_matching_processes "${PROJECT_ROOT}/backend/.venv/bin/celery"
+  kill_matching_processes "${PROJECT_ROOT}/backend/venv/bin/celery"
+  kill_matching_processes "${PROJECT_ROOT}/backend/.venv/bin/uvicorn app.main:app"
+  kill_matching_processes "${PROJECT_ROOT}/backend/venv/bin/uvicorn app.main:app"
+  kill_matching_processes "${PROJECT_ROOT}/frontend/node_modules/.*/next/dist/bin/next dev -p"
+
   echo -e "${GREEN}✓ App processes stopped.${NC}"
 }
 
@@ -209,6 +242,7 @@ start_app() {
   CELERY_RESULT_BACKEND="$REDIS" \
   MINIO_ENDPOINT="$MINIO" \
   "$CELERY" -A app.core.celery_app worker --loglevel=info --concurrency=2 \
+    -n "latexy-slot${SLOT}@%h" \
     --queues=latex,llm,combined,ats,cleanup,email \
     2>&1 | sed "s/^/[worker]   /" &
   echo $! >> "$PID_FILE"


### PR DESCRIPTION
## Summary
- forward-port the builder backend, builder UI, builder regression coverage, and runtime cleanup work that was stranded on stacked branches
- make late migrations idempotent, preserve terminal LaTeX job results, and keep API/client builder serialization aligned
- keep the current mainline improvements for SQL echo control, response parsing, and smoke reuse while layering in the missing issue work

## Issues
Closes #433
Closes #434
Closes #435
Closes #436
Closes #437
Closes #438
Closes #439

## Validation
- `./backend/.venv/bin/ruff check backend/app/api/resume_routes.py backend/app/services/resume_builder_service.py backend/app/workers/latex_worker.py backend/test/conftest.py backend/test/test_latex_worker.py backend/test/test_resume_builder.py`
- `cd backend && BETTER_AUTH_SECRET='test_secret_key_32chars_minimum_!' JWT_SECRET_KEY='test_jwt_secret_32chars_minimum_!' API_KEY_ENCRYPTION_KEY='MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=' DATABASE_URL='postgresql+asyncpg://latexy:latexy_password@localhost:5434/latexy_test' ./.venv/bin/alembic upgrade head`
- `cd backend && RATE_LIMIT_ENABLED=false TEST_DATABASE_URL='postgresql+asyncpg://latexy:latexy_password@localhost:5434/latexy_test' ./.venv/bin/pytest test/test_latex_worker.py test/test_resume_builder.py -q`
- `cd frontend && pnpm lint --file src/lib/api-client.ts --file src/lib/resume-builder.ts --file src/app/workspace/new/page.tsx --file src/app/workspace/builder/new/page.tsx --file 'src/app/workspace/builder/[resumeId]/page.tsx' --file src/components/builder/BuilderPreview.tsx`
- `cd frontend && pnpm exec tsc --noEmit`
- `cd frontend && pnpm exec playwright test e2e/resume-builder.spec.ts --project=chromium --workers=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Guided Resume Builder with template library and live preview
  * Resume creation from uploaded files with structured section editing
  * Template switching with auto-save capability
  * Builder reattach functionality for detached resumes
  * Developer API key management
  * Subscription tools (team seats, coupon codes)

* **Tests**
  * Added end-to-end tests for builder workflows
  * Enhanced LaTeX compilation test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->