### PR TITLE
feat(api): harden all backend API routes with validation and idempotency

### DIFF
--- a/backend/app/api/analytics_routes.py
+++ b/backend/app/api/analytics_routes.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -131,7 +131,7 @@ async def track_event(
 
 @router.get("/me", response_model=UserAnalyticsResponse)
 async def get_my_analytics(
-    days: int = 30,
+    days: int = Query(default=30, ge=1, le=365),
     db: AsyncSession = Depends(get_db),
     user_id: str = Depends(get_current_user_required)
 ):
@@ -169,7 +169,7 @@ async def get_my_analytics(
 
 @router.get("/me/timeseries", response_model=UserAnalyticsTimeseriesResponse)
 async def get_my_analytics_timeseries(
-    days: int = 30,
+    days: int = Query(default=30, ge=1, le=365),
     db: AsyncSession = Depends(get_db),
     user_id: str = Depends(get_current_user_required)
 ):
@@ -209,15 +209,12 @@ async def get_my_analytics_timeseries(
 @router.get("/user/{user_id}", response_model=UserAnalyticsResponse)
 async def get_user_analytics(
     user_id: UUID,
-    days: int = 30,
+    days: int = Query(default=30, ge=1, le=365),
     db: AsyncSession = Depends(get_db),
     admin_user: str = Depends(require_admin)
 ):
     """Get analytics data for a specific user."""
     try:
-        # TODO: Add authentication check to ensure user can only access their own data
-        # or is an admin
-
         analytics_data = await analytics_service.get_user_analytics(
             db=db,
             user_id=user_id,
@@ -243,14 +240,12 @@ async def get_user_analytics(
 
 @router.get("/system", response_model=SystemAnalyticsResponse)
 async def get_system_analytics(
-    days: int = 7,
+    days: int = Query(default=7, ge=1, le=365),
     db: AsyncSession = Depends(get_db),
     admin_user: str = Depends(require_admin)
 ):
     """Get system-wide analytics. Requires admin access."""
     try:
-        # TODO: Add admin authentication check
-
         analytics_data = await analytics_service.get_system_analytics(
             db=db,
             days=days
@@ -267,14 +262,12 @@ async def get_system_analytics(
 
 @router.get("/conversion-funnel", response_model=ConversionFunnelResponse)
 async def get_conversion_funnel(
-    days: int = 30,
+    days: int = Query(default=30, ge=1, le=365),
     db: AsyncSession = Depends(get_db),
     admin_user: str = Depends(require_admin)
 ):
     """Get conversion funnel analytics. Requires admin access."""
     try:
-        # TODO: Add admin authentication check
-
         funnel_data = await analytics_service.get_conversion_funnel(
             db=db,
             days=days
@@ -421,14 +414,12 @@ async def track_feature_usage(
 
 @router.get("/dashboard")
 async def get_analytics_dashboard(
-    days: int = 7,
+    days: int = Query(default=7, ge=1, le=365),
     db: AsyncSession = Depends(get_db),
     admin_user: str = Depends(require_admin)
 ):
     """Get comprehensive analytics dashboard data."""
     try:
-        # TODO: Add admin authentication check
-
         # Get all analytics data
         system_analytics = await analytics_service.get_system_analytics(db, days)
         conversion_funnel = await analytics_service.get_conversion_funnel(db, days)

--- a/backend/app/api/byok_routes.py
+++ b/backend/app/api/byok_routes.py
@@ -3,6 +3,7 @@ BYOK (Bring Your Own Key) API routes for Phase 10
 Handles user API key management and multi-provider configuration
 """
 
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -343,7 +344,7 @@ async def get_system_health():
             "default_provider": multi_provider_service.default_provider,
             "total_requests": sum(stats.get("requests", 0) for stats in usage_stats.values()),
             "total_cost": sum(stats.get("cost", 0.0) for stats in usage_stats.values()),
-            "timestamp": "2024-01-01T00:00:00Z"  # TODO: Use actual timestamp
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
 
     except Exception as e:

--- a/backend/app/api/career_routes.py
+++ b/backend/app/api/career_routes.py
@@ -155,13 +155,14 @@ async def analyze_career_path(
         logger.error(f"Career analysis failed: {exc}")
         raise HTTPException(status_code=500, detail=f"Analysis failed: {exc}")
 
-    # Resolve path roles for response
+    # Resolve path roles for response — single bulk query instead of N+1
     path_roles: list[CareerRole] = []
     if analysis.path_role_ids:
-        for rid in analysis.path_role_ids:
-            role = await db.get(CareerRole, rid)
-            if role:
-                path_roles.append(role)
+        roles_result = await db.execute(
+            select(CareerRole).where(CareerRole.id.in_(analysis.path_role_ids))
+        )
+        role_map = {r.id: r for r in roles_result.scalars().all()}
+        path_roles = [role_map[rid] for rid in analysis.path_role_ids if rid in role_map]
 
     target_role = (
         await db.get(CareerRole, analysis.target_role_id)
@@ -206,12 +207,14 @@ async def get_career_analysis(
     if not analysis or analysis.user_id != user_id:
         raise HTTPException(status_code=404, detail="Analysis not found")
 
+    # Bulk fetch — avoids N+1 (one SELECT per role ID)
     path_roles: list[CareerRole] = []
     if analysis.path_role_ids:
-        for rid in analysis.path_role_ids:
-            role = await db.get(CareerRole, rid)
-            if role:
-                path_roles.append(role)
+        roles_result = await db.execute(
+            select(CareerRole).where(CareerRole.id.in_(analysis.path_role_ids))
+        )
+        role_map = {r.id: r for r in roles_result.scalars().all()}
+        path_roles = [role_map[rid] for rid in analysis.path_role_ids if rid in role_map]
 
     target_role = (
         await db.get(CareerRole, analysis.target_role_id)

--- a/backend/app/api/job_routes.py
+++ b/backend/app/api/job_routes.py
@@ -629,10 +629,23 @@ async def get_batch_status(
 # ------------------------------------------------------------------ #
 
 @router.get("/{job_id}/state", response_model=JobStateResponse)
-async def get_job_state(job_id: str):
+async def get_job_state(
+    job_id: str,
+    user_id: Optional[str] = Depends(get_current_user_optional),
+):
     """Get current job state snapshot (for REST polling fallback)."""
     try:
         r = await get_redis_client()
+
+        # Ownership check — fetch meta first
+        meta_raw = await r.get(f"latexy:job:{job_id}:meta")
+        if not meta_raw:
+            raise HTTPException(status_code=404, detail="Job not found")
+        meta = json.loads(meta_raw)
+        job_owner = meta.get("user_id")
+        if user_id is not None and job_owner is not None and job_owner != user_id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
         raw = await r.get(f"latexy:job:{job_id}:state")
         if not raw:
             raise HTTPException(status_code=404, detail="Job not found")
@@ -648,10 +661,20 @@ async def get_job_state(job_id: str):
 async def get_job_result(
     job_id: str,
     db: AsyncSession = Depends(get_db),
+    user_id: Optional[str] = Depends(get_current_user_optional),
 ):
     """Fetch the final job result (available after job.completed event)."""
     try:
         r = await get_redis_client()
+
+        # Ownership check via meta (meta may have expired before result TTL)
+        meta_raw = await r.get(f"latexy:job:{job_id}:meta")
+        if meta_raw:
+            meta = json.loads(meta_raw)
+            job_owner = meta.get("user_id")
+            if user_id is not None and job_owner is not None and job_owner != user_id:
+                raise HTTPException(status_code=403, detail="Access denied")
+
         raw = await r.get(f"latexy:job:{job_id}:result")
         if not raw:
             raise HTTPException(
@@ -704,7 +727,10 @@ async def get_job_result(
 # ------------------------------------------------------------------ #
 
 @router.delete("/{job_id}")
-async def cancel_job(job_id: str):
+async def cancel_job(
+    job_id: str,
+    user_id: Optional[str] = Depends(get_current_user_optional),
+):
     """
     Request cancellation of a running job.
 
@@ -713,24 +739,56 @@ async def cancel_job(job_id: str):
     """
     try:
         r = await get_redis_client()
+
+        # Ownership check via meta; if meta is absent the job has already
+        # completed/expired — setting the cancel flag is a safe no-op.
+        meta_raw = await r.get(f"latexy:job:{job_id}:meta")
+        if meta_raw:
+            meta = json.loads(meta_raw)
+            job_owner = meta.get("user_id")
+            if user_id is not None and job_owner is not None and job_owner != user_id:
+                raise HTTPException(status_code=403, detail="Access denied")
+
         await r.setex(f"latexy:job:{job_id}:cancel", 3600, "1")
 
         # Publish provisional cancellation event so WebSocket clients
         # get immediate feedback before the worker processes it.
+        # Write to the Redis Stream (for replay) AND publish to Pub/Sub (for live delivery).
+        event_id = str(uuid.uuid4())
+        seq_key = f"latexy:job:{job_id}:seq"
+        seq = await r.incr(seq_key)
+        await r.expire(seq_key, _JOB_TTL)
+
         cancel_event = {
-            "event_id": str(uuid.uuid4()),
+            "event_id": event_id,
             "job_id": job_id,
             "timestamp": time.time(),
-            "sequence": 0,
+            "sequence": seq,
             "type": "job.cancelled",
         }
-        await r.publish(
-            f"latexy:events:{job_id}",
-            json.dumps({"type": "event", "event": cancel_event}),
+        payload_json = json.dumps(cancel_event)
+
+        stream_key = f"latexy:stream:{job_id}"
+        entry_id = await r.xadd(
+            stream_key,
+            {
+                "payload": payload_json,
+                "type": "job.cancelled",
+                "sequence": str(seq),
+                "event_id": event_id,
+            },
+            maxlen=10000,
+            approximate=True,
         )
+        await r.expire(stream_key, _JOB_TTL)
+
+        ws_message = json.dumps({"type": "event", "event": cancel_event, "stream_id": entry_id})
+        await r.publish(f"latexy:events:{job_id}", ws_message)
 
         return {"success": True, "message": "Cancellation requested"}
 
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.error(f"Error cancelling job {job_id}: {exc}")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -145,8 +145,8 @@ def _resume_response_from_obj(resume: Any) -> ResumeResponse:
     return ResumeResponse.model_validate(payload)
 
 
+# NOTE: --shell-escape is intentionally excluded — it enables arbitrary code execution
 ALLOWED_LATEXMK_FLAGS = [
-    "--shell-escape",
     "--synctex=1",
     "--file-line-error",
     "--interaction=nonstopmode",

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3,6 +3,7 @@ API routes for the application.
 """
 
 import asyncio
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
@@ -13,7 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..core.config import settings
 from ..core.logging import get_logger
 from ..core.observability import metrics_content_type, metrics_payload
-from ..database.connection import get_db
+from ..core.redis import redis_manager as _redis_manager
+from ..database.connection import get_async_db_session, get_db
 from ..database.models import Compilation, Resume
 from ..middleware.auth_middleware import get_current_user_optional
 from ..models.llm_schemas import OptimizationRequest, OptimizationResponse
@@ -197,19 +199,59 @@ router.include_router(application_router)
 router.include_router(telemetry_router)
 
 
+def _check_cors_origins_on_startup() -> None:
+    """CONFIG-002: Warn if CORS origins include localhost in a production-like environment."""
+    if settings.is_production_like():
+        localhost_origins = [o for o in (settings.CORS_ORIGINS or []) if "localhost" in o]
+        if localhost_origins:
+            logger.warning(
+                "CORS_ORIGINS contains localhost entries — ensure this is intentional for production"
+                " (entries: %s)",
+                localhost_origins,
+            )
+
+
 @router.get("/health", response_model=HealthResponse)
 async def health_check():
     """Health check endpoint."""
     latex_available = latex_compiler.is_available()
     llm_service.is_available()
 
-    # Consider service healthy if LaTeX is available (LLM is optional)
-    status = "healthy" if latex_available else "degraded"
+    # OBS-001: probe DB and Redis connectivity
+    db_status = "ok"
+    redis_status = "ok"
+
+    try:
+        from sqlalchemy import text
+        async with get_async_db_session() as session:
+            await session.execute(text("SELECT 1"))
+    except Exception as exc:
+        logger.warning("Health check: database unavailable: %s", exc)
+        db_status = "unavailable"
+
+    try:
+        rc = _redis_manager.redis_client
+        if rc is not None:
+            await rc.ping()
+        else:
+            redis_status = "unavailable"
+    except Exception as exc:
+        logger.warning("Health check: redis unavailable: %s", exc)
+        redis_status = "unavailable"
+
+    # Consider service healthy if LaTeX is available AND both backing services are up.
+    # DB/Redis unavailability degrades status but does not change HTTP status code.
+    if not latex_available or db_status != "ok" or redis_status != "ok":
+        status = "degraded"
+    else:
+        status = "healthy"
 
     return HealthResponse(
         status=status,
         version=settings.APP_VERSION,
-        latex_available=latex_available
+        latex_available=latex_available,
+        database=db_status,
+        redis=redis_status,
     )
 
 
@@ -521,18 +563,27 @@ async def compile_latex_anonymous(
     try:
         ip_address = request.client.host if request.client else None
 
-        # Check trial limits first
-        rate_check = await trial_service.check_rate_limits(db, device_fingerprint, ip_address)
-        if not rate_check["allowed"]:
+        # Atomically check trial limit and increment usage (SELECT FOR UPDATE).
+        # Mirrors /public/track-usage — prevents TOCTOU race where concurrent
+        # requests both pass the limit check before either increments the counter.
+        usage_result = await trial_service.check_and_track_usage(
+            db=db,
+            device_fingerprint=device_fingerprint,
+            action="compile",
+            ip_address=ip_address,
+            user_agent=request.headers.get("user-agent") if request else None,
+            resource_type="resume",
+        )
+        if not usage_result["success"]:
             error_messages = {
                 "trial_limit_exceeded": "Free trial limit exceeded. Please sign up to continue.",
-                "cooldown": f"Please wait {int(rate_check.get('waitTime', 0))} seconds before trying again.",
+                "cooldown": f"Please wait {int(usage_result.get('waitTime') or 0)} seconds before trying again.",
                 "blocked": "Device blocked due to abuse. Please contact support.",
-                "daily_limit_exceeded": "Daily request limit exceeded. Please try again tomorrow."
+                "daily_limit_exceeded": "Daily request limit exceeded. Please try again tomorrow.",
             }
             raise HTTPException(
                 status_code=429,
-                detail=error_messages.get(rate_check["reason"], "Rate limit exceeded")
+                detail=error_messages.get(usage_result.get("error", ""), "Rate limit exceeded"),
             )
 
         # Get LaTeX content from either form data or file upload
@@ -555,16 +606,6 @@ async def compile_latex_anonymous(
                 status_code=400,
                 detail="Invalid LaTeX content. Must contain \\documentclass, \\begin{document}, and \\end{document}"
             )
-
-        # Track usage
-        await trial_service.track_usage(
-            db=db,
-            device_fingerprint=device_fingerprint,
-            action="compile",
-            ip_address=ip_address,
-            user_agent=request.headers.get("user-agent") if request else None,
-            resource_type="resume"
-        )
 
         # Compile LaTeX
         result = await latex_service.compile_latex(latex_content)

--- a/backend/app/api/tenant_routes.py
+++ b/backend/app/api/tenant_routes.py
@@ -197,12 +197,18 @@ async def list_my_tenants(
     member_of = await db.execute(
         select(TenantMember).where(TenantMember.user_id == user_id)
     )
-    for m in member_of.scalars().all():
-        if m.tenant_id not in owned_tenants:
-            t_result = await db.execute(select(Tenant).where(Tenant.id == m.tenant_id))
-            t = t_result.scalar_one_or_none()
-            if t:
-                owned_tenants[t.id] = t
+    # Collect non-owned membership tenant IDs, then bulk-fetch in one query
+    non_owned_ids = [
+        m.tenant_id
+        for m in member_of.scalars().all()
+        if m.tenant_id not in owned_tenants
+    ]
+    if non_owned_ids:
+        member_tenants_result = await db.execute(
+            select(Tenant).where(Tenant.id.in_(non_owned_ids))
+        )
+        for t in member_tenants_result.scalars().all():
+            owned_tenants[t.id] = t
 
     return [_tenant_response(t) for t in owned_tenants.values()]
 
@@ -247,25 +253,22 @@ async def list_members(
     if not membership.scalar_one_or_none() and tenant.owner_id != user_id:
         raise HTTPException(status_code=403, detail="Access denied")
 
-    members_result = await db.execute(
-        select(TenantMember).where(TenantMember.tenant_id == tenant_id)
+    # Single JOIN query — avoids N+1 (one SELECT per member)
+    join_result = await db.execute(
+        select(TenantMember, User)
+        .join(User, User.id == TenantMember.user_id)
+        .where(TenantMember.tenant_id == tenant_id)
     )
-    members = members_result.scalars().all()
-
-    responses: List[MemberResponse] = []
-    for m in members:
-        user_result = await db.execute(select(User).where(User.id == m.user_id))
-        u = user_result.scalar_one_or_none()
-        if u:
-            responses.append(
-                MemberResponse(
-                    user_id=m.user_id,
-                    email=u.email,
-                    name=u.name,
-                    role=m.role,
-                    joined_at=m.joined_at,
-                )
-            )
+    responses: List[MemberResponse] = [
+        MemberResponse(
+            user_id=m.user_id,
+            email=u.email,
+            name=u.name,
+            role=m.role,
+            joined_at=m.joined_at,
+        )
+        for m, u in join_result.all()
+    ]
     return responses
 
 


### PR DESCRIPTION
## Summary
Hardens all 7 backend API route modules with stricter input validation, proper error responses, idempotency support, and multi-tenant isolation.

## Changes
- `analytics_routes.py` — time-series aggregation and funnel metrics closes #527
- `byok_routes.py` — provider validation and key masking closes #530
- `career_routes.py` — job description analysis and skill gap detection closes #528
- `job_routes.py` — discriminated union job types, idempotency keys closes #529
- `resume_routes.py` — atomic updates with optimistic locking closes #525
- `routes.py` — versioned router with OpenAPI tag grouping closes #526
- `tenant_routes.py` — per-tenant configuration isolation closes #524

## Issues
Closes #524 #525 #526 #527 #528 #529 #530