### PR TITLE
feat(tui): nanostores — session, messages, overlay, UI state

### DIFF
--- a/packages/tui/src/stores/messages.ts
+++ b/packages/tui/src/stores/messages.ts
@@ -1,0 +1,50 @@
+import { atom } from 'nanostores'
+
+export type MessageRole =
+  | 'user'
+  | 'assistant'
+  | 'tool_use'
+  | 'log_stream'
+  | 'compile_result'
+  | 'ats_result'
+  | 'resume_list'
+  | 'system'
+  | 'error'
+
+export interface Message {
+  id: string
+  role: MessageRole
+  content: string
+  timestamp: string
+  streaming?: boolean
+  toolName?: string
+  toolArgs?: Record<string, unknown>
+  toolState?: 'running' | 'success' | 'error' | 'cancelled'
+  toolResult?: unknown
+  durationMs?: number
+  jobId?: string
+  resultData?: unknown
+}
+
+export const $messages = atom<Message[]>([])
+export const $activeJobId = atom<string | null>(null)
+
+let _idCounter = 0
+export function nextId(): string {
+  return `msg-${Date.now()}-${_idCounter++}`
+}
+
+export function addMessage(msg: Omit<Message, 'id' | 'timestamp'>): string {
+  const id = nextId()
+  const full: Message = { id, timestamp: new Date().toISOString(), ...msg }
+  $messages.set([...$messages.get(), full])
+  return id
+}
+
+export function updateMessage(id: string, patch: Partial<Message>): void {
+  $messages.set($messages.get().map(m => m.id === id ? { ...m, ...patch } : m))
+}
+
+export function clearMessages(): void {
+  $messages.set([])
+}

--- a/packages/tui/src/stores/overlay.ts
+++ b/packages/tui/src/stores/overlay.ts
@@ -1,0 +1,13 @@
+import { atom, computed } from 'nanostores'
+import type { ReactNode } from 'react'
+
+export const $overlay = atom<ReactNode | null>(null)
+export const $isBlocked = computed($overlay, o => o !== null)
+
+export function openOverlay(node: ReactNode): void {
+  $overlay.set(node)
+}
+
+export function closeOverlay(): void {
+  $overlay.set(null)
+}

--- a/packages/tui/src/stores/session.ts
+++ b/packages/tui/src/stores/session.ts
@@ -1,0 +1,23 @@
+import { atom } from 'nanostores'
+
+export interface SessionState {
+  token: string | null
+  userId: string | null
+  email: string | null
+  plan: 'free' | 'basic' | 'pro' | 'byok' | 'team' | null
+  backendUrl: string
+  wsUrl: string
+  isAuthenticated: boolean
+}
+
+const defaultBackendUrl = process.env['LATEXY_API_URL'] ?? 'http://localhost:8030'
+
+export const $session = atom<SessionState>({
+  token: null,
+  userId: null,
+  email: null,
+  plan: null,
+  backendUrl: defaultBackendUrl,
+  wsUrl: defaultBackendUrl.replace(/^http/, 'ws') + '/ws/jobs',
+  isAuthenticated: false,
+})

--- a/packages/tui/src/stores/ui.ts
+++ b/packages/tui/src/stores/ui.ts
@@ -1,0 +1,17 @@
+import { atom } from 'nanostores'
+
+export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+
+export interface UIState {
+  theme: 'dark' | 'light'
+  healthStatus: HealthStatus
+  wsConnected: boolean
+  notifications: Array<{ id: string; message: string; level: 'info' | 'error' }>
+}
+
+export const $ui = atom<UIState>({
+  theme: 'dark',
+  healthStatus: 'unknown',
+  wsConnected: false,
+  notifications: [],
+})


### PR DESCRIPTION
## Summary

- Add src/stores/session.ts: token/userId/email/plan/backendUrl atom with LATEXY_API_URL env default
- Add src/stores/messages.ts: TUIMessage[] atom with addMessage/updateMessage/clearMessages helpers
- Add src/stores/overlay.ts: ReactNode|null atom with $isBlocked computed gate blocking all keyboard input
- Add src/stores/ui.ts: wsConnected boolean and healthStatus ('healthy'|'degraded'|'unhealthy'|'unknown') atom

## Issues

Closes #624, #625, #626, #627

## Test plan

- [ ] All 39 tests pass: `cd packages/tui && pnpm test`
- [ ] TypeScript clean: `pnpm typecheck`
- [ ] Build succeeds: `pnpm build`
- [ ] Shebang in dist/cli.js: `head -1 packages/tui/dist/cli.js`