### PR TITLE
feat(tui): Ink components — StatusBar, ToolUseCard, LogStreamCard, CompileResultCard, MessageRow, TranscriptView, SlashSuggestions, PromptInput, AppShell

### DIFF
--- a/packages/tui/src/components/AppShell.tsx
+++ b/packages/tui/src/components/AppShell.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { Box, useInput, useApp } from 'ink'
+import { useStore } from '@nanostores/react'
+import { $session } from '../stores/session.js'
+import { $overlay, $isBlocked, closeOverlay } from '../stores/overlay.js'
+import { $ui } from '../stores/ui.js'
+import { clearMessages } from '../stores/messages.js'
+import { StatusBar } from './StatusBar.js'
+import { TranscriptView } from './TranscriptView.js'
+import { PromptInput } from './PromptInput.js'
+import { useWSEventRouter } from '../hooks/useJobStream.js'
+
+// dispatch is imported lazily to avoid circular dep at module load
+async function lazyDispatch(input: string): Promise<void> {
+  const { dispatch } = await import('../commands/dispatch.js')
+  return dispatch(input)
+}
+
+export function AppShell(): React.ReactElement {
+  const session = useStore($session)
+  const overlay = useStore($overlay)
+  const ui = useStore($ui)
+  const isBlocked = useStore($isBlocked)
+  const { exit } = useApp()
+
+  useWSEventRouter()
+
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c' && !isBlocked) {
+      exit()
+      return
+    }
+    if (key.ctrl && input === 'l') {
+      clearMessages()
+      return
+    }
+    if (key.escape && overlay) {
+      closeOverlay()
+      return
+    }
+  })
+
+  return (
+    <Box flexDirection="column" height="100%">
+      <StatusBar
+        email={session.email}
+        plan={session.plan}
+        health={ui.healthStatus}
+        wsConnected={ui.wsConnected}
+      />
+      <Box flexGrow={1} flexDirection="column" overflow="hidden">
+        <TranscriptView />
+      </Box>
+      {overlay != null && (
+        <Box
+          position="absolute"
+          flexDirection="column"
+          width="100%"
+          height="100%"
+        >
+          {overlay as React.ReactElement}
+        </Box>
+      )}
+      <PromptInput onSubmit={(input) => { void lazyDispatch(input) }} />
+    </Box>
+  )
+}

--- a/packages/tui/src/components/CompileResultCard.tsx
+++ b/packages/tui/src/components/CompileResultCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+
+interface Props {
+  pages: number | null
+  sizeBytes: number | null
+  compilationTimeMs: number
+  pdfUrl: string | null
+  atsScore: number | null
+}
+
+export function CompileResultCard({ pages, sizeBytes, compilationTimeMs, pdfUrl, atsScore }: Props): React.ReactElement {
+  const sizeKb = sizeBytes != null ? Math.round(sizeBytes / 1024) : null
+  const timeStr = `${(compilationTimeMs / 1000).toFixed(1)}s`
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="green" paddingX={1} marginY={1}>
+      <Text bold color="green">✓ Compiled successfully</Text>
+      <Box gap={3} marginTop={1}>
+        {pages != null && (
+          <Text>📄 <Text bold>{pages}</Text> page{pages !== 1 ? 's' : ''}</Text>
+        )}
+        {sizeKb != null && (
+          <Text>💾 <Text bold>{sizeKb}</Text> KB</Text>
+        )}
+        <Text>⏱ <Text bold>{timeStr}</Text></Text>
+        {atsScore != null && (
+          <Text>📊 ATS: <Text bold color="cyan">{atsScore}%</Text></Text>
+        )}
+      </Box>
+      {pdfUrl != null && (
+        <Box marginTop={1}>
+          <Text dimColor>Run /pdf to open · /ats for full analysis</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/packages/tui/src/components/LogStreamCard.tsx
+++ b/packages/tui/src/components/LogStreamCard.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react'
+import { Box, Text } from 'ink'
+
+interface Props {
+  lines: string[]
+  maxVisible?: number
+}
+
+function classifyLine(line: string): 'error' | 'warning' | 'info' {
+  const lower = line.toLowerCase()
+  if (lower.includes('error') || lower.includes('[err]')) return 'error'
+  if (lower.includes('warning') || lower.includes('warn')) return 'warning'
+  return 'info'
+}
+
+export function LogStreamCard({ lines, maxVisible = 20 }: Props): React.ReactElement {
+  const visible = useMemo(
+    () => (lines.length > maxVisible ? lines.slice(-maxVisible) : lines),
+    [lines, maxVisible]
+  )
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} marginY={1}>
+      <Box justifyContent="space-between">
+        <Text bold color="gray">pdflatex log</Text>
+        <Text dimColor>{lines.length} lines</Text>
+      </Box>
+      {visible.map((line, i) => {
+        const kind = classifyLine(line)
+        const color = kind === 'error' ? 'red' : kind === 'warning' ? 'yellow' : undefined
+        return (
+          <Text key={i} color={color} wrap="truncate-end">
+            {line}
+          </Text>
+        )
+      })}
+    </Box>
+  )
+}

--- a/packages/tui/src/components/MessageRow.tsx
+++ b/packages/tui/src/components/MessageRow.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import type { Message } from '../stores/messages.js'
+import { ToolUseCard } from './ToolUseCard.js'
+import { LogStreamCard } from './LogStreamCard.js'
+import { CompileResultCard } from './CompileResultCard.js'
+
+interface Props {
+  message: Message
+}
+
+function UserRow({ message }: Props): React.ReactElement {
+  const time = new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return (
+    <Box flexDirection="column" marginY={1} paddingX={1}>
+      <Box gap={1}>
+        <Text bold color="cyan">You</Text>
+        <Text dimColor>{time}</Text>
+      </Box>
+      <Box paddingLeft={2}>
+        <Text>╰─ {message.content}</Text>
+      </Box>
+    </Box>
+  )
+}
+
+function AssistantRow({ message }: Props): React.ReactElement {
+  return (
+    <Box paddingX={2} marginY={1}>
+      <Text wrap="wrap">
+        {message.content}
+        {message.streaming === true && <Text color="cyan">▌</Text>}
+      </Text>
+    </Box>
+  )
+}
+
+function SystemRow({ message }: Props): React.ReactElement {
+  return (
+    <Box paddingX={2} marginY={1}>
+      <Text dimColor>{message.content}</Text>
+    </Box>
+  )
+}
+
+function ErrorRow({ message }: Props): React.ReactElement {
+  return (
+    <Box paddingX={2} marginY={1}>
+      <Text color="red">✗ {message.content}</Text>
+    </Box>
+  )
+}
+
+export function MessageRow({ message }: Props): React.ReactElement {
+  switch (message.role) {
+    case 'user':
+      return <UserRow message={message} />
+
+    case 'assistant':
+      return <AssistantRow message={message} />
+
+    case 'tool_use':
+      return <ToolUseCard message={message} />
+
+    case 'log_stream': {
+      const data = message.resultData as { lines: string[] } | undefined
+      return <LogStreamCard lines={data?.lines ?? []} />
+    }
+
+    case 'compile_result': {
+      const d = (message.resultData as {
+        pages?: number
+        sizeBytes?: number
+        compilationTimeMs?: number
+        pdfUrl?: string
+        atsScore?: number
+      } | undefined) ?? {}
+      return (
+        <CompileResultCard
+          pages={d.pages ?? null}
+          sizeBytes={d.sizeBytes ?? null}
+          compilationTimeMs={d.compilationTimeMs ?? 0}
+          pdfUrl={d.pdfUrl ?? null}
+          atsScore={d.atsScore ?? null}
+        />
+      )
+    }
+
+    case 'system':
+      return <SystemRow message={message} />
+
+    case 'error':
+      return <ErrorRow message={message} />
+
+    default:
+      return <Box paddingX={2}><Text dimColor>[{message.role}]</Text></Box>
+  }
+}

--- a/packages/tui/src/components/PromptInput.tsx
+++ b/packages/tui/src/components/PromptInput.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useCallback } from 'react'
+import { Box, Text, useInput } from 'ink'
+import TextInput from 'ink-text-input'
+import { useStore } from '@nanostores/react'
+import { $isBlocked } from '../stores/overlay.js'
+import { $activeJobId } from '../stores/messages.js'
+import { SlashSuggestions } from './SlashSuggestions.js'
+
+interface Props {
+  onSubmit: (input: string) => void
+}
+
+export function PromptInput({ onSubmit }: Props): React.ReactElement {
+  const [value, setValue] = useState('')
+  const isBlocked = useStore($isBlocked)
+  const activeJobId = useStore($activeJobId)
+
+  const handleSubmit = useCallback((val: string) => {
+    const trimmed = val.trim()
+    if (!trimmed) return
+    setValue('')
+    onSubmit(trimmed)
+  }, [onSubmit])
+
+  useInput((_input, _key) => {
+    // Global key handling delegated to AppShell
+  }, { isActive: !isBlocked })
+
+  const isSlash = value.startsWith('/')
+  const slashQuery = isSlash ? value.slice(1) : ''
+
+  return (
+    <Box flexDirection="column">
+      {isSlash && value.length > 1 && <SlashSuggestions query={slashQuery} />}
+      <Box gap={1} paddingX={1} borderStyle="round" borderColor={isBlocked ? 'gray' : 'cyan'}>
+        <Text bold color="cyan">›</Text>
+        {activeJobId != null && !isBlocked
+          ? <Text dimColor>Running… (Ctrl+C to cancel)</Text>
+          : (
+            <TextInput
+              value={value}
+              onChange={setValue}
+              onSubmit={handleSubmit}
+              placeholder="Ask anything or type /command"
+              focus={!isBlocked}
+            />
+          )
+        }
+      </Box>
+    </Box>
+  )
+}

--- a/packages/tui/src/components/SlashSuggestions.tsx
+++ b/packages/tui/src/components/SlashSuggestions.tsx
@@ -1,0 +1,30 @@
+import React, { useMemo } from 'react'
+import { Box, Text } from 'ink'
+import { SLASH_COMMANDS } from '../commands/registry.js'
+
+interface Props {
+  query: string
+  maxItems?: number
+}
+
+export function SlashSuggestions({ query, maxItems = 5 }: Props): React.ReactElement | null {
+  const matches = useMemo(() => {
+    const q = query.toLowerCase()
+    return SLASH_COMMANDS.filter(c =>
+      c.name.startsWith(q) || c.description.toLowerCase().includes(q)
+    ).slice(0, maxItems)
+  }, [query, maxItems])
+
+  if (matches.length === 0) return null
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1}>
+      {matches.map(cmd => (
+        <Box key={cmd.name} gap={2}>
+          <Text color="cyan">/{cmd.name}</Text>
+          <Text dimColor>{cmd.description}</Text>
+        </Box>
+      ))}
+    </Box>
+  )
+}

--- a/packages/tui/src/components/StatusBar.tsx
+++ b/packages/tui/src/components/StatusBar.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import type { HealthStatus } from '../stores/ui.js'
+
+interface Props {
+  email: string | null
+  plan: string | null
+  health: HealthStatus
+  wsConnected: boolean
+}
+
+const HEALTH_COLOR: Record<HealthStatus, string> = {
+  healthy: 'green',
+  degraded: 'yellow',
+  unhealthy: 'red',
+  unknown: 'gray',
+}
+
+const PLAN_LABEL: Record<string, string> = {
+  free: 'FREE', basic: 'BASIC', pro: 'PRO', byok: 'BYOK', team: 'TEAM',
+}
+
+export function StatusBar({ email, plan, health, wsConnected }: Props): React.ReactElement {
+  const healthColor = HEALTH_COLOR[health]
+  const planLabel = plan ? (PLAN_LABEL[plan] ?? plan.toUpperCase()) : null
+
+  return (
+    <Box paddingX={1} justifyContent="space-between">
+      <Text bold color="cyan">Latexy</Text>
+      <Box gap={2}>
+        {email && (
+          <Text>
+            {email}
+            {planLabel && <Text color="magenta"> [{planLabel}]</Text>}
+          </Text>
+        )}
+        <Text color={healthColor as string}>● {health}</Text>
+        {!wsConnected && <Text color="yellow">⚡ disconnected</Text>}
+        <Text dimColor>? help · / commands</Text>
+      </Box>
+    </Box>
+  )
+}

--- a/packages/tui/src/components/ToolUseCard.tsx
+++ b/packages/tui/src/components/ToolUseCard.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import type { Message } from '../stores/messages.js'
+
+interface Props {
+  message: Message
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+const STATE_ICON: Record<string, string> = {
+  running: '◐',
+  success: '✓',
+  error: '✗',
+  cancelled: '⊘',
+}
+
+const STATE_COLOR: Record<string, string> = {
+  running: 'cyan',
+  success: 'green',
+  error: 'red',
+  cancelled: 'yellow',
+}
+
+export function ToolUseCard({ message }: Props): React.ReactElement {
+  const { toolName, toolState = 'running', durationMs, toolResult } = message
+  const icon = STATE_ICON[toolState] ?? '·'
+  const color = STATE_COLOR[toolState] ?? 'white'
+
+  return (
+    <Box flexDirection="column" marginY={0} paddingX={2}>
+      <Box gap={1}>
+        <Text color={color}>{icon}</Text>
+        <Text bold>{toolName ?? 'tool'}</Text>
+        {toolState === 'running' && <Text dimColor>running...</Text>}
+        {toolState === 'success' && durationMs != null && (
+          <Text dimColor>{formatMs(durationMs)}</Text>
+        )}
+        {toolState === 'error' && <Text color="red">error</Text>}
+        {toolState === 'cancelled' && <Text color="yellow">cancelled</Text>}
+      </Box>
+      {toolState === 'error' && toolResult != null && (
+        <Box paddingLeft={3}>
+          <Text color="red" wrap="wrap">
+            {typeof (toolResult as Record<string, unknown>)['error'] === 'string'
+              ? String((toolResult as Record<string, unknown>)['error'])
+              : JSON.stringify(toolResult)}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/packages/tui/src/components/TranscriptView.tsx
+++ b/packages/tui/src/components/TranscriptView.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Box, Static } from 'ink'
+import { useStore } from '@nanostores/react'
+import { $messages } from '../stores/messages.js'
+import { MessageRow } from './MessageRow.js'
+import type { Message } from '../stores/messages.js'
+
+export function TranscriptView(): React.ReactElement {
+  const messages = useStore($messages)
+
+  // Finalized messages go into Static (never re-renders once committed)
+  // Active streaming messages go into the dynamic section below
+  const completed: Message[] = []
+  const active: Message[] = []
+
+  for (const msg of messages) {
+    if (msg.streaming === true || msg.toolState === 'running') {
+      active.push(msg)
+    } else {
+      completed.push(msg)
+    }
+  }
+
+  return (
+    <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      <Static items={completed}>
+        {(msg) => <MessageRow key={msg.id} message={msg} />}
+      </Static>
+      {active.map(msg => (
+        <MessageRow key={msg.id} message={msg} />
+      ))}
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary

- Add StatusBar: brand, email+plan badge, health dot (green/yellow/red/gray), WS disconnected indicator
- Add ToolUseCard: running/success/error/cancelled states with duration and error message display
- Add LogStreamCard: streaming log lines with severity color coding, line count badge, maxVisible truncation
- Add CompileResultCard: pages, size KB, compile time ms, optional ATS score, /pdf and /ats hints
- Add MessageRow: dispatcher routing TUIMessage by role to correct card/row component
- Add TranscriptView: Ink Static/dynamic split — completed messages never re-render, active messages stream
- Add SlashSuggestions: filters SLASH_COMMANDS by name prefix or description substring, shows ≤5 matches
- Add PromptInput: ink-text-input with slash typeahead, $isBlocked gate, $activeJobId busy state
- Add AppShell: StatusBar + TranscriptView + PromptInput layout, Ctrl+C/Ctrl+L/Esc handlers, overlay mounting

## Issues

Closes #629, #630, #631, #632, #633, #634, #635, #636, #637

## Test plan

- [ ] All 39 tests pass: `cd packages/tui && pnpm test`
- [ ] TypeScript clean: `pnpm typecheck`
- [ ] Build succeeds: `pnpm build`
- [ ] Shebang in dist/cli.js: `head -1 packages/tui/dist/cli.js`