### PR TITLE
feat(tui): slash command system — 32 commands, tokenizer, two-tier dispatch

### DIFF
--- a/packages/tui/src/commands/dispatch.ts
+++ b/packages/tui/src/commands/dispatch.ts
@@ -1,0 +1,117 @@
+import React from 'react'
+import { parseSlashCommand } from './parser.js'
+import { COMMAND_MAP } from './registry.js'
+import { addMessage, $activeJobId, clearMessages } from '../stores/messages.js'
+import { openOverlay, closeOverlay } from '../stores/overlay.js'
+import { $session } from '../stores/session.js'
+import { writeConfig, clearConfig } from '../lib/config.js'
+import { wsClient } from '../lib/ws-client.js'
+
+// Lazy imports to avoid circular deps at module load
+async function getLoginOverlay(): Promise<React.ReactElement> {
+  const { LoginOverlay } = await import('../components/overlays/LoginOverlay.js')
+  return React.createElement(LoginOverlay)
+}
+
+async function getResumePicker(): Promise<React.ReactElement> {
+  const { ResumePicker } = await import('../components/overlays/ResumePicker.js')
+  return React.createElement(ResumePicker)
+}
+
+// Tier 1: local handlers (no API call, just UI changes)
+const LOCAL_HANDLERS: Record<string, (parsed: ReturnType<typeof parseSlashCommand>) => Promise<void>> = {
+  list: async () => {
+    openOverlay(await getResumePicker())
+  },
+  clear: async () => {
+    clearMessages()
+  },
+  help: async (p) => {
+    const cmdName = p?.positional[0]
+    const cmd = cmdName ? COMMAND_MAP.get(cmdName) : null
+    addMessage({
+      role: 'system',
+      content: cmd
+        ? `/${cmd.name} — ${cmd.description}\nUsage: ${cmd.usage}`
+        : `Available commands:\n${[...COMMAND_MAP.keys()].map(k => `  /${k}`).join('\n')}`,
+    })
+  },
+  logout: async () => {
+    await clearConfig()
+    const session = $session.get()
+    $session.set({ ...session, token: null, isAuthenticated: false, email: null, plan: null, userId: null })
+    wsClient.destroy()
+    addMessage({ role: 'system', content: 'Logged out successfully.' })
+    openOverlay(await getLoginOverlay())
+  },
+}
+
+// Tier 2: API handlers (REST calls, job submission)
+const API_HANDLERS: Record<string, (parsed: NonNullable<ReturnType<typeof parseSlashCommand>>) => Promise<void>> = {
+  compile: async (p) => {
+    if ($activeJobId.get() != null) {
+      addMessage({ role: 'error', content: 'A job is already running. Use /cancel to stop it first.' })
+      return
+    }
+    const { runCompile } = await import('../tools/compile.js')
+    await runCompile(p)
+  },
+  health: async () => {
+    const { getApiClient } = await import('../lib/api-client.js')
+    try {
+      const result = await getApiClient().get<{ status: string }>('/health')
+      addMessage({ role: 'system', content: `Backend status: ${result.status}` })
+    } catch (err) {
+      addMessage({ role: 'error', content: `Health check failed: ${String(err)}` })
+    }
+  },
+  cancel: async (p) => {
+    const jobId = p.positional[0] ?? $activeJobId.get()
+    if (!jobId) {
+      addMessage({ role: 'error', content: 'No active job to cancel.' })
+      return
+    }
+    const { getApiClient } = await import('../lib/api-client.js')
+    try {
+      await getApiClient().post(`/api/jobs/${jobId}/cancel`)
+      addMessage({ role: 'system', content: `Job ${jobId} cancellation requested.` })
+    } catch (err) {
+      addMessage({ role: 'error', content: `Cancel failed: ${String(err)}` })
+    }
+  },
+}
+
+export async function dispatch(input: string): Promise<void> {
+  if (input.startsWith('/')) {
+    const parsed = parseSlashCommand(input)
+    if (!parsed) return
+
+    addMessage({ role: 'user', content: input })
+
+    const localHandler = LOCAL_HANDLERS[parsed.name]
+    if (localHandler) {
+      await localHandler(parsed)
+      return
+    }
+
+    const apiHandler = API_HANDLERS[parsed.name]
+    if (apiHandler) {
+      await apiHandler(parsed)
+      return
+    }
+
+    // Unknown command
+    addMessage({
+      role: 'error',
+      content: `Unknown command: /${parsed.name}. Type /help to see available commands.`,
+    })
+    return
+  }
+
+  // Free-text input: agent mode (not yet implemented in Phase 1)
+  addMessage({ role: 'user', content: input })
+  addMessage({
+    role: 'system',
+    content: 'No model configured — run /byok to add an API key or /model to select a provider.',
+  })
+}

--- a/packages/tui/src/commands/parser.ts
+++ b/packages/tui/src/commands/parser.ts
@@ -1,0 +1,61 @@
+export interface ParsedCommand {
+  name: string
+  args: Record<string, string | boolean>
+  positional: string[]
+  raw: string
+}
+
+export function parseSlashCommand(input: string): ParsedCommand | null {
+  if (!input.startsWith('/')) return null
+
+  const withoutSlash = input.slice(1)
+  const tokens: string[] = []
+  // Tokenize: handle --key="value with spaces", "quoted strings", and plain tokens
+  const re = /--[\w-]+=(?:"[^"]*"|[^\s]+)|--[\w-]+|"([^"]*)"|(\S+)/g
+  let match: RegExpExecArray | null
+
+  while ((match = re.exec(withoutSlash)) !== null) {
+    tokens.push(match[0])
+  }
+
+  if (tokens.length === 0) return null
+
+  const [nameRaw, ...rest] = tokens
+  if (!nameRaw) return null
+
+  const args: Record<string, string | boolean> = {}
+  const positional: string[] = []
+
+  let i = 0
+  while (i < rest.length) {
+    const tok = rest[i]!
+    if (tok.startsWith('--')) {
+      if (tok.includes('=')) {
+        const eqIdx = tok.indexOf('=')
+        const key = tok.slice(2, eqIdx)
+        let val = tok.slice(eqIdx + 1)
+        if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1)
+        args[key] = val
+        i++
+      } else {
+        const key = tok.slice(2)
+        const next = rest[i + 1]
+        if (next && !next.startsWith('--')) {
+          let val = next
+          if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1)
+          args[key] = val
+          i += 2
+        } else {
+          args[key] = true
+          i++
+        }
+      }
+    } else {
+      const val = tok.startsWith('"') && tok.endsWith('"') ? tok.slice(1, -1) : tok
+      positional.push(val)
+      i++
+    }
+  }
+
+  return { name: nameRaw.toLowerCase(), args, positional, raw: input }
+}

--- a/packages/tui/src/commands/registry.ts
+++ b/packages/tui/src/commands/registry.ts
@@ -1,0 +1,43 @@
+export interface SlashCommand {
+  name: string
+  description: string
+  usage: string
+  isLocal: boolean
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  { name: 'compile', description: 'Compile selected resume to PDF', usage: '/compile [resume-id] [--compiler pdflatex|xelatex|lualatex]', isLocal: false },
+  { name: 'optimize', description: 'AI-optimize resume for a job', usage: '/optimize [resume-id] [--jd url|file] [--level conservative|balanced|aggressive]', isLocal: false },
+  { name: 'combined', description: 'Optimize + compile in one job', usage: '/combined [resume-id] [--jd url|file]', isLocal: false },
+  { name: 'ats', description: 'Run ATS deep analysis', usage: '/ats [resume-id] [--jd url|file] [--industry software_engineering]', isLocal: false },
+  { name: 'quick-ats', description: 'Fast rule-based ATS (no LLM)', usage: '/quick-ats [resume-id]', isLocal: false },
+  { name: 'list', description: 'Open resume picker', usage: '/list [--archived] [--type resume|academic_cv]', isLocal: true },
+  { name: 'new', description: 'Create new resume', usage: '/new [title]', isLocal: false },
+  { name: 'edit', description: 'Open resume in $EDITOR', usage: '/edit [resume-id]', isLocal: false },
+  { name: 'fork', description: 'Fork resume into a variant', usage: '/fork [resume-id] [new-title]', isLocal: false },
+  { name: 'pdf', description: 'Download and open last PDF', usage: '/pdf [job-id]', isLocal: false },
+  { name: 'log', description: 'View full pdflatex log', usage: '/log [job-id]', isLocal: false },
+  { name: 'cancel', description: 'Cancel running job', usage: '/cancel [job-id]', isLocal: false },
+  { name: 'jobs', description: 'Open job monitor overlay', usage: '/jobs', isLocal: true },
+  { name: 'byok', description: 'Manage BYOK API keys', usage: '/byok', isLocal: true },
+  { name: 'analytics', description: 'View personal analytics', usage: '/analytics [--period 7d|30d|90d]', isLocal: false },
+  { name: 'billing', description: 'View subscription and billing', usage: '/billing', isLocal: true },
+  { name: 'tracker', description: 'Open job application tracker', usage: '/tracker', isLocal: true },
+  { name: 'cover', description: 'Generate cover letter', usage: '/cover [resume-id] --company "..." --role "..."', isLocal: false },
+  { name: 'interview', description: 'Generate interview questions', usage: '/interview [resume-id] --jd url|file', isLocal: false },
+  { name: 'health', description: 'Show backend health status', usage: '/health', isLocal: false },
+  { name: 'history', description: 'Show optimization history', usage: '/history [resume-id]', isLocal: false },
+  { name: 'checkpoint', description: 'Create named checkpoint', usage: '/checkpoint [resume-id] [label]', isLocal: false },
+  { name: 'restore', description: 'Restore to a checkpoint', usage: '/restore [resume-id]', isLocal: true },
+  { name: 'diff', description: 'Show diff with parent variant', usage: '/diff [resume-id]', isLocal: false },
+  { name: 'export', description: 'Export resume to another format', usage: '/export [resume-id] --format docx|markdown|html', isLocal: false },
+  { name: 'share', description: 'Generate and copy share link', usage: '/share [resume-id]', isLocal: false },
+  { name: 'snippets', description: 'Browse snippet marketplace', usage: '/snippets', isLocal: true },
+  { name: 'settings', description: 'Open notification settings', usage: '/settings', isLocal: true },
+  { name: 'help', description: 'Show help', usage: '/help [command]', isLocal: true },
+  { name: 'model', description: 'Open model picker for agent mode', usage: '/model', isLocal: true },
+  { name: 'clear', description: 'Clear transcript', usage: '/clear', isLocal: true },
+  { name: 'logout', description: 'Clear session and exit', usage: '/logout', isLocal: true },
+]
+
+export const COMMAND_MAP = new Map(SLASH_COMMANDS.map(c => [c.name, c]))


### PR DESCRIPTION
## Summary

- Add src/commands/registry.ts: SLASH_COMMANDS array with 32 commands (compile, optimize, combined, ats, list, new, edit, cancel, help, logout, etc.) and O(1) COMMAND_MAP
- Add src/commands/parser.ts: tokenizer handling --key=value, --flag value, boolean flags, quoted strings, positional args; returns ParsedCommand or null for free-text
- Add src/commands/dispatch.ts: LOCAL_HANDLERS (list/clear/help/logout, no API), API_HANDLERS (compile/health/cancel); free-text falls through to agent placeholder; lazy imports to avoid circular deps

## Issues

Closes #638, #639, #640

## Test plan

- [ ] All 39 tests pass: `cd packages/tui && pnpm test`
- [ ] TypeScript clean: `pnpm typecheck`
- [ ] Build succeeds: `pnpm build`
- [ ] Shebang in dist/cli.js: `head -1 packages/tui/dist/cli.js`