### PR TITLE
feat(tui): overlays and tools — LoginOverlay, ResumePicker, compile tool

### DIFF
--- a/packages/tui/src/components/overlays/LoginOverlay.tsx
+++ b/packages/tui/src/components/overlays/LoginOverlay.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useCallback } from 'react'
+import { Box, Text, useInput } from 'ink'
+import TextInput from 'ink-text-input'
+import { initApiClient } from '../../lib/api-client.js'
+import { writeConfig } from '../../lib/config.js'
+import { $session } from '../../stores/session.js'
+import { closeOverlay } from '../../stores/overlay.js'
+import { addMessage } from '../../stores/messages.js'
+import { wsClient } from '../../lib/ws-client.js'
+import { $ui } from '../../stores/ui.js'
+
+type Step = 'email' | 'password' | 'loading' | 'error'
+
+interface AuthResponse {
+  token: string
+  user: { id: string; email: string; plan?: string }
+}
+
+export function LoginOverlay(): React.ReactElement {
+  const [step, setStep] = useState<Step>('email')
+  const [email, setEmail] = useState(process.env['LATEXY_EMAIL'] ?? '')
+  const [password, setPassword] = useState('')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  const handleEmailSubmit = useCallback((val: string) => {
+    if (!val.trim()) return
+    setEmail(val.trim())
+    setStep('password')
+  }, [])
+
+  const handlePasswordSubmit = useCallback(async (val: string) => {
+    if (!val.trim()) return
+    setStep('loading')
+    setErrorMsg(null)
+
+    const session = $session.get()
+    const client = initApiClient(session.backendUrl, null)
+
+    try {
+      // Better Auth signin endpoint
+      const res = await client.post<AuthResponse>('/api/auth/sign-in/email', {
+        email: email.trim(),
+        password: val,
+      })
+
+      // Clear password from process env
+      if ('LATEXY_PASSWORD' in process.env) {
+        delete process.env['LATEXY_PASSWORD']
+      }
+
+      const { token, user } = res
+      await writeConfig({ token, email: user.email, userId: user.id })
+
+      const newClient = initApiClient(session.backendUrl, token)
+      void newClient // used for side effects
+      const wsUrl = session.wsUrl
+
+      $session.set({
+        ...session,
+        token,
+        userId: user.id,
+        email: user.email,
+        plan: (user.plan ?? null) as 'free' | 'basic' | 'pro' | 'byok' | 'team' | null,
+        isAuthenticated: true,
+      })
+
+      wsClient.connect(wsUrl, token)
+      wsClient.on('connected', () => {
+        $ui.set({ ...$ui.get(), wsConnected: true })
+        wsClient.drain()
+      })
+
+      closeOverlay()
+      addMessage({ role: 'system', content: `Welcome, ${user.email}` })
+    } catch (err) {
+      setErrorMsg(String(err))
+      setStep('error')
+      setPassword('')
+    }
+  }, [email])
+
+  useInput((_input, key) => {
+    if (key.escape && step === 'error') {
+      setStep('email')
+      setErrorMsg(null)
+    }
+  })
+
+  return (
+    <Box flexDirection="column" padding={2} borderStyle="round" borderColor="cyan">
+      <Text bold color="cyan">Welcome to Latexy</Text>
+      <Text dimColor>Sign in to continue</Text>
+      <Box marginTop={1} />
+
+      {step === 'email' && (
+        <Box gap={1}>
+          <Text>Email:</Text>
+          <TextInput
+            value={email}
+            onChange={setEmail}
+            onSubmit={handleEmailSubmit}
+            placeholder="you@example.com"
+          />
+        </Box>
+      )}
+
+      {step === 'password' && (
+        <>
+          <Text dimColor>Email: {email}</Text>
+          <Box gap={1} marginTop={1}>
+            <Text>Password:</Text>
+            <TextInput
+              value={password}
+              onChange={setPassword}
+              onSubmit={(val) => { void handlePasswordSubmit(val) }}
+              mask="*"
+              placeholder="••••••••"
+            />
+          </Box>
+        </>
+      )}
+
+      {step === 'loading' && (
+        <Text color="yellow">Signing in…</Text>
+      )}
+
+      {step === 'error' && (
+        <Box flexDirection="column" gap={1}>
+          <Text color="red">✗ {errorMsg}</Text>
+          <Text dimColor>Press Esc to try again</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/packages/tui/src/components/overlays/ResumePicker.tsx
+++ b/packages/tui/src/components/overlays/ResumePicker.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { Box, Text, useInput } from 'ink'
+import TextInput from 'ink-text-input'
+import { getApiClient } from '../../lib/api-client.js'
+import { closeOverlay } from '../../stores/overlay.js'
+import { writeConfig } from '../../lib/config.js'
+import { addMessage } from '../../stores/messages.js'
+
+interface Resume {
+  id: string
+  title: string
+  type?: string
+  updated_at: string
+  is_pinned?: boolean
+}
+
+interface ResumeListResponse {
+  resumes: Resume[]
+  total: number
+}
+
+export function ResumePicker(): React.ReactElement {
+  const [resumes, setResumes] = useState<Resume[]>([])
+  const [filter, setFilter] = useState('')
+  const [cursor, setCursor] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    const client = getApiClient()
+    client.get<ResumeListResponse>('/api/resumes?limit=50')
+      .then(res => {
+        setResumes(res.resumes)
+        setLoading(false)
+      })
+      .catch(err => {
+        setErrorMsg(String(err))
+        setLoading(false)
+      })
+  }, [])
+
+  const filtered = filter
+    ? resumes.filter(r => r.title.toLowerCase().includes(filter.toLowerCase()))
+    : resumes
+
+  const select = useCallback((resume: Resume) => {
+    void writeConfig({ defaultResumeId: resume.id })
+    addMessage({ role: 'system', content: `Selected: ${resume.title}` })
+    closeOverlay()
+  }, [])
+
+  useInput((_input, key) => {
+    if (key.escape) { closeOverlay(); return }
+    if (key.upArrow) { setCursor(c => Math.max(0, c - 1)); return }
+    if (key.downArrow) { setCursor(c => Math.min(filtered.length - 1, c + 1)); return }
+    if (key.return && filtered[cursor]) { select(filtered[cursor]!); return }
+  })
+
+  const formatAge = (iso: string): string => {
+    const days = Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000)
+    if (days === 0) return 'today'
+    if (days === 1) return 'yesterday'
+    if (days < 30) return `${days}d ago`
+    return `${Math.floor(days / 30)}mo ago`
+  }
+
+  return (
+    <Box flexDirection="column" borderStyle="double" borderColor="cyan" padding={1}>
+      <Text bold color="cyan">Select Resume</Text>
+      <Text dimColor>↑↓ navigate · Enter select · Esc cancel</Text>
+      <Box marginTop={1} gap={1}>
+        <Text dimColor>Filter:</Text>
+        <TextInput value={filter} onChange={setFilter} placeholder="type to filter..." />
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        {loading && <Text color="yellow">Loading resumes…</Text>}
+        {errorMsg != null && <Text color="red">Error: {errorMsg}</Text>}
+        {!loading && errorMsg == null && filtered.length === 0 && (
+          <Text dimColor>No resumes found</Text>
+        )}
+        {filtered.map((r, i) => (
+          <Box key={r.id} gap={2}>
+            <Text color={i === cursor ? 'cyan' : undefined}>
+              {i === cursor ? '▶' : ' '} {r.title}
+            </Text>
+            {r.type && <Text dimColor>{r.type}</Text>}
+            <Text dimColor>{formatAge(r.updated_at)}</Text>
+            {r.is_pinned === true && <Text color="yellow">★</Text>}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}

--- a/packages/tui/src/tools/compile.ts
+++ b/packages/tui/src/tools/compile.ts
@@ -1,0 +1,114 @@
+import { readFile } from 'node:fs/promises'
+import { basename } from 'node:path'
+import type { ParsedCommand } from '../commands/parser.js'
+import { getApiClient } from '../lib/api-client.js'
+import { wsClient } from '../lib/ws-client.js'
+import { $session } from '../stores/session.js'
+import { addMessage, updateMessage, $activeJobId } from '../stores/messages.js'
+import { createJobController } from '../hooks/useJobStream.js'
+
+interface JobSubmitResponse {
+  job_id: string
+  status: string
+}
+
+interface ResumeListResponse {
+  resumes: Array<{ id: string; title: string }>
+}
+
+export async function runCompile(parsed: ParsedCommand): Promise<void> {
+  const client = getApiClient()
+  const session = $session.get()
+
+  if (!session.isAuthenticated) {
+    addMessage({ role: 'error', content: 'Not logged in. Use /login or restart to authenticate.' })
+    return
+  }
+
+  const compiler = (parsed.args['compiler'] as string | undefined) ?? 'pdflatex'
+  const resumeIdFlag = parsed.args['resume-id'] as string | undefined
+  // Positional: if it looks like a UUID (contains dashes), treat as resume-id; otherwise treat as file path
+  const firstPositional = parsed.positional[0]
+  const looksLikeUUID = firstPositional ? /^[0-9a-f-]{36}$/i.test(firstPositional) : false
+  const resumeId = resumeIdFlag ?? (looksLikeUUID ? firstPositional : undefined)
+  const filePath = !looksLikeUUID ? firstPositional : undefined
+
+  // Case 1: local .tex file upload
+  if (filePath) {
+    const toolMsgId = addMessage({
+      role: 'tool_use',
+      content: '',
+      toolName: 'compile_pdf',
+      toolState: 'running',
+      toolArgs: { file: basename(filePath), compiler },
+    })
+
+    try {
+      const fileBytes = await readFile(filePath)
+      const form = new FormData()
+      form.append('file', new Blob([fileBytes], { type: 'application/octet-stream' }), basename(filePath))
+      form.append('compiler', compiler)
+
+      const res = await client.postForm<JobSubmitResponse>('/api/compile', form)
+      const jobId = res.job_id
+
+      $activeJobId.set(jobId)
+      const ctrl = createJobController(jobId)
+      ctrl.setToolMsgId(toolMsgId)
+      wsClient.subscribe(jobId, '0')
+    } catch (err) {
+      updateMessage(toolMsgId, {
+        toolState: 'error',
+        toolResult: { error: String(err) },
+        durationMs: 0,
+      })
+    }
+    return
+  }
+
+  // Case 2: resume ID given — submit job directly
+  let actualResumeId = resumeId
+
+  if (!actualResumeId) {
+    // No resume specified — fetch first resume
+    try {
+      const list = await client.get<ResumeListResponse>('/api/resumes?limit=1')
+      actualResumeId = list.resumes[0]?.id
+      if (!actualResumeId) {
+        addMessage({ role: 'error', content: 'No resumes found. Create one first with /new.' })
+        return
+      }
+    } catch (err) {
+      addMessage({ role: 'error', content: `Failed to fetch resumes: ${String(err)}` })
+      return
+    }
+  }
+
+  const toolMsgId = addMessage({
+    role: 'tool_use',
+    content: '',
+    toolName: 'compile_pdf',
+    toolState: 'running',
+    toolArgs: { resume_id: actualResumeId, compiler },
+  })
+
+  try {
+    const res = await client.post<JobSubmitResponse>('/api/jobs/submit', {
+      job_type: 'latex_compilation',
+      resume_id: actualResumeId,
+      settings: { compiler },
+    })
+    const jobId = res.job_id
+
+    $activeJobId.set(jobId)
+    const ctrl = createJobController(jobId)
+    ctrl.setToolMsgId(toolMsgId)
+    wsClient.subscribe(jobId, '0')
+  } catch (err) {
+    updateMessage(toolMsgId, {
+      toolState: 'error',
+      toolResult: { error: String(err) },
+      durationMs: 0,
+    })
+  }
+}


### PR DESCRIPTION
## Summary

- Add src/tools/compile.ts: two paths — local .tex file via FormData POST or resume UUID job submission; fallback fetches first resume if no arg given; integrates JobController and sets $activeJobId
- Add src/components/overlays/LoginOverlay.tsx: 4-step Better Auth flow (email → password → loading → success/error); writes config, updates $session, connects WS, drains buffer on success; masked password field
- Add src/components/overlays/ResumePicker.tsx: fetches /api/resumes?limit=50, filterable by title, ↑↓/Enter/Esc keyboard nav, shows type/age/pinned fields, writes defaultResumeId to config on select

## Issues

Closes #641, #642, #643

## Test plan

- [ ] All 39 tests pass: `cd packages/tui && pnpm test`
- [ ] TypeScript clean: `pnpm typecheck`
- [ ] Build succeeds: `pnpm build`
- [ ] Shebang in dist/cli.js: `head -1 packages/tui/dist/cli.js`