### PR TITLE
feat(tui): entry points — app root, CLI entry, headless CI mode

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect } from 'react'
+import { useStore } from '@nanostores/react'
+import { $session } from './stores/session.js'
+import { $overlay, openOverlay } from './stores/overlay.js'
+import { $ui } from './stores/ui.js'
+import { AppShell } from './components/AppShell.js'
+import { wsClient } from './lib/ws-client.js'
+import { initApiClient } from './lib/api-client.js'
+import { readConfig } from './lib/config.js'
+import { addMessage } from './stores/messages.js'
+
+export function App(): React.ReactElement {
+  const _session = useStore($session)
+  const _overlay = useStore($overlay)
+
+  useEffect(() => {
+    const init = async (): Promise<void> => {
+      const cfg = await readConfig()
+
+      const backendUrl = cfg.backendUrl
+      const wsUrl = backendUrl.replace(/^http/, 'ws') + '/ws/jobs'
+
+      initApiClient(backendUrl, cfg.token)
+
+      $session.set({
+        token: cfg.token,
+        userId: cfg.userId ?? null,
+        email: cfg.email ?? null,
+        plan: null,
+        backendUrl,
+        wsUrl,
+        isAuthenticated: cfg.token != null,
+      })
+
+      if (cfg.token) {
+        wsClient.connect(wsUrl, cfg.token)
+        wsClient.on('connected', () => {
+          $ui.set({ ...$ui.get(), wsConnected: true })
+          wsClient.drain()
+        })
+        wsClient.on('disconnected', () => {
+          $ui.set({ ...$ui.get(), wsConnected: false })
+        })
+
+        // Validate token + get user info
+        const { getApiClient } = await import('./lib/api-client.js')
+        try {
+          const me = await getApiClient().get<{ id: string; email: string; plan?: string }>('/api/me')
+          $session.set({
+            ...$session.get(),
+            userId: me.id,
+            email: me.email,
+            plan: (me.plan ?? null) as 'free' | 'basic' | 'pro' | 'byok' | 'team' | null,
+          })
+          addMessage({ role: 'system', content: `Welcome back, ${me.email}` })
+        } catch {
+          // Invalid token — show login
+          $session.set({ ...$session.get(), token: null, isAuthenticated: false })
+          const { LoginOverlay } = await import('./components/overlays/LoginOverlay.js')
+          openOverlay(React.createElement(LoginOverlay))
+        }
+
+        // Background health poll every 30s
+        const poll = async () => {
+          try {
+            await getApiClient().get('/health')
+            $ui.set({ ...$ui.get(), healthStatus: 'healthy' })
+          } catch {
+            $ui.set({ ...$ui.get(), healthStatus: 'unhealthy' })
+          }
+        }
+        await poll()
+        setInterval(() => { void poll() }, 30_000)
+      } else {
+        const { LoginOverlay } = await import('./components/overlays/LoginOverlay.js')
+        openOverlay(React.createElement(LoginOverlay))
+      }
+    }
+
+    init().catch(err => {
+      addMessage({ role: 'error', content: `Startup error: ${String(err)}` })
+    })
+  }, [])
+
+  return <AppShell />
+}

--- a/packages/tui/src/cli.tsx
+++ b/packages/tui/src/cli.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render } from 'ink'
+import { App } from './app.js'
+import { runHeadless } from './headless.js'
+
+const args = process.argv.slice(2)
+const isCI = process.env['CI'] === 'true' || process.stdout.isTTY !== true
+const hasJsonFlag = args.includes('--json')
+const subcommand = args.find(a => !a.startsWith('-'))
+
+if (isCI || hasJsonFlag) {
+  runHeadless(subcommand, args).then(code => {
+    process.exit(code)
+  }).catch(err => {
+    const msg = String(err)
+    if (hasJsonFlag) {
+      process.stdout.write(JSON.stringify({ success: false, error: msg }) + '\n')
+    } else {
+      process.stderr.write(`Error: ${msg}\n`)
+    }
+    process.exit(1)
+  })
+} else {
+  const { unmount } = render(React.createElement(App), { patchConsole: false })
+  process.on('SIGTERM', () => {
+    unmount()
+    process.exit(0)
+  })
+}

--- a/packages/tui/src/headless.ts
+++ b/packages/tui/src/headless.ts
@@ -1,0 +1,128 @@
+import { readConfig } from './lib/config.js'
+import { initApiClient } from './lib/api-client.js'
+import { wsClient } from './lib/ws-client.js'
+import type { AnyEvent, JobCompletedEvent, JobFailedEvent } from './lib/event-types.js'
+import { readFile, writeFile } from 'node:fs/promises'
+import { basename } from 'node:path'
+
+const useJson = process.argv.includes('--json')
+
+function out(obj: unknown): void {
+  if (useJson) process.stdout.write(JSON.stringify(obj) + '\n')
+  else process.stderr.write(JSON.stringify(obj, null, 2) + '\n')
+}
+
+function log(msg: string): void {
+  process.stderr.write(msg + '\n')
+}
+
+async function waitForJob(jobId: string, token: string, wsUrl: string): Promise<JobCompletedEvent | JobFailedEvent> {
+  return new Promise((resolve, reject) => {
+    wsClient.connect(wsUrl, token)
+    wsClient.drain()
+    wsClient.subscribe(jobId, '0')
+
+    const timeout = setTimeout(() => {
+      wsClient.destroy()
+      reject(new Error('Job timed out after 5 minutes'))
+    }, 300_000)
+
+    wsClient.on('event', (ev: AnyEvent) => {
+      if (ev.job_id !== jobId) return
+      if (ev.type === 'log.line') log(ev.line)
+      if (ev.type === 'job.progress') log(`[${ev.percent}%] ${ev.stage}`)
+      if (ev.type === 'job.completed' || ev.type === 'job.failed') {
+        clearTimeout(timeout)
+        wsClient.destroy()
+        resolve(ev)
+      }
+    })
+  })
+}
+
+async function headlessCompile(args: string[]): Promise<number> {
+  const cfg = await readConfig()
+  if (!cfg.token) {
+    out({ success: false, error: 'Not authenticated. Set LATEXY_SESSION_TOKEN env var.' })
+    return 2
+  }
+
+  const client = initApiClient(cfg.backendUrl, cfg.token)
+  const wsUrl = cfg.backendUrl.replace(/^http/, 'ws') + '/ws/jobs'
+
+  const resumeIdIdx = args.indexOf('--resume-id')
+  const resumeId = resumeIdIdx !== -1 ? args[resumeIdIdx + 1] : null
+  const compilerIdx = args.indexOf('--compiler')
+  const compiler = compilerIdx !== -1 ? args[compilerIdx + 1] ?? 'pdflatex' : 'pdflatex'
+  const outputIdx = args.indexOf('--output')
+  const outputPath = outputIdx !== -1 ? args[outputIdx + 1] ?? null : null
+
+  let jobId: string
+
+  if (resumeId) {
+    log(`Compiling resume ${resumeId}…`)
+    const res = await client.post<{ job_id: string }>('/api/jobs/submit', {
+      job_type: 'latex_compilation',
+      resume_id: resumeId,
+      settings: { compiler },
+    })
+    jobId = res.job_id
+  } else {
+    // Local file upload
+    const filePath = args.find(a => !a.startsWith('-') && a !== 'compile')
+    if (!filePath) {
+      out({ success: false, error: 'Provide a .tex file path or --resume-id <uuid>' })
+      return 3
+    }
+    log(`Uploading ${basename(filePath)}…`)
+    const bytes = await readFile(filePath)
+    const form = new FormData()
+    form.append('file', new Blob([bytes], { type: 'application/octet-stream' }), basename(filePath))
+    form.append('compiler', compiler)
+    const res = await client.postForm<{ job_id: string }>('/api/compile', form)
+    jobId = res.job_id
+  }
+
+  log(`Job submitted: ${jobId}`)
+  const ev = await waitForJob(jobId, cfg.token, wsUrl)
+
+  if (ev.type === 'job.completed') {
+    const result = ev.result as Record<string, unknown>
+    if (outputPath && result['pdf_url']) {
+      const pdfRes = await fetch(cfg.backendUrl + (result['pdf_url'] as string), {
+        headers: { Authorization: `Bearer ${cfg.token}` },
+      })
+      const buf = await pdfRes.arrayBuffer()
+      await writeFile(outputPath, Buffer.from(buf))
+      log(`PDF saved: ${outputPath}`)
+    }
+    out({
+      success: true,
+      job_id: jobId,
+      pages: result['pages'] ?? null,
+      size_bytes: result['size_bytes'] ?? null,
+      ats_score: result['ats_score'] ?? null,
+      pdf_url: result['pdf_url'] ?? null,
+      compilation_time_ms: result['compilation_time_ms'] ?? null,
+    })
+    return 0
+  } else {
+    const failed = ev as JobFailedEvent
+    out({ success: false, error: failed.error, error_code: failed.error_code, retryable: failed.retryable })
+    return 1
+  }
+}
+
+export async function runHeadless(subcommand: string | undefined, args: string[]): Promise<number> {
+  try {
+    switch (subcommand) {
+      case 'compile': return await headlessCompile(args.slice(1))
+      default:
+        out({ success: false, error: `Unknown subcommand: ${String(subcommand)}. Available: compile` })
+        return 3
+    }
+  } catch (err) {
+    out({ success: false, error: String(err) })
+    return 1
+  }
+}


### PR DESCRIPTION
## Summary

- Add src/app.tsx: reads config, inits API client, sets $session, connects WS, validates token via /api/me, polls /health every 30s; shows LoginOverlay on missing/invalid token
- Add src/cli.tsx: detects CI (isTTY !== true or CI=true env), routes to render(<App />) or runHeadless(); handles SIGTERM with WS disconnect and graceful exit
- Add src/headless.ts: runHeadless('compile', args) submits job, streams WS events to stderr, outputs JSON to stdout (--json), downloads PDF (--output), returns exit code 0/1

## Issues

Closes #644, #645, #646

## Test plan

- [ ] All 39 tests pass: `cd packages/tui && pnpm test`
- [ ] TypeScript clean: `pnpm typecheck`
- [ ] Build succeeds: `pnpm build`
- [ ] Shebang in dist/cli.js: `head -1 packages/tui/dist/cli.js`