### PR TITLE
feat(modal): Modal infra — profile, dispatch helper, DEPLOY_TARGET config

### DIFF
--- a/.modal.toml
+++ b/.modal.toml
@@ -1,0 +1,1 @@
+active = "latexy"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -206,11 +206,18 @@ class Settings(BaseSettings):
     DEV_API_DAILY_LIMIT_PRO: int = 1000
     DEV_API_DAILY_LIMIT_BYOK: int = 500
 
+    # Deployment target
+    DEPLOY_TARGET: str = Field(default="local", description="Deployment target: 'local' (Celery) or 'modal'")
+
     # Redis Config
     REDIS_URL: str = Field(default="redis://localhost:6379/0", description="Redis URL for job queue")
     REDIS_CACHE_URL: str = Field(default="redis://localhost:6379/1", description="Redis URL for caching")
     REDIS_PASSWORD: str = Field(default="", description="Redis password")
     REDIS_MAX_CONNECTIONS: int = Field(default=20, description="Redis max connections")
+
+    # Upstash Redis (for Modal deployment)
+    UPSTASH_REDIS_REST_URL: str = Field(default="", description="Upstash Redis REST URL")
+    UPSTASH_REDIS_REST_TOKEN: str = Field(default="", description="Upstash Redis REST token")
 
     # Celery Configuration
     CELERY_BROKER_URL: str = Field(default="redis://localhost:6379/0", description="Celery broker URL")

--- a/backend/app/core/modal_dispatch.py
+++ b/backend/app/core/modal_dispatch.py
@@ -1,0 +1,20 @@
+"""
+Modal task dispatcher — used when DEPLOY_TARGET=modal.
+
+Call spawn(function_name, payload) to fire-and-forget a Modal function.
+All imports are lazy so this module is safe to import in local-dev mode.
+"""
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_APP_NAME = "latexy-backend"
+
+
+def spawn(function_name: str, payload: dict) -> None:
+    """Fire-and-forget a Modal function by name."""
+    import modal  # noqa: PLC0415 — intentionally lazy
+    fn = modal.Function.from_name(_APP_NAME, function_name)
+    fn.spawn(payload)
+    logger.debug("Modal spawn: %s", function_name)


### PR DESCRIPTION
## Summary
- Adds `.modal.toml` to set active Modal workspace profile to `latexy`
- Adds `backend/app/core/modal_dispatch.py` with a lazy-import `spawn(fn_name, payload)` helper — safe to import in local-dev where `modal` is not installed
- Extends `backend/app/core/config.py` with `DEPLOY_TARGET` (default `"local"`), `UPSTASH_REDIS_REST_URL`, and `UPSTASH_REDIS_REST_TOKEN` settings

## Issues Closed
- closes #678 (.modal.toml workspace profile)
- closes #679 (modal_dispatch.py fire-and-forget helper)
- closes #681 (DEPLOY_TARGET + Upstash config fields)

## Test Plan
- [ ] `DEPLOY_TARGET` defaults to `"local"` — no behaviour change on existing local/Docker setup
- [ ] `from app.core.modal_dispatch import spawn` does not raise ImportError in local mode (modal not installed)
- [ ] `.modal.toml` selects latexy workspace when running `modal` CLI commands