### PR TITLE
feat(modal): add Modal dispatch branches to all 5 worker submit functions

### DIFF
--- a/.modal.toml
+++ b/.modal.toml
@@ -1,0 +1,1 @@
+active = "latexy"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -206,11 +206,18 @@ class Settings(BaseSettings):
     DEV_API_DAILY_LIMIT_PRO: int = 1000
     DEV_API_DAILY_LIMIT_BYOK: int = 500
 
+    # Deployment target
+    DEPLOY_TARGET: str = Field(default="local", description="Deployment target: 'local' (Celery) or 'modal'")
+
     # Redis Config
     REDIS_URL: str = Field(default="redis://localhost:6379/0", description="Redis URL for job queue")
     REDIS_CACHE_URL: str = Field(default="redis://localhost:6379/1", description="Redis URL for caching")
     REDIS_PASSWORD: str = Field(default="", description="Redis password")
     REDIS_MAX_CONNECTIONS: int = Field(default=20, description="Redis max connections")
+
+    # Upstash Redis (for Modal deployment)
+    UPSTASH_REDIS_REST_URL: str = Field(default="", description="Upstash Redis REST URL")
+    UPSTASH_REDIS_REST_TOKEN: str = Field(default="", description="Upstash Redis REST token")
 
     # Celery Configuration
     CELERY_BROKER_URL: str = Field(default="redis://localhost:6379/0", description="Celery broker URL")

--- a/backend/app/core/modal_dispatch.py
+++ b/backend/app/core/modal_dispatch.py
@@ -1,0 +1,20 @@
+"""
+Modal task dispatcher — used when DEPLOY_TARGET=modal.
+
+Call spawn(function_name, payload) to fire-and-forget a Modal function.
+All imports are lazy so this module is safe to import in local-dev mode.
+"""
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_APP_NAME = "latexy-backend"
+
+
+def spawn(function_name: str, payload: dict) -> None:
+    """Fire-and-forget a Modal function by name."""
+    import modal  # noqa: PLC0415 — intentionally lazy
+    fn = modal.Function.from_name(_APP_NAME, function_name)
+    fn.spawn(payload)
+    logger.debug("Modal spawn: %s", function_name)

--- a/backend/app/workers/ats_worker.py
+++ b/backend/app/workers/ats_worker.py
@@ -328,6 +328,23 @@ def submit_ats_scoring(
     if priority is None:
         priority = get_task_priority(user_plan)
 
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_ats_task", {
+            "latex_content": latex_content,
+            "job_id": job_id,
+            "job_description": job_description,
+            "industry": industry,
+            "industry_profile_key": industry_profile_key,
+            "user_id": user_id,
+            "user_plan": user_plan,
+            "device_fingerprint": device_fingerprint,
+            "metadata": metadata,
+        })
+        logger.info(f"Modal spawn: ATS scoring for job {job_id}")
+        return job_id
+
     score_resume_ats_task.apply_async(
         args=[latex_content],
         kwargs={
@@ -358,6 +375,19 @@ def submit_job_description_analysis(
     """Enqueue analyze_job_description_ats_task on the ats queue."""
     if priority is None:
         priority = get_task_priority(user_plan)
+
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_jd_analysis_task", {
+            "job_description": job_description,
+            "job_id": job_id,
+            "user_id": user_id,
+            "user_plan": user_plan,
+            "metadata": metadata,
+        })
+        logger.info(f"Modal spawn: JD analysis for job {job_id}")
+        return job_id
 
     analyze_job_description_ats_task.apply_async(
         args=[job_description],
@@ -702,3 +732,68 @@ def embed_resume_task(
         if self.request.retries < self.max_retries:
             raise self.retry(countdown=60, exc=exc)
         return {"success": False, "resume_id": resume_id, "error": str(exc)}
+
+
+# ------------------------------------------------------------------ #
+#  Submit helpers for tasks without existing wrappers                 #
+# ------------------------------------------------------------------ #
+
+def submit_deep_analyze_ats(
+    latex_content: str,
+    job_id: str,
+    job_description: Optional[str] = None,
+    api_key: Optional[str] = None,
+    industry_override: Optional[str] = None,
+    metadata: Optional[Dict] = None,
+) -> str:
+    """Enqueue deep_analyze_ats_task (Celery) or Modal."""
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_deep_analyze_task", {
+            "latex_content": latex_content,
+            "job_id": job_id,
+            "job_description": job_description,
+            "api_key": api_key,
+            "industry_override": industry_override,
+            "metadata": metadata,
+        })
+        logger.info(f"Modal spawn: deep ATS analysis for job {job_id}")
+        return job_id
+
+    deep_analyze_ats_task.apply_async(
+        kwargs={
+            "latex_content": latex_content,
+            "job_id": job_id,
+            "job_description": job_description,
+            "api_key": api_key,
+            "industry_override": industry_override,
+            "metadata": metadata,
+        },
+        queue="ats",
+    )
+    logger.info(f"Submitted deep ATS analysis for job {job_id}")
+    return job_id
+
+
+def submit_embed_resume(
+    resume_id: str,
+    latex_content: str,
+    user_id: Optional[str] = None,
+) -> None:
+    """Enqueue embed_resume_task (Celery) or Modal. Fire-and-forget."""
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_embed_resume_task", {
+            "resume_id": resume_id,
+            "latex_content": latex_content,
+            "user_id": user_id,
+        })
+        return
+
+    embed_resume_task.apply_async(
+        kwargs={"resume_id": resume_id, "latex_content": latex_content, "user_id": user_id},
+        queue="ats",
+        priority=1,
+    )

--- a/backend/app/workers/cleanup_worker.py
+++ b/backend/app/workers/cleanup_worker.py
@@ -618,7 +618,20 @@ def submit_temp_files_cleanup(
     Returns:
         job_id: Job ID for tracking
     """
-    # Submit task to queue
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        import uuid
+        job_id = f"cleanup_{uuid.uuid4()}"
+        spawn("run_cleanup_task", {
+            "task_type": "temp_files",
+            "max_age_hours": max_age_hours,
+            "target_directory": target_directory,
+            "metadata": metadata,
+        })
+        logger.info(f"Modal spawn: temp files cleanup {job_id}")
+        return job_id
+
     task = cleanup_temp_files_task.apply_async(
         args=[max_age_hours],
         kwargs={
@@ -644,7 +657,20 @@ def submit_expired_jobs_cleanup(
     Returns:
         job_id: Job ID for tracking
     """
-    # Submit task to queue
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        import uuid
+        job_id = f"job_cleanup_{uuid.uuid4()}"
+        spawn("run_cleanup_task", {
+            "task_type": "expired_jobs",
+            "max_age_hours": max_age_hours,
+            "batch_size": batch_size,
+            "metadata": metadata,
+        })
+        logger.info(f"Modal spawn: expired jobs cleanup {job_id}")
+        return job_id
+
     task = cleanup_expired_jobs_task.apply_async(
         args=[max_age_hours],
         kwargs={

--- a/backend/app/workers/latex_worker.py
+++ b/backend/app/workers/latex_worker.py
@@ -518,11 +518,30 @@ def submit_latex_compilation(
     compile_settings: Optional[Dict] = None,
     watermark: Optional[str] = None,
 ) -> str:
-    """Enqueue compile_latex_task on the latex queue."""
+    """Enqueue compile_latex_task on the latex queue (Celery) or Modal."""
+    import os
     if priority is None:
         priority = get_task_priority(user_plan)
     compiler = compiler or settings.DEFAULT_LATEX_COMPILER
     timeout = timeout_seconds or get_compile_timeout(user_plan)
+
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_latex_task", {
+            "latex_content": latex_content,
+            "job_id": job_id,
+            "user_id": user_id,
+            "user_plan": user_plan,
+            "device_fingerprint": device_fingerprint,
+            "metadata": metadata,
+            "resume_id": resume_id,
+            "compiler": compiler,
+            "timeout_seconds": timeout,
+            "compile_settings": compile_settings,
+            "watermark": watermark,
+        })
+        logger.info(f"Modal spawn: LaTeX compilation for job {job_id} (compiler={compiler})")
+        return job_id
 
     compile_latex_task.apply_async(
         args=[latex_content],
@@ -540,8 +559,8 @@ def submit_latex_compilation(
         },
         priority=priority,
         queue="latex",
-        time_limit=timeout + 30,       # Celery hard kill
-        soft_time_limit=timeout + 15,  # raises SoftTimeLimitExceeded
+        time_limit=timeout + 30,
+        soft_time_limit=timeout + 15,
     )
     logger.info(f"Submitted LaTeX compilation for job {job_id} (compiler={compiler}, timeout={timeout}s)")
     return job_id

--- a/backend/app/workers/llm_worker.py
+++ b/backend/app/workers/llm_worker.py
@@ -275,6 +275,23 @@ def submit_resume_optimization(
     if priority is None:
         priority = get_task_priority(user_plan)
 
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_llm_task", {
+            "latex_content": latex_content,
+            "job_description": job_description,
+            "job_id": job_id,
+            "user_id": user_id,
+            "user_plan": user_plan,
+            "optimization_level": optimization_level,
+            "user_api_key": user_api_key,
+            "metadata": metadata,
+            "model": model,
+        })
+        logger.info(f"Modal spawn: LLM optimization for job {job_id}")
+        return job_id
+
     optimize_resume_task.apply_async(
         args=[latex_content, job_description],
         kwargs={

--- a/backend/app/workers/orchestrator.py
+++ b/backend/app/workers/orchestrator.py
@@ -672,6 +672,30 @@ def submit_optimize_and_compile(
     # Task time_limit covers both LLM stage (~120s) + compile stage + buffer
     task_time_limit = compile_timeout + 180
 
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_orchestrator_task", {
+            "latex_content": latex_content,
+            "job_description": job_description,
+            "job_id": job_id,
+            "user_id": user_id,
+            "user_plan": user_plan,
+            "optimization_level": optimization_level,
+            "user_api_key": user_api_key,
+            "device_fingerprint": device_fingerprint,
+            "target_sections": target_sections,
+            "custom_instructions": custom_instructions,
+            "model": model,
+            "metadata": metadata,
+            "resume_id": resume_id,
+            "compiler": compiler,
+            "timeout_seconds": compile_timeout,
+            "persona": persona,
+        })
+        logger.info(f"Modal spawn: orchestrator for job {job_id} (compiler={compiler})")
+        return job_id
+
     optimize_and_compile_task.apply_async(
         args=[latex_content, job_description],
         kwargs={


### PR DESCRIPTION
## Summary
All five worker modules gain a `DEPLOY_TARGET=modal` branch in their submit functions:

| Worker | Submit Function | Modal Target |
|---|---|---|
| `latex_worker.py` | `submit_latex_compilation` | `run_latex_task` |
| `llm_worker.py` | `submit_resume_optimization` | `run_llm_task` |
| `orchestrator.py` | `submit_optimize_and_compile` | `run_orchestrator_task` |
| `ats_worker.py` | `submit_ats_scoring` | `run_ats_task` |
| `ats_worker.py` | `submit_job_description_analysis` | `run_jd_analysis_task` |
| `ats_worker.py` | `submit_deep_analyze_ats` *(new)* | `run_deep_analyze_task` |
| `ats_worker.py` | `submit_embed_resume` *(new)* | `run_embed_resume_task` |
| `cleanup_worker.py` | `submit_temp_files_cleanup` | `run_cleanup_task` (task_type=temp_files) |
| `cleanup_worker.py` | `submit_expired_jobs_cleanup` | `run_cleanup_task` (task_type=expired_jobs) |

Local Celery paths are completely untouched.

## Issues Closed
- closes #682 (latex_worker Modal dispatch)
- closes #683 (llm_worker Modal dispatch)
- closes #684 (orchestrator Modal dispatch)
- closes #685 (ats_worker Modal dispatch + new submit helpers)
- closes #686 (cleanup_worker Modal dispatch)

## Test Plan
- [ ] `DEPLOY_TARGET=local` → all workers use existing Celery queues (no regression)
- [ ] `DEPLOY_TARGET=modal` → all submit functions call `modal_dispatch.spawn()` and return `job_id` immediately
- [ ] `submit_deep_analyze_ats` and `submit_embed_resume` are importable from `ats_worker`
- [ ] Cleanup tasks include correct `task_type` discriminator in payload