### PR TITLE
refactor(api-routes): dispatch-agnostic ATS/resume routes + Modal-aware health endpoint

### DIFF
--- a/.modal.toml
+++ b/.modal.toml
@@ -1,0 +1,1 @@
+active = "latexy"

--- a/backend/app/api/ats_routes.py
+++ b/backend/app/api/ats_routes.py
@@ -26,7 +26,7 @@ from ..services.ats_quick_scorer import quick_score_latex
 from ..services.ats_scoring_service import ats_scoring_service
 from ..services.ats_simulator_service import ATS_PROFILES, ats_simulator_service
 from ..services.industry_ats_profiles import INDUSTRY_PROFILES, detect_industry
-from ..workers.ats_worker import deep_analyze_ats_task, submit_ats_scoring, submit_job_description_analysis
+from ..workers.ats_worker import submit_ats_scoring, submit_deep_analyze_ats, submit_job_description_analysis
 
 logger = get_logger(__name__)
 
@@ -643,16 +643,13 @@ async def deep_analyze_resume(
     except Exception as e:
         logger.warning(f"Redis state write failed for job {job_id}: {e} — proceeding without state")
 
-    deep_analyze_ats_task.apply_async(
-        kwargs={
-            "latex_content": request.latex_content,
-            "job_id": job_id,
-            "job_description": request.job_description,
-            "api_key": api_key,
-            "industry_override": request.industry_override,
-            "metadata": {"user_id": user_id},
-        },
-        queue="ats",
+    submit_deep_analyze_ats(
+        latex_content=request.latex_content,
+        job_id=job_id,
+        job_description=request.job_description,
+        api_key=api_key,
+        industry_override=request.industry_override,
+        metadata={"user_id": user_id},
     )
 
     return DeepAnalyzeResponse(
@@ -713,11 +710,8 @@ async def semantic_match_resumes(
             # Fire background embed task so it's ready next time
             if settings.OPENAI_API_KEY:
                 try:
-                    from ..workers.ats_worker import embed_resume_task
-                    embed_resume_task.apply_async(
-                        kwargs={"resume_id": str(resume.id), "latex_content": resume.latex_content or ""},
-                        queue="ats", priority=1,
-                    )
+                    from ..workers.ats_worker import submit_embed_resume
+                    submit_embed_resume(str(resume.id), resume.latex_content or "")
                 except Exception:
                     pass
             continue

--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -489,12 +489,8 @@ async def create_resume(
 
     if settings.OPENAI_API_KEY:
         try:
-            from ..workers.ats_worker import embed_resume_task
-            embed_resume_task.apply_async(
-                kwargs={"resume_id": str(resume.id), "latex_content": resume.latex_content,
-                        "user_id": user_id},
-                queue="ats", priority=1,
-            )
+            from ..workers.ats_worker import submit_embed_resume
+            submit_embed_resume(str(resume.id), resume.latex_content, user_id)
         except Exception as exc:
             logger.warning(f"Failed to enqueue embedding for resume {resume.id}: {exc}")
 
@@ -803,12 +799,8 @@ async def update_resume(
 
     if settings.OPENAI_API_KEY and update_data.get("latex_content"):
         try:
-            from ..workers.ats_worker import embed_resume_task
-            embed_resume_task.apply_async(
-                kwargs={"resume_id": str(resume.id), "latex_content": resume.latex_content,
-                        "user_id": user_id},
-                queue="ats", priority=1,
-            )
+            from ..workers.ats_worker import submit_embed_resume
+            submit_embed_resume(str(resume.id), resume.latex_content, user_id)
         except Exception as exc:
             logger.warning(f"Failed to enqueue embedding for resume {resume.id}: {exc}")
 
@@ -1023,12 +1015,8 @@ async def fork_resume(
     # Fire-and-forget embedding task
     if settings.OPENAI_API_KEY:
         try:
-            from ..workers.ats_worker import embed_resume_task
-            embed_resume_task.apply_async(
-                kwargs={"resume_id": str(variant.id), "latex_content": variant.latex_content,
-                        "user_id": user_id},
-                queue="ats", priority=1,
-            )
+            from ..workers.ats_worker import submit_embed_resume
+            submit_embed_resume(str(variant.id), variant.latex_content, user_id)
         except Exception as exc:
             logger.warning(f"Failed to enqueue embedding for variant {variant.id}: {exc}")
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -213,7 +213,9 @@ def _check_cors_origins_on_startup() -> None:
 @router.get("/health", response_model=HealthResponse)
 async def health_check():
     """Health check endpoint."""
-    latex_available = latex_compiler.is_available()
+    import os
+    # On Modal, LaTeX runs in a separate worker container — report as available
+    latex_available = True if os.environ.get("DEPLOY_TARGET") == "modal" else latex_compiler.is_available()
     llm_service.is_available()
 
     # OBS-001: probe DB and Redis connectivity

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -206,11 +206,18 @@ class Settings(BaseSettings):
     DEV_API_DAILY_LIMIT_PRO: int = 1000
     DEV_API_DAILY_LIMIT_BYOK: int = 500
 
+    # Deployment target
+    DEPLOY_TARGET: str = Field(default="local", description="Deployment target: 'local' (Celery) or 'modal'")
+
     # Redis Config
     REDIS_URL: str = Field(default="redis://localhost:6379/0", description="Redis URL for job queue")
     REDIS_CACHE_URL: str = Field(default="redis://localhost:6379/1", description="Redis URL for caching")
     REDIS_PASSWORD: str = Field(default="", description="Redis password")
     REDIS_MAX_CONNECTIONS: int = Field(default=20, description="Redis max connections")
+
+    # Upstash Redis (for Modal deployment)
+    UPSTASH_REDIS_REST_URL: str = Field(default="", description="Upstash Redis REST URL")
+    UPSTASH_REDIS_REST_TOKEN: str = Field(default="", description="Upstash Redis REST token")
 
     # Celery Configuration
     CELERY_BROKER_URL: str = Field(default="redis://localhost:6379/0", description="Celery broker URL")

--- a/backend/app/core/modal_dispatch.py
+++ b/backend/app/core/modal_dispatch.py
@@ -1,0 +1,20 @@
+"""
+Modal task dispatcher — used when DEPLOY_TARGET=modal.
+
+Call spawn(function_name, payload) to fire-and-forget a Modal function.
+All imports are lazy so this module is safe to import in local-dev mode.
+"""
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_APP_NAME = "latexy-backend"
+
+
+def spawn(function_name: str, payload: dict) -> None:
+    """Fire-and-forget a Modal function by name."""
+    import modal  # noqa: PLC0415 — intentionally lazy
+    fn = modal.Function.from_name(_APP_NAME, function_name)
+    fn.spawn(payload)
+    logger.debug("Modal spawn: %s", function_name)

--- a/backend/app/workers/ats_worker.py
+++ b/backend/app/workers/ats_worker.py
@@ -328,6 +328,23 @@ def submit_ats_scoring(
     if priority is None:
         priority = get_task_priority(user_plan)
 
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_ats_task", {
+            "latex_content": latex_content,
+            "job_id": job_id,
+            "job_description": job_description,
+            "industry": industry,
+            "industry_profile_key": industry_profile_key,
+            "user_id": user_id,
+            "user_plan": user_plan,
+            "device_fingerprint": device_fingerprint,
+            "metadata": metadata,
+        })
+        logger.info(f"Modal spawn: ATS scoring for job {job_id}")
+        return job_id
+
     score_resume_ats_task.apply_async(
         args=[latex_content],
         kwargs={
@@ -358,6 +375,19 @@ def submit_job_description_analysis(
     """Enqueue analyze_job_description_ats_task on the ats queue."""
     if priority is None:
         priority = get_task_priority(user_plan)
+
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_jd_analysis_task", {
+            "job_description": job_description,
+            "job_id": job_id,
+            "user_id": user_id,
+            "user_plan": user_plan,
+            "metadata": metadata,
+        })
+        logger.info(f"Modal spawn: JD analysis for job {job_id}")
+        return job_id
 
     analyze_job_description_ats_task.apply_async(
         args=[job_description],
@@ -702,3 +732,68 @@ def embed_resume_task(
         if self.request.retries < self.max_retries:
             raise self.retry(countdown=60, exc=exc)
         return {"success": False, "resume_id": resume_id, "error": str(exc)}
+
+
+# ------------------------------------------------------------------ #
+#  Submit helpers for tasks without existing wrappers                 #
+# ------------------------------------------------------------------ #
+
+def submit_deep_analyze_ats(
+    latex_content: str,
+    job_id: str,
+    job_description: Optional[str] = None,
+    api_key: Optional[str] = None,
+    industry_override: Optional[str] = None,
+    metadata: Optional[Dict] = None,
+) -> str:
+    """Enqueue deep_analyze_ats_task (Celery) or Modal."""
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_deep_analyze_task", {
+            "latex_content": latex_content,
+            "job_id": job_id,
+            "job_description": job_description,
+            "api_key": api_key,
+            "industry_override": industry_override,
+            "metadata": metadata,
+        })
+        logger.info(f"Modal spawn: deep ATS analysis for job {job_id}")
+        return job_id
+
+    deep_analyze_ats_task.apply_async(
+        kwargs={
+            "latex_content": latex_content,
+            "job_id": job_id,
+            "job_description": job_description,
+            "api_key": api_key,
+            "industry_override": industry_override,
+            "metadata": metadata,
+        },
+        queue="ats",
+    )
+    logger.info(f"Submitted deep ATS analysis for job {job_id}")
+    return job_id
+
+
+def submit_embed_resume(
+    resume_id: str,
+    latex_content: str,
+    user_id: Optional[str] = None,
+) -> None:
+    """Enqueue embed_resume_task (Celery) or Modal. Fire-and-forget."""
+    import os
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_embed_resume_task", {
+            "resume_id": resume_id,
+            "latex_content": latex_content,
+            "user_id": user_id,
+        })
+        return
+
+    embed_resume_task.apply_async(
+        kwargs={"resume_id": resume_id, "latex_content": latex_content, "user_id": user_id},
+        queue="ats",
+        priority=1,
+    )


### PR DESCRIPTION
## Summary
Refactors API route layer to use dispatch-agnostic submit helpers instead of direct Celery task references.

### `backend/app/api/ats_routes.py`
- Import changed: `deep_analyze_ats_task` → `submit_deep_analyze_ats`
- `deep_analyze_resume`: direct `apply_async` → `submit_deep_analyze_ats(...)`
- `semantic_match_resumes`: `embed_resume_task.apply_async()` → `submit_embed_resume()`

### `backend/app/api/resume_routes.py`
- All 3 locations of `embed_resume_task.apply_async()` → `submit_embed_resume()`

### `backend/app/api/routes.py`
- `/health` endpoint: `latex_available` now returns `True` when `DEPLOY_TARGET=modal` (LaTeX runs in separate container, not available locally)

## Issues Closed
- closes #687 (health endpoint Modal-awareness)
- closes #688 (ats_routes dispatch-agnostic refactor)
- closes #689 (resume_routes dispatch-agnostic refactor)

## Test Plan
- [ ] No direct `apply_async` calls remain in `ats_routes.py` or `resume_routes.py`
- [ ] `/health` returns `latex_available: true` when `DEPLOY_TARGET=modal`
- [ ] `/health` returns real probe result when `DEPLOY_TARGET=local`
- [ ] ATS deep-analyze endpoint dispatches correctly in both modes
- [ ] Resume embed triggers correctly on create/update/import in both modes