### PR TITLE
fix(ci): resolve ruff lint failures from Modal deployment merge

### DIFF
--- a/backend/app/core/modal_dispatch.py
+++ b/backend/app/core/modal_dispatch.py
@@ -5,7 +5,6 @@ Call spawn(function_name, payload) to fire-and-forget a Modal function.
 All imports are lazy so this module is safe to import in local-dev mode.
 """
 import logging
-from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/workers/cleanup_worker.py
+++ b/backend/app/workers/cleanup_worker.py
@@ -620,8 +620,9 @@ def submit_temp_files_cleanup(
     """
     import os
     if os.environ.get("DEPLOY_TARGET") == "modal":
-        from ..core.modal_dispatch import spawn
         import uuid
+
+        from ..core.modal_dispatch import spawn
         job_id = f"cleanup_{uuid.uuid4()}"
         spawn("run_cleanup_task", {
             "task_type": "temp_files",
@@ -659,8 +660,9 @@ def submit_expired_jobs_cleanup(
     """
     import os
     if os.environ.get("DEPLOY_TARGET") == "modal":
-        from ..core.modal_dispatch import spawn
         import uuid
+
+        from ..core.modal_dispatch import spawn
         job_id = f"job_cleanup_{uuid.uuid4()}"
         spawn("run_cleanup_task", {
             "task_type": "expired_jobs",

--- a/backend/test/test_ats_deep_analysis.py
+++ b/backend/test/test_ats_deep_analysis.py
@@ -13,7 +13,6 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from celery.result import AsyncResult
 from httpx import AsyncClient
 
 # ── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Remove unused `typing.Any` import from `modal_dispatch.py` (F401) closes #700
- Fix inline import ordering in `cleanup_worker.py` Modal dispatch blocks (I001) closes #701
- Remove unused `AsyncResult` import from `test_ats_deep_analysis.py` (F401) closes #702

## Root cause

These three files were introduced/modified in the Modal deployment PR (#699). The ruff lint CI step caught them after merge.

## Test plan
- [ ] CI Backend Lint (ruff) passes on this PR