### PR TITLE
fix(jobs): import validate_job_id in job_routes

### DIFF
--- a/backend/app/api/job_routes.py
+++ b/backend/app/api/job_routes.py
@@ -26,6 +26,7 @@ from ..core.config import resolve_plan_family, settings
 from ..core.logging import get_logger
 from ..core.redis import get_redis_client, redis_manager
 from ..database.connection import get_db
+from ..utils.file_utils import validate_job_id
 from ..database.models import Compilation, Resume, User
 from ..middleware.auth_middleware import get_current_user_optional, get_current_user_required
 from ..services.optimization_personas import VALID_PERSONA_KEYS


### PR DESCRIPTION
## Summary
- GET /jobs/{job_id}/stream was returning HTTP 500 due to a NameError
- `validate_job_id` was called on the inbound job_id but was never imported in `job_routes.py`
- Added the missing import from `..utils.file_utils`

## Test plan
- [ ] Submit a latex_compilation job
- [ ] Wait for completion
- [ ] GET /jobs/{job_id}/stream → HTTP 200 with full event replay
- [ ] Verify event count and stream_id fields are present

Closes #717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for job retrieval to ensure data integrity when accessing job streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->