### PR TITLE
fix(lint): sort imports in job_routes

### DIFF
--- a/backend/app/api/job_routes.py
+++ b/backend/app/api/job_routes.py
@@ -26,10 +26,10 @@ from ..core.config import resolve_plan_family, settings
 from ..core.logging import get_logger
 from ..core.redis import get_redis_client, redis_manager
 from ..database.connection import get_db
-from ..utils.file_utils import validate_job_id
 from ..database.models import Compilation, Resume, User
 from ..middleware.auth_middleware import get_current_user_optional, get_current_user_required
 from ..services.optimization_personas import VALID_PERSONA_KEYS
+from ..utils.file_utils import validate_job_id
 from ..workers.ats_worker import submit_ats_scoring
 from ..workers.cleanup_worker import submit_expired_jobs_cleanup, submit_temp_files_cleanup
 from ..workers.latex_worker import submit_latex_compilation


### PR DESCRIPTION
Ruff I001: validate_job_id import was at the wrong position after #717. Auto-fixed with ruff --fix.

Closes #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->