### PR TITLE
fix: regression batch — 7 bugs from full regression sweep

### DIFF
--- a/backend/app/api/job_routes.py
+++ b/backend/app/api/job_routes.py
@@ -282,9 +282,9 @@ async def submit_job(
                 logger.debug(f"Could not fetch resume compile settings: {exc}")
 
         if request.job_type == "latex_compilation":
-            if not request.latex_content:
+            if not request.latex_content or not request.latex_content.strip():
                 raise HTTPException(
-                    status_code=400,
+                    status_code=422,
                     detail="latex_content is required for latex_compilation jobs",
                 )
             await _write_initial_redis_state(job_id, request.job_type, user_id, estimated_time)
@@ -300,9 +300,9 @@ async def submit_job(
             )
 
         elif request.job_type == "llm_optimization":
-            if not request.latex_content:
+            if not request.latex_content or not request.latex_content.strip():
                 raise HTTPException(
-                    status_code=400,
+                    status_code=422,
                     detail="latex_content is required for llm_optimization jobs",
                 )
             await _write_initial_redis_state(job_id, request.job_type, user_id, estimated_time)
@@ -318,9 +318,9 @@ async def submit_job(
             )
 
         elif request.job_type == "combined":
-            if not request.latex_content:
+            if not request.latex_content or not request.latex_content.strip():
                 raise HTTPException(
-                    status_code=400,
+                    status_code=422,
                     detail="latex_content is required for combined jobs",
                 )
             if request.persona and request.persona not in VALID_PERSONA_KEYS:
@@ -346,9 +346,9 @@ async def submit_job(
             )
 
         elif request.job_type == "ats_scoring":
-            if not request.latex_content:
+            if not request.latex_content or not request.latex_content.strip():
                 raise HTTPException(
-                    status_code=400,
+                    status_code=422,
                     detail="latex_content is required for ats_scoring jobs",
                 )
             await _write_initial_redis_state(job_id, request.job_type, user_id, estimated_time)
@@ -635,6 +635,7 @@ async def get_job_state(
     user_id: Optional[str] = Depends(get_current_user_optional),
 ):
     """Get current job state snapshot (for REST polling fallback)."""
+    validate_job_id(job_id)
     try:
         r = await get_redis_client()
 
@@ -665,6 +666,7 @@ async def get_job_result(
     user_id: Optional[str] = Depends(get_current_user_optional),
 ):
     """Fetch the final job result (available after job.completed event)."""
+    validate_job_id(job_id)
     try:
         r = await get_redis_client()
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -60,6 +60,7 @@ class Settings(BaseSettings):
     # CORS
     CORS_ORIGINS: List[str] = Field(
         default=[
+            # Local development
             "http://localhost:3000",
             "http://127.0.0.1:3000",
             "http://localhost:5180",
@@ -70,6 +71,11 @@ class Settings(BaseSettings):
             "http://127.0.0.1:5182",
             "http://localhost:5183",
             "http://127.0.0.1:5183",
+            # Production
+            "https://latexy.com",
+            "https://www.latexy.com",
+            "https://app.latexy.com",
+            "https://latexy.vercel.app",
         ]
     )
 

--- a/backend/app/workers/ats_worker.py
+++ b/backend/app/workers/ats_worker.py
@@ -132,6 +132,7 @@ def score_resume_ats_task(
 
         publish_job_result(job_id, result)
         publish_event(job_id, "job.completed", {
+            "percent": 100,
             "pdf_job_id": job_id,
             "ats_score": scoring_result.overall_score,
             "ats_details": {
@@ -284,6 +285,7 @@ def analyze_job_description_ats_task(
 
         publish_job_result(job_id, result)
         publish_event(job_id, "job.completed", {
+            "percent": 100,
             "pdf_job_id": job_id,
             "ats_score": 0.0,
             "ats_details": {"detected_industry": detected_industry},
@@ -616,6 +618,7 @@ async def _async_deep_analyze(
     })
 
     publish_event(job_id, "job.completed", {
+        "percent": 100,
         "pdf_job_id": job_id,
         "ats_score": float(result.get("overall_score", 0)),
         "ats_details": {

--- a/backend/app/workers/cleanup_worker.py
+++ b/backend/app/workers/cleanup_worker.py
@@ -521,8 +521,8 @@ def health_check_task(
             "message": "Checking active jobs",
         })
 
-        active_jobs = job_status_manager.get_active_jobs_sync()
-        active_jobs_count = len(active_jobs)
+        _r = get_worker_redis()
+        active_jobs_count = len(_r.keys("latexy:job:*:state"))
 
         # Determine overall health
         health_issues = []

--- a/backend/app/workers/cleanup_worker.py
+++ b/backend/app/workers/cleanup_worker.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, Optional
 from ..core.celery_app import celery_app
 from ..core.config import settings
 from ..core.logging import get_logger
-from ..core.redis import job_status_manager, redis_manager
+from ..core.redis import redis_manager
 from ..workers.event_publisher import get_worker_redis, publish_event, publish_job_result
 
 logger = get_logger(__name__)

--- a/backend/app/workers/latex_worker.py
+++ b/backend/app/workers/latex_worker.py
@@ -431,6 +431,7 @@ def compile_latex_task(
                 })
 
             publish_event(job_id, "job.completed", {
+                "percent": 100,
                 "pdf_job_id": job_id,
                 "ats_score": 0.0,
                 "ats_details": {},

--- a/backend/app/workers/llm_worker.py
+++ b/backend/app/workers/llm_worker.py
@@ -206,6 +206,7 @@ def optimize_resume_task(
 
         publish_job_result(job_id, result)
         publish_event(job_id, "job.completed", {
+            "percent": 100,
             "pdf_job_id": job_id,
             "ats_score": 0.0,
             "ats_details": {},

--- a/backend/app/workers/orchestrator.py
+++ b/backend/app/workers/orchestrator.py
@@ -226,6 +226,7 @@ def optimize_and_compile_task(
 
         publish_job_result(job_id, result)
         publish_event(job_id, "job.completed", {
+            "percent": 100,
             "pdf_job_id": job_id,
             "ats_score": ats_score,
             "ats_details": ats_details,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -72,6 +72,7 @@ kombu==5.6.2
 pgvector==0.4.2
 
 # Document parsing
+pdfminer.six==20231228
 pdfplumber==0.11.4
 python-docx==1.2.0
 mammoth==1.12.0

--- a/backend/test/test_cleanup_worker.py
+++ b/backend/test/test_cleanup_worker.py
@@ -62,19 +62,10 @@ def mock_jsm():
     mock_r.delete.return_value = 1
     mock_r.ping.return_value = True
 
-    with patch("app.workers.cleanup_worker.job_status_manager") as m, \
-         patch("app.workers.cleanup_worker.publish_event") as mock_pub, \
+    m = MagicMock()
+    with patch("app.workers.cleanup_worker.publish_event") as mock_pub, \
          patch("app.workers.cleanup_worker.publish_job_result") as mock_res, \
          patch("app.workers.cleanup_worker.get_worker_redis", return_value=mock_r):
-        m.set_job_status = AsyncMock(return_value=True)
-        m.set_job_progress = AsyncMock(return_value=True)
-        m.set_job_result = AsyncMock(return_value=True)
-        m.get_active_jobs = AsyncMock(return_value=[])
-        m.get_job_status = AsyncMock(return_value=None)
-        m.delete_job_data = AsyncMock(return_value=True)
-        m.get_active_jobs_sync = MagicMock(side_effect=lambda: _resolve(m.get_active_jobs))
-        m.get_job_status_sync = MagicMock(side_effect=lambda job_id: _resolve(m.get_job_status, job_id))
-        m.delete_job_data_sync = MagicMock(side_effect=lambda job_id: _resolve(m.delete_job_data, job_id))
         mock_pub.return_value = None
         mock_res.return_value = None
         # Expose on mock_jsm for test assertions
@@ -287,8 +278,7 @@ class TestCleanupTempFilesTask:
 
         mock_r2 = MagicMock()
         mock_r2.keys.return_value = []
-        with patch("app.workers.cleanup_worker.job_status_manager"), \
-             patch("app.workers.cleanup_worker.publish_event", side_effect=_side_effect), \
+        with patch("app.workers.cleanup_worker.publish_event", side_effect=_side_effect), \
              patch("app.workers.cleanup_worker.publish_job_result"), \
              patch("app.workers.cleanup_worker.get_worker_redis", return_value=mock_r2):
             result = cleanup_temp_files_task.apply(
@@ -468,8 +458,7 @@ class TestHealthCheckTask:
 
     def _run(self, mock_jsm, mock_rm, *, free_gb=10.0, total_gb=100.0, active_jobs=None):
         du = _disk_usage(free_gb, total_gb)
-        mock_jsm.get_active_jobs = AsyncMock(return_value=active_jobs or [])
-        mock_jsm.get_active_jobs_sync = MagicMock(return_value=active_jobs or [])
+        mock_jsm._mock_redis.keys.return_value = active_jobs or []
         with patch("shutil.disk_usage", return_value=du):
             return health_check_task.apply(kwargs={}).result
 

--- a/backend/test/test_compile_timeout.py
+++ b/backend/test/test_compile_timeout.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+import itertools
 from unittest.mock import MagicMock, patch
 
 from app.core.config import get_compile_timeout, settings
@@ -95,8 +96,9 @@ class TestCompileLatexTaskTimeout:
             patch("app.workers.latex_worker.publish_event") as mock_publish,
             patch("app.workers.latex_worker.publish_job_result"),
             patch("app.workers.latex_worker.is_cancelled", return_value=False),
-            # start_time=0.0, subsequent calls return 999.0 which exceeds timeout=1
-            patch("app.workers.latex_worker.time.time", side_effect=[0.0] + [999.0] * 20),
+            # Each call advances 100s, so elapsed always exceeds any timeout regardless of
+            # how many extra time.time() calls Celery's task machinery makes beforehand.
+            patch("app.workers.latex_worker.time.time", side_effect=itertools.count(100, 100)),
         ):
             mock_proc = MagicMock()
             mock_proc.stdout = _one_log_line()
@@ -132,7 +134,7 @@ class TestCompileLatexTaskTimeout:
             patch("app.workers.latex_worker.publish_event") as mock_publish,
             patch("app.workers.latex_worker.publish_job_result"),
             patch("app.workers.latex_worker.is_cancelled", return_value=False),
-            patch("app.workers.latex_worker.time.time", side_effect=[0.0] + [9999.0] * 20),
+            patch("app.workers.latex_worker.time.time", side_effect=itertools.count(100, 100)),
         ):
             mock_proc = MagicMock()
             mock_proc.stdout = iter(["log line\n"])
@@ -206,8 +208,7 @@ class TestCompileLatexTaskTimeout:
             patch("app.workers.latex_worker.publish_event") as mock_publish,
             patch("app.workers.latex_worker.publish_job_result"),
             patch("app.workers.latex_worker.is_cancelled", return_value=False),
-            # start_time=0.0, subsequent calls return 200.0 which exceeds timeout=60
-            patch("app.workers.latex_worker.time.time", side_effect=[0.0] + [200.0] * 20),
+            patch("app.workers.latex_worker.time.time", side_effect=itertools.count(100, 100)),
         ):
             mock_proc = MagicMock()
             mock_proc.stdout = iter(["line\n"])

--- a/backend/test/test_compile_timeout.py
+++ b/backend/test/test_compile_timeout.py
@@ -95,9 +95,8 @@ class TestCompileLatexTaskTimeout:
             patch("app.workers.latex_worker.publish_event") as mock_publish,
             patch("app.workers.latex_worker.publish_job_result"),
             patch("app.workers.latex_worker.is_cancelled", return_value=False),
-            # logger.info() creates a LogRecord which calls time.time() before start_time does;
-            # first 0.0 is consumed by the logger, second 0.0 is start_time, 999.0 trips timeout
-            patch("app.workers.latex_worker.time.time", side_effect=[0.0, 0.0] + [999.0] * 20),
+            # start_time=0.0, subsequent calls return 999.0 which exceeds timeout=1
+            patch("app.workers.latex_worker.time.time", side_effect=[0.0] + [999.0] * 20),
         ):
             mock_proc = MagicMock()
             mock_proc.stdout = _one_log_line()
@@ -133,7 +132,7 @@ class TestCompileLatexTaskTimeout:
             patch("app.workers.latex_worker.publish_event") as mock_publish,
             patch("app.workers.latex_worker.publish_job_result"),
             patch("app.workers.latex_worker.is_cancelled", return_value=False),
-            patch("app.workers.latex_worker.time.time", side_effect=[0.0, 0.0] + [9999.0] * 20),
+            patch("app.workers.latex_worker.time.time", side_effect=[0.0] + [9999.0] * 20),
         ):
             mock_proc = MagicMock()
             mock_proc.stdout = iter(["log line\n"])
@@ -207,8 +206,8 @@ class TestCompileLatexTaskTimeout:
             patch("app.workers.latex_worker.publish_event") as mock_publish,
             patch("app.workers.latex_worker.publish_job_result"),
             patch("app.workers.latex_worker.is_cancelled", return_value=False),
-            # logger.info() consumes first time.time(); start_time=0.0, check=200.0 > 60 → timeout
-            patch("app.workers.latex_worker.time.time", side_effect=[0.0, 0.0] + [200.0] * 20),
+            # start_time=0.0, subsequent calls return 200.0 which exceeds timeout=60
+            patch("app.workers.latex_worker.time.time", side_effect=[0.0] + [200.0] * 20),
         ):
             mock_proc = MagicMock()
             mock_proc.stdout = iter(["line\n"])


### PR DESCRIPTION
## Summary

Fixes all bugs identified in the 2026-06-22 full regression sweep.

- **#722** `pdfminer.six` added to `requirements.txt` (was transitive only via pdfplumber, broke in lean builds)
- **#723** CORS: production domains (`latexy.com`, `www.latexy.com`, `app.latexy.com`, `latexy.vercel.app`) added to `CORS_ORIGINS` default
- **#724** All 5 worker `job.completed` events now include `"percent": 100` so frontend progress bar reaches 100% instead of snapping back to 0%
- **#725** Whitespace-only `latex_content` now rejected with 422 at submit time for all 4 job types
- **#726** `cleanup_worker` health check now scans `latexy:job:*:state` (correct namespace) instead of stale `job_status:*` keys
- **#727** `validate_job_id` added to `/jobs/{id}/state` and `/jobs/{id}/result` so invalid UUIDs return 400 instead of 404
- **#728** Compile-timeout test `time.time()` mock off-by-one fixed (structlog uses `datetime.now()`, not `time.time()`)

## Test plan
- [ ] All 2086 pytest tests pass locally
- [ ] ruff lint: clean
- [ ] CI green on this PR

Closes #721 #722 #723 #724 #725 #726 #727 #728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or whitespace-only LaTeX submissions are now rejected with appropriate error responses.
  * Enhanced validation for job state retrieval.

* **Infrastructure**
  * Added production domain support (latexy.com, www.latexy.com, app.latexy.com, latexy.vercel.app).
  * Integrated enhanced document parsing capabilities.
  * Improved job completion event tracking with progress indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->