### PR TITLE
fix(modal): prevent double-execution of latex jobs closes #730

### DIFF
--- a/backend/modal_app.py
+++ b/backend/modal_app.py
@@ -99,28 +99,29 @@ def _init_worker_redis() -> None:
     image=latex_image,
     secrets=_secrets,
     timeout=300,
-    retries=modal.Retries(max_retries=1, backoff_coefficient=2.0),
     scaledown_window=60,
 )
 def run_latex_task(payload: dict) -> None:
     """Compile LaTeX to PDF (texlive installed in image; no Docker needed)."""
     _init_worker_redis()
     from app.workers.latex_worker import compile_latex_task
-    compile_latex_task.apply(kwargs=payload)
+    # throw=False: prevents Celery's self.retry() Retry exception from propagating
+    # to Modal (which would cause a double-execution via Modal's retry mechanism).
+    # The Celery task publishes its own error events; Modal must not independently retry.
+    compile_latex_task.apply(kwargs=payload, throw=False)
 
 
 @app.function(
     image=worker_image,
     secrets=_secrets,
     timeout=600,
-    retries=modal.Retries(max_retries=1, backoff_coefficient=2.0),
     scaledown_window=60,
 )
 def run_orchestrator_task(payload: dict) -> None:
     """Combined LLM optimisation → LaTeX compilation → ATS scoring pipeline."""
     _init_worker_redis()
     from app.workers.orchestrator import optimize_and_compile_task
-    optimize_and_compile_task.apply(kwargs=payload)
+    optimize_and_compile_task.apply(kwargs=payload, throw=False)
 
 
 @app.function(
@@ -133,7 +134,7 @@ def run_llm_task(payload: dict) -> None:
     """LLM resume optimisation (streaming tokens published via Redis)."""
     _init_worker_redis()
     from app.workers.llm_worker import optimize_resume_task
-    optimize_resume_task.apply(kwargs=payload)
+    optimize_resume_task.apply(kwargs=payload, throw=False)
 
 
 @app.function(
@@ -146,7 +147,7 @@ def run_ats_task(payload: dict) -> None:
     """ATS resume scoring."""
     _init_worker_redis()
     from app.workers.ats_worker import score_resume_ats_task
-    score_resume_ats_task.apply(kwargs=payload)
+    score_resume_ats_task.apply(kwargs=payload, throw=False)
 
 
 @app.function(
@@ -159,7 +160,7 @@ def run_jd_analysis_task(payload: dict) -> None:
     """Job-description keyword analysis."""
     _init_worker_redis()
     from app.workers.ats_worker import analyze_job_description_ats_task
-    analyze_job_description_ats_task.apply(kwargs=payload)
+    analyze_job_description_ats_task.apply(kwargs=payload, throw=False)
 
 
 @app.function(
@@ -172,7 +173,7 @@ def run_deep_analyze_task(payload: dict) -> None:
     """Deep LLM-powered ATS analysis."""
     _init_worker_redis()
     from app.workers.ats_worker import deep_analyze_ats_task
-    deep_analyze_ats_task.apply(kwargs=payload)
+    deep_analyze_ats_task.apply(kwargs=payload, throw=False)
 
 
 @app.function(
@@ -184,7 +185,7 @@ def run_deep_analyze_task(payload: dict) -> None:
 def run_embed_resume_task(payload: dict) -> None:
     """Compute and store resume embedding (low-priority background task)."""
     from app.workers.ats_worker import embed_resume_task
-    embed_resume_task.apply(kwargs=payload)
+    embed_resume_task.apply(kwargs=payload, throw=False)
 
 
 @app.function(
@@ -198,10 +199,10 @@ def run_cleanup_task(payload: dict) -> None:
     task_type = payload.pop("task_type", "temp_files")
     if task_type == "expired_jobs":
         from app.workers.cleanup_worker import cleanup_expired_jobs_task
-        cleanup_expired_jobs_task.apply(kwargs=payload)
+        cleanup_expired_jobs_task.apply(kwargs=payload, throw=False)
     else:
         from app.workers.cleanup_worker import cleanup_temp_files_task
-        cleanup_temp_files_task.apply(kwargs=payload)
+        cleanup_temp_files_task.apply(kwargs=payload, throw=False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Every `latex_compilation` job was executing twice (~9s apart) due to `task_eager_propagates=True` + Modal's retry mechanism
- `compile_latex_task` calls `self.retry()` on any transient exception; with `task_eager_propagates=True` this `Retry` exception propagated through `.apply()` and crashed the Modal function
- Modal's `retries=modal.Retries(max_retries=1)` then re-ran the function with the same `job_id`, publishing all events (including `job.completed`) a second time

## Changes

- `modal_app.py`: Added `throw=False` to all 9 `.apply(kwargs=payload)` calls — Celery exceptions (including `Retry`) are now caught internally and never escape to Modal
- `modal_app.py`: Removed `retries=modal.Retries(max_retries=1, backoff_coefficient=2.0)` from `run_latex_task` and `run_orchestrator_task` — Celery tasks self-publish error events; Modal should not independently retry them

## Test plan

- [ ] Submit a latex job, observe stream events — should have exactly 1 `job.started` and 1 `job.completed`
- [ ] Verify download and logs still work after completion
- [ ] ATS job should still work (unaffected path)