### PR TITLE
fix(backend): add GET /me endpoint for TUI auth check

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -8,6 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.config import settings
@@ -15,8 +16,9 @@ from ..core.logging import get_logger
 from ..core.observability import metrics_content_type, metrics_payload
 from ..core.redis import redis_manager as _redis_manager
 from ..database.connection import get_async_db_session, get_db
-from ..database.models import Compilation, Resume
-from ..middleware.auth_middleware import get_current_user_optional, get_current_user_required as _require_user
+from ..database.models import Compilation, Resume, User
+from ..middleware.auth_middleware import get_current_user_optional
+from ..middleware.auth_middleware import get_current_user_required as _require_user
 from ..models.llm_schemas import OptimizationRequest, OptimizationResponse
 from ..models.schemas import CompilationResponse, HealthResponse, LogsResponse
 from ..services.feature_flag_service import feature_flag_service
@@ -222,9 +224,6 @@ async def get_me(
     user_id: str = Depends(_require_user),
 ):
     """Return the authenticated user's id, email, and subscription plan."""
-    from sqlalchemy import select
-    from ..database.models import User
-
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
     if user is None:

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -16,7 +16,7 @@ from ..core.observability import metrics_content_type, metrics_payload
 from ..core.redis import redis_manager as _redis_manager
 from ..database.connection import get_async_db_session, get_db
 from ..database.models import Compilation, Resume
-from ..middleware.auth_middleware import get_current_user_optional
+from ..middleware.auth_middleware import get_current_user_optional, get_current_user_required as _require_user
 from ..models.llm_schemas import OptimizationRequest, OptimizationResponse
 from ..models.schemas import CompilationResponse, HealthResponse, LogsResponse
 from ..services.feature_flag_service import feature_flag_service
@@ -208,6 +208,28 @@ def _check_cors_origins_on_startup() -> None:
                 " (entries: %s)",
                 localhost_origins,
             )
+
+
+class MeResponse(BaseModel):
+    id: str
+    email: str
+    plan: str
+
+
+@router.get("/me", response_model=MeResponse)
+async def get_me(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(_require_user),
+):
+    """Return the authenticated user's id, email, and subscription plan."""
+    from sqlalchemy import select
+    from ..database.models import User
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return MeResponse(id=user.id, email=user.email, plan=user.subscription_plan)
 
 
 @router.get("/health", response_model=HealthResponse)


### PR DESCRIPTION
## Summary
- Adds `GET /me` returning `{id, email, plan}` for authenticated user
- Required by TUI startup health/auth check (was 404ing on `/api/me`)

## Issues
closes #736

## Test plan
- [ ] `curl -H "Authorization: Bearer <token>" http://localhost:8032/me` returns user data
- [ ] Unauthenticated request returns 401