### PR TITLE
fix(tui): unwrap WS envelope + correct JobCompletedEvent shape

### DIFF
--- a/packages/tui/src/__tests__/ws-client.test.ts
+++ b/packages/tui/src/__tests__/ws-client.test.ts
@@ -41,8 +41,8 @@ describe('LatexyWSClient', () => {
   it('buffers events before drain()', () => {
     const received: unknown[] = []
     client.on('event', e => received.push(e))
-    const ev = { type: 'log.line', job_id: 'j1', event_id: 'e1', sequence: 1, timestamp: 1, line: 'hello', level: 'info' }
-    mockWSInstance.emit('message', Buffer.from(JSON.stringify(ev)))
+    const inner = { type: 'log.line', job_id: 'j1', event_id: 'e1', sequence: 1, timestamp: 1, line: 'hello', level: 'info' }
+    mockWSInstance.emit('message', Buffer.from(JSON.stringify({ type: 'event', event: inner })))
     expect(received).toHaveLength(0)
     client.drain()
     expect(received).toHaveLength(1)
@@ -52,8 +52,8 @@ describe('LatexyWSClient', () => {
     client.drain()
     const received: unknown[] = []
     client.on('event', e => received.push(e))
-    const ev = { type: 'log.line', job_id: 'j1', event_id: 'e2', sequence: 2, timestamp: 2, line: 'world', level: 'info' }
-    mockWSInstance.emit('message', Buffer.from(JSON.stringify(ev)))
+    const inner = { type: 'log.line', job_id: 'j1', event_id: 'e2', sequence: 2, timestamp: 2, line: 'world', level: 'info' }
+    mockWSInstance.emit('message', Buffer.from(JSON.stringify({ type: 'event', event: inner })))
     expect(received).toHaveLength(1)
   })
 

--- a/packages/tui/src/lib/event-types.ts
+++ b/packages/tui/src/lib/event-types.ts
@@ -44,8 +44,15 @@ export interface JobProgressEvent extends BaseEvent {
 
 export interface JobCompletedEvent extends BaseEvent {
   type: 'job.completed'
-  result: Record<string, unknown>
-  final_status: string
+  pdf_job_id?: string
+  page_count?: number | null
+  ats_score?: number | null
+  compilation_time?: number | null
+  optimization_time?: number | null
+  compiler?: string
+  is_beamer?: boolean
+  // Legacy / fallback: some paths wrap fields under result
+  result?: Record<string, unknown>
 }
 
 export interface JobFailedEvent extends BaseEvent {

--- a/packages/tui/src/lib/ws-client.ts
+++ b/packages/tui/src/lib/ws-client.ts
@@ -39,8 +39,14 @@ export class LatexyWSClient extends EventEmitter {
 
     this.ws.on('message', (data: Buffer) => {
       try {
-        const ev = JSON.parse(data.toString()) as AnyEvent
-        this.publish(ev)
+        const outer = JSON.parse(data.toString()) as Record<string, unknown>
+        if (outer['type'] === 'event' && outer['event']) {
+          // Unwrap the server's envelope: {type:"event", event:{...}} → emit inner event
+          this.publish(outer['event'] as AnyEvent)
+        } else if (outer['type'] === 'subscribed') {
+          this.emit('subscribed', outer)
+        }
+        // Other outer types (heartbeat, error) are intentionally ignored
       } catch {}
     })
 


### PR DESCRIPTION
## Summary
- `ws-client.ts`: server sends `{type:"event",event:{...}}` — publish inner event not outer wrapper. Without this, `ev.job_id` was always `undefined` and every job event was silently dropped
- `event-types.ts`: `JobCompletedEvent` now has flat fields (`page_count`, `compilation_time`, `ats_score`, `compiler`) matching actual server shape
- Tests updated to send proper envelope format

## Issues
closes #735

## Test plan
- [ ] Headless compile `--resume-id` resolves without timeout
- [ ] Headless compile file path resolves without timeout
- [ ] 94/94 unit tests pass (`npx vitest run`)