### PR TITLE
fix(tui): remove /api prefix + send latex_content in all compile paths

### DIFF
--- a/packages/tui/src/components/overlays/ResumePicker.tsx
+++ b/packages/tui/src/components/overlays/ResumePicker.tsx
@@ -28,7 +28,7 @@ export function ResumePicker(): React.ReactElement {
 
   useEffect(() => {
     const client = getApiClient()
-    client.get<ResumeListResponse>('/api/resumes?limit=50')
+    client.get<ResumeListResponse>('/resumes?limit=50')
       .then(res => {
         setResumes(res.resumes)
         setLoading(false)
@@ -42,6 +42,11 @@ export function ResumePicker(): React.ReactElement {
   const filtered = filter
     ? resumes.filter(r => r.title.toLowerCase().includes(filter.toLowerCase()))
     : resumes
+
+  // Reset cursor when filter narrows the list
+  useEffect(() => {
+    setCursor(0)
+  }, [filter])
 
   const select = useCallback((resume: Resume) => {
     void writeConfig({ defaultResumeId: resume.id })

--- a/packages/tui/src/headless.ts
+++ b/packages/tui/src/headless.ts
@@ -9,7 +9,7 @@ const useJson = process.argv.includes('--json')
 
 function out(obj: unknown): void {
   if (useJson) process.stdout.write(JSON.stringify(obj) + '\n')
-  else process.stderr.write(JSON.stringify(obj, null, 2) + '\n')
+  else process.stdout.write(JSON.stringify(obj, null, 2) + '\n')
 }
 
 function log(msg: string): void {
@@ -61,25 +61,27 @@ async function headlessCompile(args: string[]): Promise<number> {
 
   if (resumeId) {
     log(`Compiling resume ${resumeId}…`)
-    const res = await client.post<{ job_id: string }>('/api/jobs/submit', {
+    const resume = await client.get<{ latex_content: string }>(`/resumes/${resumeId}`)
+    const res = await client.post<{ job_id: string }>('/jobs/submit', {
       job_type: 'latex_compilation',
-      resume_id: resumeId,
-      settings: { compiler },
+      latex_content: resume.latex_content,
+      compiler,
     })
     jobId = res.job_id
   } else {
-    // Local file upload
+    // Local file path: read content and submit via the job queue (same as --resume-id)
     const filePath = args.find(a => !a.startsWith('-') && a !== 'compile')
     if (!filePath) {
       out({ success: false, error: 'Provide a .tex file path or --resume-id <uuid>' })
       return 3
     }
-    log(`Uploading ${basename(filePath)}…`)
-    const bytes = await readFile(filePath)
-    const form = new FormData()
-    form.append('file', new Blob([bytes], { type: 'application/octet-stream' }), basename(filePath))
-    form.append('compiler', compiler)
-    const res = await client.postForm<{ job_id: string }>('/api/compile', form)
+    log(`Compiling ${basename(filePath)}…`)
+    const latex_content = await readFile(filePath, 'utf-8')
+    const res = await client.post<{ job_id: string }>('/jobs/submit', {
+      job_type: 'latex_compilation',
+      latex_content,
+      compiler,
+    })
     jobId = res.job_id
   }
 
@@ -87,9 +89,8 @@ async function headlessCompile(args: string[]): Promise<number> {
   const ev = await waitForJob(jobId, cfg.token, wsUrl)
 
   if (ev.type === 'job.completed') {
-    const result = ev.result as Record<string, unknown>
-    if (outputPath && result['pdf_url']) {
-      const pdfRes = await fetch(cfg.backendUrl + (result['pdf_url'] as string), {
+    if (outputPath) {
+      const pdfRes = await fetch(`${cfg.backendUrl}/download/${jobId}`, {
         headers: { Authorization: `Bearer ${cfg.token}` },
       })
       const buf = await pdfRes.arrayBuffer()
@@ -99,11 +100,12 @@ async function headlessCompile(args: string[]): Promise<number> {
     out({
       success: true,
       job_id: jobId,
-      pages: result['pages'] ?? null,
-      size_bytes: result['size_bytes'] ?? null,
-      ats_score: result['ats_score'] ?? null,
-      pdf_url: result['pdf_url'] ?? null,
-      compilation_time_ms: result['compilation_time_ms'] ?? null,
+      pages: ev.page_count ?? null,
+      ats_score: ev.ats_score ?? null,
+      compilation_time_ms: ev.compilation_time != null
+        ? Math.round(ev.compilation_time * 1000)
+        : null,
+      compiler: ev.compiler ?? null,
     })
     return 0
   } else {

--- a/packages/tui/src/tools/compile.ts
+++ b/packages/tui/src/tools/compile.ts
@@ -49,7 +49,7 @@ export async function runCompile(parsed: ParsedCommand): Promise<void> {
       form.append('file', new Blob([fileBytes], { type: 'application/octet-stream' }), basename(filePath))
       form.append('compiler', compiler)
 
-      const res = await client.postForm<JobSubmitResponse>('/api/compile', form)
+      const res = await client.postForm<JobSubmitResponse>('/compile', form)
       const jobId = res.job_id
 
       $activeJobId.set(jobId)
@@ -72,7 +72,7 @@ export async function runCompile(parsed: ParsedCommand): Promise<void> {
   if (!actualResumeId) {
     // No resume specified — fetch first resume
     try {
-      const list = await client.get<ResumeListResponse>('/api/resumes?limit=1')
+      const list = await client.get<ResumeListResponse>('/resumes?limit=1')
       actualResumeId = list.resumes[0]?.id
       if (!actualResumeId) {
         addMessage({ role: 'error', content: 'No resumes found. Create one first with /new.' })
@@ -93,10 +93,11 @@ export async function runCompile(parsed: ParsedCommand): Promise<void> {
   })
 
   try {
-    const res = await client.post<JobSubmitResponse>('/api/jobs/submit', {
+    const resume = await client.get<{ latex_content: string }>(`/resumes/${actualResumeId}`)
+    const res = await client.post<JobSubmitResponse>('/jobs/submit', {
       job_type: 'latex_compilation',
-      resume_id: actualResumeId,
-      settings: { compiler },
+      latex_content: resume.latex_content,
+      compiler,
     })
     const jobId = res.job_id
 


### PR DESCRIPTION
## Summary
- `compile.ts`: removed `/api` prefix, fetches `latex_content` from resume before submit, correct top-level `compiler` field
- `headless.ts`: file-path flow now reads content and POSTs to `/jobs/submit` (Celery/WS path) instead of synchronous `/compile` endpoint; `--resume-id` flow fetches content first; result extracted from flat event fields
- `ResumePicker.tsx`: removed `/api` prefix, cursor resets on filter change

## Issues
closes #732 closes #733

## Test plan
- [ ] `/compile` from TUI succeeds end-to-end with correct PDF
- [ ] Headless file-path compile exits 0 with populated JSON result
- [ ] Headless `--resume-id` exits 0 with populated JSON result