### PR TITLE
fix(tui): cancel job via DELETE /jobs/{id}

### DIFF
--- a/packages/tui/src/__tests__/e2e/dispatch.e2e.test.ts
+++ b/packages/tui/src/__tests__/e2e/dispatch.e2e.test.ts
@@ -140,26 +140,26 @@ describe('dispatch — API_HANDLERS', () => {
     expect(err?.content).toContain('No active job')
   })
 
-  it('/cancel with active job calls POST /api/jobs/:id/cancel', async () => {
+  it('/cancel with active job calls DELETE /jobs/:id', async () => {
     $activeJobId.set('job-abc')
     const { getApiClient } = await import('../../lib/api-client.js')
-    const mockPost = vi.fn().mockResolvedValue({})
-    vi.mocked(getApiClient).mockReturnValue({ get: vi.fn(), post: mockPost } as never)
+    const mockDelete = vi.fn().mockResolvedValue({})
+    vi.mocked(getApiClient).mockReturnValue({ get: vi.fn(), post: vi.fn(), delete: mockDelete } as never)
 
     const { dispatch } = await import('../../commands/dispatch.js')
     await dispatch('/cancel')
 
-    expect(mockPost).toHaveBeenCalledWith('/api/jobs/job-abc/cancel')
+    expect(mockDelete).toHaveBeenCalledWith('/jobs/job-abc')
   })
 
   it('/cancel with explicit job-id uses that id', async () => {
     const { getApiClient } = await import('../../lib/api-client.js')
-    const mockPost = vi.fn().mockResolvedValue({})
-    vi.mocked(getApiClient).mockReturnValue({ get: vi.fn(), post: mockPost } as never)
+    const mockDelete = vi.fn().mockResolvedValue({})
+    vi.mocked(getApiClient).mockReturnValue({ get: vi.fn(), post: vi.fn(), delete: mockDelete } as never)
 
     const { dispatch } = await import('../../commands/dispatch.js')
     await dispatch('/cancel explicit-job-id')
 
-    expect(mockPost).toHaveBeenCalledWith('/api/jobs/explicit-job-id/cancel')
+    expect(mockDelete).toHaveBeenCalledWith('/jobs/explicit-job-id')
   })
 })

--- a/packages/tui/src/commands/dispatch.ts
+++ b/packages/tui/src/commands/dispatch.ts
@@ -73,7 +73,7 @@ const API_HANDLERS: Record<string, (parsed: NonNullable<ReturnType<typeof parseS
     }
     const { getApiClient } = await import('../lib/api-client.js')
     try {
-      await getApiClient().post(`/api/jobs/${jobId}/cancel`)
+      await getApiClient().delete(`/jobs/${jobId}`)
       addMessage({ role: 'system', content: `Job ${jobId} cancellation requested.` })
     } catch (err) {
       addMessage({ role: 'error', content: `Cancel failed: ${String(err)}` })


### PR DESCRIPTION
## Summary
- `dispatch.ts`: changed from `POST /api/jobs/{id}/cancel` to `DELETE /jobs/{id}`
- E2E tests updated to match

## Issues
closes #734

## Test plan
- [ ] `/cancel` command in TUI sends DELETE and receives 204
- [ ] Cancel e2e tests pass