### PR TITLE
fix(tui): TOML null crash + build-time version injection

### DIFF
--- a/packages/tui/src/lib/config.ts
+++ b/packages/tui/src/lib/config.ts
@@ -48,7 +48,9 @@ export async function writeConfig(patch: Partial<LatexyConfig>): Promise<void> {
   await mkdir(configDir(), { recursive: true })
   const current = await readConfig()
   const next = { ...current, ...patch }
-  const toml = TOML.stringify(next as TOML.JsonMap)
+  // @iarna/toml does not support null — strip null fields before serialising
+  const toWrite = Object.fromEntries(Object.entries(next).filter(([, v]) => v !== null))
+  const toml = TOML.stringify(toWrite as TOML.JsonMap)
   await writeFile(configPath(), toml, { encoding: 'utf-8', mode: 0o600 })
   await chmod(configPath(), 0o600)
 }

--- a/packages/tui/tsup.config.ts
+++ b/packages/tui/tsup.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'tsup'
+import { readFileSync } from 'node:fs'
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string }
 
 export default defineConfig({
   entry: { cli: 'src/cli.tsx' },
@@ -11,4 +14,7 @@ export default defineConfig({
   sourcemap: true,
   banner: { js: '#!/usr/bin/env node' },
   external: [],
+  define: {
+    __LATEXY_VERSION__: JSON.stringify(version),
+  },
 })


### PR DESCRIPTION
## Summary
- `config.ts`: strip null values before `TOML.stringify()` — `@iarna/toml` throws on null, causing logout to crash
- `tsup.config.ts`: inject `__LATEXY_VERSION__` at build time via `define` — runtime `createRequire('./package.json')` resolved incorrectly from inside `dist/`

## Issues
closes #737 closes #738

## Test plan
- [ ] Logging out does not throw a TOML error
- [ ] `latexy --version` or `/help` shows correct version string