### PR TITLE
fix(tui): UX guards — listener leaks, input isolation, SIGINT, cosmetics

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -16,7 +16,7 @@ from ..core.observability import metrics_content_type, metrics_payload
 from ..core.redis import redis_manager as _redis_manager
 from ..database.connection import get_async_db_session, get_db
 from ..database.models import Compilation, Resume
-from ..middleware.auth_middleware import get_current_user_optional
+from ..middleware.auth_middleware import get_current_user_optional, get_current_user_required as _require_user
 from ..models.llm_schemas import OptimizationRequest, OptimizationResponse
 from ..models.schemas import CompilationResponse, HealthResponse, LogsResponse
 from ..services.feature_flag_service import feature_flag_service
@@ -208,6 +208,28 @@ def _check_cors_origins_on_startup() -> None:
                 " (entries: %s)",
                 localhost_origins,
             )
+
+
+class MeResponse(BaseModel):
+    id: str
+    email: str
+    plan: str
+
+
+@router.get("/me", response_model=MeResponse)
+async def get_me(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(_require_user),
+):
+    """Return the authenticated user's id, email, and subscription plan."""
+    from sqlalchemy import select
+    from ..database.models import User
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return MeResponse(id=user.id, email=user.email, plan=user.subscription_plan)
 
 
 @router.get("/health", response_model=HealthResponse)

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -14,6 +14,8 @@ export function App(): React.ReactElement {
   const _overlay = useStore($overlay)
 
   useEffect(() => {
+    let healthInterval: ReturnType<typeof setInterval> | null = null
+
     const init = async (): Promise<void> => {
       const cfg = await readConfig()
 
@@ -34,18 +36,18 @@ export function App(): React.ReactElement {
 
       if (cfg.token) {
         wsClient.connect(wsUrl, cfg.token)
-        wsClient.on('connected', () => {
+        wsClient.once('connected', () => {
           $ui.set({ ...$ui.get(), wsConnected: true })
           wsClient.drain()
         })
-        wsClient.on('disconnected', () => {
+        wsClient.once('disconnected', () => {
           $ui.set({ ...$ui.get(), wsConnected: false })
         })
 
         // Validate token + get user info
         const { getApiClient } = await import('./lib/api-client.js')
         try {
-          const me = await getApiClient().get<{ id: string; email: string; plan?: string }>('/api/me')
+          const me = await getApiClient().get<{ id: string; email: string; plan?: string }>('/me')
           $session.set({
             ...$session.get(),
             userId: me.id,
@@ -70,7 +72,7 @@ export function App(): React.ReactElement {
           }
         }
         await poll()
-        setInterval(() => { void poll() }, 30_000)
+        healthInterval = setInterval(() => { void poll() }, 30_000)
       } else {
         const { LoginOverlay } = await import('./components/overlays/LoginOverlay.js')
         openOverlay(React.createElement(LoginOverlay))
@@ -80,6 +82,11 @@ export function App(): React.ReactElement {
     init().catch(err => {
       addMessage({ role: 'error', content: `Startup error: ${String(err)}` })
     })
+
+    return () => {
+      if (healthInterval != null) clearInterval(healthInterval)
+      wsClient.destroy()
+    }
   }, [])
 
   return <AppShell />

--- a/packages/tui/src/cli.tsx
+++ b/packages/tui/src/cli.tsx
@@ -22,8 +22,7 @@ if (isCI || hasJsonFlag) {
   })
 } else {
   const { unmount } = render(React.createElement(App), { patchConsole: false })
-  process.on('SIGTERM', () => {
-    unmount()
-    process.exit(0)
-  })
+  const shutdown = () => { unmount(); process.exit(0) }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
 }

--- a/packages/tui/src/components/CompileResultCard.tsx
+++ b/packages/tui/src/components/CompileResultCard.tsx
@@ -8,9 +8,10 @@ interface Props {
   compilationTimeMs: number
   pdfUrl: string | null
   atsScore: number | null
+  compiler?: string
 }
 
-export function CompileResultCard({ pages, sizeBytes, compilationTimeMs, pdfUrl, atsScore }: Props): React.ReactElement {
+export function CompileResultCard({ pages, sizeBytes, compilationTimeMs, pdfUrl, atsScore, compiler = 'pdflatex' }: Props): React.ReactElement {
   const sizeStr = sizeBytes != null ? `${(sizeBytes / 1024).toFixed(1)} KB` : null
   const timeStr = compilationTimeMs.toLocaleString() + ' ms'
 
@@ -47,7 +48,7 @@ export function CompileResultCard({ pages, sizeBytes, compilationTimeMs, pdfUrl,
         )}
         <Box flexDirection="column">
           <Text dimColor>Compiler</Text>
-          <Text bold>pdflatex</Text>
+          <Text bold>{compiler}</Text>
         </Box>
         <Box flexDirection="column">
           <Text dimColor>Time</Text>

--- a/packages/tui/src/components/LogStreamCard.tsx
+++ b/packages/tui/src/components/LogStreamCard.tsx
@@ -6,6 +6,7 @@ interface Props {
   lines: string[]
   maxVisible?: number
   percent?: number
+  isActive?: boolean
 }
 
 function classifyLine(line: string): 'error' | 'warning' | 'success' | 'info' {
@@ -16,14 +17,14 @@ function classifyLine(line: string): 'error' | 'warning' | 'success' | 'info' {
   return 'info'
 }
 
-export function LogStreamCard({ lines, maxVisible = 25, percent }: Props): React.ReactElement {
+export function LogStreamCard({ lines, maxVisible = 25, percent, isActive = false }: Props): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false)
 
   useInput((_input, key) => {
     if (key.return) {
       setCollapsed(c => !c)
     }
-  })
+  }, { isActive })
 
   const visible = useMemo(
     () => (lines.length > maxVisible ? lines.slice(-maxVisible) : lines),

--- a/packages/tui/src/components/PromptInput.tsx
+++ b/packages/tui/src/components/PromptInput.tsx
@@ -44,7 +44,13 @@ export function PromptInput({ onSubmit }: Props): React.ReactElement {
 
   return (
     <Box flexDirection="column">
-      {isSlash && value.length > 1 && <SlashSuggestions query={slashQuery} />}
+      {isSlash && value.length > 1 && (
+        <SlashSuggestions
+          query={slashQuery}
+          isActive={!isBlocked}
+          onComplete={(name) => { setValue(`/${name} `) }}
+        />
+      )}
       <Box gap={1} paddingX={1} borderStyle="single" borderColor="cyan">
         <Text bold color={promptColor}>{promptGlyph}</Text>
         {activeJobId != null

--- a/packages/tui/src/components/SlashSuggestions.tsx
+++ b/packages/tui/src/components/SlashSuggestions.tsx
@@ -6,9 +6,10 @@ interface Props {
   query: string
   maxItems?: number
   onComplete?: (name: string) => void
+  isActive?: boolean
 }
 
-export function SlashSuggestions({ query, maxItems = 7, onComplete }: Props): React.ReactElement | null {
+export function SlashSuggestions({ query, maxItems = 7, onComplete, isActive = true }: Props): React.ReactElement | null {
   const [selectedIndex, setSelectedIndex] = useState(0)
 
   const matches = useMemo(() => {
@@ -40,7 +41,7 @@ export function SlashSuggestions({ query, maxItems = 7, onComplete }: Props): Re
     } else if (key.tab) {
       handleComplete()
     }
-  })
+  }, { isActive })
 
   if (matches.length === 0) return null
 

--- a/packages/tui/src/components/TranscriptView.tsx
+++ b/packages/tui/src/components/TranscriptView.tsx
@@ -5,8 +5,8 @@ import { $messages } from '../stores/messages.js'
 import { MessageRow } from './MessageRow.js'
 import type { Message } from '../stores/messages.js'
 
-// Import version from package.json
-const VERSION = '1.0.0'
+declare const __LATEXY_VERSION__: string
+const VERSION: string = __LATEXY_VERSION__
 
 function WelcomeBanner(): React.ReactElement {
   return (

--- a/packages/tui/src/components/overlays/LoginOverlay.tsx
+++ b/packages/tui/src/components/overlays/LoginOverlay.tsx
@@ -65,7 +65,7 @@ export function LoginOverlay(): React.ReactElement {
       })
 
       wsClient.connect(wsUrl, token)
-      wsClient.on('connected', () => {
+      wsClient.once('connected', () => {
         $ui.set({ ...$ui.get(), wsConnected: true })
         wsClient.drain()
       })


### PR DESCRIPTION
## Summary
- `cli.tsx`: SIGINT/SIGTERM handlers for clean shutdown
- `app.tsx`: `/me` path (was `/api/me`), `wsClient.once` for connected events, interval cleanup on unmount
- `LoginOverlay.tsx`: `wsClient.once` to prevent listener accumulation on repeated logins
- `SlashSuggestions.tsx` + `PromptInput.tsx` + `LogStreamCard.tsx`: `isActive` prop guards `useInput` so overlays don't capture input when not visible
- `CompileResultCard.tsx`: dynamic compiler name prop instead of hardcoded
- `TranscriptView.tsx`: version from build-time constant (aligns with tsup define fix)

## Issues
closes #736 closes #738

## Test plan
- [ ] Ctrl+C exits TUI cleanly (exit 0)
- [ ] Slash suggestions don't capture keys when blocked by an overlay
- [ ] Login screen doesn't accumulate WS listeners on repeated attempts
- [ ] CompileResultCard shows actual compiler (xelatex vs pdflatex)