### PR TITLE
fix(tui): 26 critical TUI bugs — API paths, WS events, headless compile, UX guards

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -8,6 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.config import settings
@@ -15,8 +16,9 @@ from ..core.logging import get_logger
 from ..core.observability import metrics_content_type, metrics_payload
 from ..core.redis import redis_manager as _redis_manager
 from ..database.connection import get_async_db_session, get_db
-from ..database.models import Compilation, Resume
-from ..middleware.auth_middleware import get_current_user_optional, get_current_user_required as _require_user
+from ..database.models import Compilation, Resume, User
+from ..middleware.auth_middleware import get_current_user_optional
+from ..middleware.auth_middleware import get_current_user_required as _require_user
 from ..models.llm_schemas import OptimizationRequest, OptimizationResponse
 from ..models.schemas import CompilationResponse, HealthResponse, LogsResponse
 from ..services.feature_flag_service import feature_flag_service
@@ -222,9 +224,6 @@ async def get_me(
     user_id: str = Depends(_require_user),
 ):
     """Return the authenticated user's id, email, and subscription plan."""
-    from sqlalchemy import select
-    from ..database.models import User
-
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
     if user is None:

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -16,7 +16,7 @@ from ..core.observability import metrics_content_type, metrics_payload
 from ..core.redis import redis_manager as _redis_manager
 from ..database.connection import get_async_db_session, get_db
 from ..database.models import Compilation, Resume
-from ..middleware.auth_middleware import get_current_user_optional
+from ..middleware.auth_middleware import get_current_user_optional, get_current_user_required as _require_user
 from ..models.llm_schemas import OptimizationRequest, OptimizationResponse
 from ..models.schemas import CompilationResponse, HealthResponse, LogsResponse
 from ..services.feature_flag_service import feature_flag_service
@@ -208,6 +208,28 @@ def _check_cors_origins_on_startup() -> None:
                 " (entries: %s)",
                 localhost_origins,
             )
+
+
+class MeResponse(BaseModel):
+    id: str
+    email: str
+    plan: str
+
+
+@router.get("/me", response_model=MeResponse)
+async def get_me(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(_require_user),
+):
+    """Return the authenticated user's id, email, and subscription plan."""
+    from sqlalchemy import select
+    from ..database.models import User
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return MeResponse(id=user.id, email=user.email, plan=user.subscription_plan)
 
 
 @router.get("/health", response_model=HealthResponse)

--- a/packages/tui/src/__tests__/e2e/dispatch.e2e.test.ts
+++ b/packages/tui/src/__tests__/e2e/dispatch.e2e.test.ts
@@ -140,26 +140,26 @@ describe('dispatch — API_HANDLERS', () => {
     expect(err?.content).toContain('No active job')
   })
 
-  it('/cancel with active job calls POST /api/jobs/:id/cancel', async () => {
+  it('/cancel with active job calls DELETE /jobs/:id', async () => {
     $activeJobId.set('job-abc')
     const { getApiClient } = await import('../../lib/api-client.js')
-    const mockPost = vi.fn().mockResolvedValue({})
-    vi.mocked(getApiClient).mockReturnValue({ get: vi.fn(), post: mockPost } as never)
+    const mockDelete = vi.fn().mockResolvedValue({})
+    vi.mocked(getApiClient).mockReturnValue({ get: vi.fn(), post: vi.fn(), delete: mockDelete } as never)
 
     const { dispatch } = await import('../../commands/dispatch.js')
     await dispatch('/cancel')
 
-    expect(mockPost).toHaveBeenCalledWith('/api/jobs/job-abc/cancel')
+    expect(mockDelete).toHaveBeenCalledWith('/jobs/job-abc')
   })
 
   it('/cancel with explicit job-id uses that id', async () => {
     const { getApiClient } = await import('../../lib/api-client.js')
-    const mockPost = vi.fn().mockResolvedValue({})
-    vi.mocked(getApiClient).mockReturnValue({ get: vi.fn(), post: mockPost } as never)
+    const mockDelete = vi.fn().mockResolvedValue({})
+    vi.mocked(getApiClient).mockReturnValue({ get: vi.fn(), post: vi.fn(), delete: mockDelete } as never)
 
     const { dispatch } = await import('../../commands/dispatch.js')
     await dispatch('/cancel explicit-job-id')
 
-    expect(mockPost).toHaveBeenCalledWith('/api/jobs/explicit-job-id/cancel')
+    expect(mockDelete).toHaveBeenCalledWith('/jobs/explicit-job-id')
   })
 })

--- a/packages/tui/src/__tests__/ws-client.test.ts
+++ b/packages/tui/src/__tests__/ws-client.test.ts
@@ -41,8 +41,8 @@ describe('LatexyWSClient', () => {
   it('buffers events before drain()', () => {
     const received: unknown[] = []
     client.on('event', e => received.push(e))
-    const ev = { type: 'log.line', job_id: 'j1', event_id: 'e1', sequence: 1, timestamp: 1, line: 'hello', level: 'info' }
-    mockWSInstance.emit('message', Buffer.from(JSON.stringify(ev)))
+    const inner = { type: 'log.line', job_id: 'j1', event_id: 'e1', sequence: 1, timestamp: 1, line: 'hello', level: 'info' }
+    mockWSInstance.emit('message', Buffer.from(JSON.stringify({ type: 'event', event: inner })))
     expect(received).toHaveLength(0)
     client.drain()
     expect(received).toHaveLength(1)
@@ -52,8 +52,8 @@ describe('LatexyWSClient', () => {
     client.drain()
     const received: unknown[] = []
     client.on('event', e => received.push(e))
-    const ev = { type: 'log.line', job_id: 'j1', event_id: 'e2', sequence: 2, timestamp: 2, line: 'world', level: 'info' }
-    mockWSInstance.emit('message', Buffer.from(JSON.stringify(ev)))
+    const inner = { type: 'log.line', job_id: 'j1', event_id: 'e2', sequence: 2, timestamp: 2, line: 'world', level: 'info' }
+    mockWSInstance.emit('message', Buffer.from(JSON.stringify({ type: 'event', event: inner })))
     expect(received).toHaveLength(1)
   })
 

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -14,6 +14,8 @@ export function App(): React.ReactElement {
   const _overlay = useStore($overlay)
 
   useEffect(() => {
+    let healthInterval: ReturnType<typeof setInterval> | null = null
+
     const init = async (): Promise<void> => {
       const cfg = await readConfig()
 
@@ -34,18 +36,18 @@ export function App(): React.ReactElement {
 
       if (cfg.token) {
         wsClient.connect(wsUrl, cfg.token)
-        wsClient.on('connected', () => {
+        wsClient.once('connected', () => {
           $ui.set({ ...$ui.get(), wsConnected: true })
           wsClient.drain()
         })
-        wsClient.on('disconnected', () => {
+        wsClient.once('disconnected', () => {
           $ui.set({ ...$ui.get(), wsConnected: false })
         })
 
         // Validate token + get user info
         const { getApiClient } = await import('./lib/api-client.js')
         try {
-          const me = await getApiClient().get<{ id: string; email: string; plan?: string }>('/api/me')
+          const me = await getApiClient().get<{ id: string; email: string; plan?: string }>('/me')
           $session.set({
             ...$session.get(),
             userId: me.id,
@@ -70,7 +72,7 @@ export function App(): React.ReactElement {
           }
         }
         await poll()
-        setInterval(() => { void poll() }, 30_000)
+        healthInterval = setInterval(() => { void poll() }, 30_000)
       } else {
         const { LoginOverlay } = await import('./components/overlays/LoginOverlay.js')
         openOverlay(React.createElement(LoginOverlay))
@@ -80,6 +82,11 @@ export function App(): React.ReactElement {
     init().catch(err => {
       addMessage({ role: 'error', content: `Startup error: ${String(err)}` })
     })
+
+    return () => {
+      if (healthInterval != null) clearInterval(healthInterval)
+      wsClient.destroy()
+    }
   }, [])
 
   return <AppShell />

--- a/packages/tui/src/cli.tsx
+++ b/packages/tui/src/cli.tsx
@@ -22,8 +22,7 @@ if (isCI || hasJsonFlag) {
   })
 } else {
   const { unmount } = render(React.createElement(App), { patchConsole: false })
-  process.on('SIGTERM', () => {
-    unmount()
-    process.exit(0)
-  })
+  const shutdown = () => { unmount(); process.exit(0) }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
 }

--- a/packages/tui/src/commands/dispatch.ts
+++ b/packages/tui/src/commands/dispatch.ts
@@ -73,7 +73,7 @@ const API_HANDLERS: Record<string, (parsed: NonNullable<ReturnType<typeof parseS
     }
     const { getApiClient } = await import('../lib/api-client.js')
     try {
-      await getApiClient().post(`/api/jobs/${jobId}/cancel`)
+      await getApiClient().delete(`/jobs/${jobId}`)
       addMessage({ role: 'system', content: `Job ${jobId} cancellation requested.` })
     } catch (err) {
       addMessage({ role: 'error', content: `Cancel failed: ${String(err)}` })

--- a/packages/tui/src/components/CompileResultCard.tsx
+++ b/packages/tui/src/components/CompileResultCard.tsx
@@ -8,9 +8,10 @@ interface Props {
   compilationTimeMs: number
   pdfUrl: string | null
   atsScore: number | null
+  compiler?: string
 }
 
-export function CompileResultCard({ pages, sizeBytes, compilationTimeMs, pdfUrl, atsScore }: Props): React.ReactElement {
+export function CompileResultCard({ pages, sizeBytes, compilationTimeMs, pdfUrl, atsScore, compiler = 'pdflatex' }: Props): React.ReactElement {
   const sizeStr = sizeBytes != null ? `${(sizeBytes / 1024).toFixed(1)} KB` : null
   const timeStr = compilationTimeMs.toLocaleString() + ' ms'
 
@@ -47,7 +48,7 @@ export function CompileResultCard({ pages, sizeBytes, compilationTimeMs, pdfUrl,
         )}
         <Box flexDirection="column">
           <Text dimColor>Compiler</Text>
-          <Text bold>pdflatex</Text>
+          <Text bold>{compiler}</Text>
         </Box>
         <Box flexDirection="column">
           <Text dimColor>Time</Text>

--- a/packages/tui/src/components/LogStreamCard.tsx
+++ b/packages/tui/src/components/LogStreamCard.tsx
@@ -6,6 +6,7 @@ interface Props {
   lines: string[]
   maxVisible?: number
   percent?: number
+  isActive?: boolean
 }
 
 function classifyLine(line: string): 'error' | 'warning' | 'success' | 'info' {
@@ -16,14 +17,14 @@ function classifyLine(line: string): 'error' | 'warning' | 'success' | 'info' {
   return 'info'
 }
 
-export function LogStreamCard({ lines, maxVisible = 25, percent }: Props): React.ReactElement {
+export function LogStreamCard({ lines, maxVisible = 25, percent, isActive = false }: Props): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false)
 
   useInput((_input, key) => {
     if (key.return) {
       setCollapsed(c => !c)
     }
-  })
+  }, { isActive })
 
   const visible = useMemo(
     () => (lines.length > maxVisible ? lines.slice(-maxVisible) : lines),

--- a/packages/tui/src/components/PromptInput.tsx
+++ b/packages/tui/src/components/PromptInput.tsx
@@ -44,7 +44,13 @@ export function PromptInput({ onSubmit }: Props): React.ReactElement {
 
   return (
     <Box flexDirection="column">
-      {isSlash && value.length > 1 && <SlashSuggestions query={slashQuery} />}
+      {isSlash && value.length > 1 && (
+        <SlashSuggestions
+          query={slashQuery}
+          isActive={!isBlocked}
+          onComplete={(name) => { setValue(`/${name} `) }}
+        />
+      )}
       <Box gap={1} paddingX={1} borderStyle="single" borderColor="cyan">
         <Text bold color={promptColor}>{promptGlyph}</Text>
         {activeJobId != null

--- a/packages/tui/src/components/SlashSuggestions.tsx
+++ b/packages/tui/src/components/SlashSuggestions.tsx
@@ -6,9 +6,10 @@ interface Props {
   query: string
   maxItems?: number
   onComplete?: (name: string) => void
+  isActive?: boolean
 }
 
-export function SlashSuggestions({ query, maxItems = 7, onComplete }: Props): React.ReactElement | null {
+export function SlashSuggestions({ query, maxItems = 7, onComplete, isActive = true }: Props): React.ReactElement | null {
   const [selectedIndex, setSelectedIndex] = useState(0)
 
   const matches = useMemo(() => {
@@ -40,7 +41,7 @@ export function SlashSuggestions({ query, maxItems = 7, onComplete }: Props): Re
     } else if (key.tab) {
       handleComplete()
     }
-  })
+  }, { isActive })
 
   if (matches.length === 0) return null
 

--- a/packages/tui/src/components/TranscriptView.tsx
+++ b/packages/tui/src/components/TranscriptView.tsx
@@ -5,8 +5,8 @@ import { $messages } from '../stores/messages.js'
 import { MessageRow } from './MessageRow.js'
 import type { Message } from '../stores/messages.js'
 
-// Import version from package.json
-const VERSION = '1.0.0'
+declare const __LATEXY_VERSION__: string
+const VERSION: string = __LATEXY_VERSION__
 
 function WelcomeBanner(): React.ReactElement {
   return (

--- a/packages/tui/src/components/overlays/LoginOverlay.tsx
+++ b/packages/tui/src/components/overlays/LoginOverlay.tsx
@@ -65,7 +65,7 @@ export function LoginOverlay(): React.ReactElement {
       })
 
       wsClient.connect(wsUrl, token)
-      wsClient.on('connected', () => {
+      wsClient.once('connected', () => {
         $ui.set({ ...$ui.get(), wsConnected: true })
         wsClient.drain()
       })

--- a/packages/tui/src/components/overlays/ResumePicker.tsx
+++ b/packages/tui/src/components/overlays/ResumePicker.tsx
@@ -28,7 +28,7 @@ export function ResumePicker(): React.ReactElement {
 
   useEffect(() => {
     const client = getApiClient()
-    client.get<ResumeListResponse>('/api/resumes?limit=50')
+    client.get<ResumeListResponse>('/resumes?limit=50')
       .then(res => {
         setResumes(res.resumes)
         setLoading(false)
@@ -42,6 +42,11 @@ export function ResumePicker(): React.ReactElement {
   const filtered = filter
     ? resumes.filter(r => r.title.toLowerCase().includes(filter.toLowerCase()))
     : resumes
+
+  // Reset cursor when filter narrows the list
+  useEffect(() => {
+    setCursor(0)
+  }, [filter])
 
   const select = useCallback((resume: Resume) => {
     void writeConfig({ defaultResumeId: resume.id })

--- a/packages/tui/src/headless.ts
+++ b/packages/tui/src/headless.ts
@@ -9,7 +9,7 @@ const useJson = process.argv.includes('--json')
 
 function out(obj: unknown): void {
   if (useJson) process.stdout.write(JSON.stringify(obj) + '\n')
-  else process.stderr.write(JSON.stringify(obj, null, 2) + '\n')
+  else process.stdout.write(JSON.stringify(obj, null, 2) + '\n')
 }
 
 function log(msg: string): void {
@@ -61,25 +61,27 @@ async function headlessCompile(args: string[]): Promise<number> {
 
   if (resumeId) {
     log(`Compiling resume ${resumeId}…`)
-    const res = await client.post<{ job_id: string }>('/api/jobs/submit', {
+    const resume = await client.get<{ latex_content: string }>(`/resumes/${resumeId}`)
+    const res = await client.post<{ job_id: string }>('/jobs/submit', {
       job_type: 'latex_compilation',
-      resume_id: resumeId,
-      settings: { compiler },
+      latex_content: resume.latex_content,
+      compiler,
     })
     jobId = res.job_id
   } else {
-    // Local file upload
+    // Local file path: read content and submit via the job queue (same as --resume-id)
     const filePath = args.find(a => !a.startsWith('-') && a !== 'compile')
     if (!filePath) {
       out({ success: false, error: 'Provide a .tex file path or --resume-id <uuid>' })
       return 3
     }
-    log(`Uploading ${basename(filePath)}…`)
-    const bytes = await readFile(filePath)
-    const form = new FormData()
-    form.append('file', new Blob([bytes], { type: 'application/octet-stream' }), basename(filePath))
-    form.append('compiler', compiler)
-    const res = await client.postForm<{ job_id: string }>('/api/compile', form)
+    log(`Compiling ${basename(filePath)}…`)
+    const latex_content = await readFile(filePath, 'utf-8')
+    const res = await client.post<{ job_id: string }>('/jobs/submit', {
+      job_type: 'latex_compilation',
+      latex_content,
+      compiler,
+    })
     jobId = res.job_id
   }
 
@@ -87,9 +89,8 @@ async function headlessCompile(args: string[]): Promise<number> {
   const ev = await waitForJob(jobId, cfg.token, wsUrl)
 
   if (ev.type === 'job.completed') {
-    const result = ev.result as Record<string, unknown>
-    if (outputPath && result['pdf_url']) {
-      const pdfRes = await fetch(cfg.backendUrl + (result['pdf_url'] as string), {
+    if (outputPath) {
+      const pdfRes = await fetch(`${cfg.backendUrl}/download/${jobId}`, {
         headers: { Authorization: `Bearer ${cfg.token}` },
       })
       const buf = await pdfRes.arrayBuffer()
@@ -99,11 +100,12 @@ async function headlessCompile(args: string[]): Promise<number> {
     out({
       success: true,
       job_id: jobId,
-      pages: result['pages'] ?? null,
-      size_bytes: result['size_bytes'] ?? null,
-      ats_score: result['ats_score'] ?? null,
-      pdf_url: result['pdf_url'] ?? null,
-      compilation_time_ms: result['compilation_time_ms'] ?? null,
+      pages: ev.page_count ?? null,
+      ats_score: ev.ats_score ?? null,
+      compilation_time_ms: ev.compilation_time != null
+        ? Math.round(ev.compilation_time * 1000)
+        : null,
+      compiler: ev.compiler ?? null,
     })
     return 0
   } else {

--- a/packages/tui/src/lib/config.ts
+++ b/packages/tui/src/lib/config.ts
@@ -48,7 +48,9 @@ export async function writeConfig(patch: Partial<LatexyConfig>): Promise<void> {
   await mkdir(configDir(), { recursive: true })
   const current = await readConfig()
   const next = { ...current, ...patch }
-  const toml = TOML.stringify(next as TOML.JsonMap)
+  // @iarna/toml does not support null — strip null fields before serialising
+  const toWrite = Object.fromEntries(Object.entries(next).filter(([, v]) => v !== null))
+  const toml = TOML.stringify(toWrite as TOML.JsonMap)
   await writeFile(configPath(), toml, { encoding: 'utf-8', mode: 0o600 })
   await chmod(configPath(), 0o600)
 }

--- a/packages/tui/src/lib/event-types.ts
+++ b/packages/tui/src/lib/event-types.ts
@@ -44,8 +44,15 @@ export interface JobProgressEvent extends BaseEvent {
 
 export interface JobCompletedEvent extends BaseEvent {
   type: 'job.completed'
-  result: Record<string, unknown>
-  final_status: string
+  pdf_job_id?: string
+  page_count?: number | null
+  ats_score?: number | null
+  compilation_time?: number | null
+  optimization_time?: number | null
+  compiler?: string
+  is_beamer?: boolean
+  // Legacy / fallback: some paths wrap fields under result
+  result?: Record<string, unknown>
 }
 
 export interface JobFailedEvent extends BaseEvent {

--- a/packages/tui/src/lib/ws-client.ts
+++ b/packages/tui/src/lib/ws-client.ts
@@ -39,8 +39,14 @@ export class LatexyWSClient extends EventEmitter {
 
     this.ws.on('message', (data: Buffer) => {
       try {
-        const ev = JSON.parse(data.toString()) as AnyEvent
-        this.publish(ev)
+        const outer = JSON.parse(data.toString()) as Record<string, unknown>
+        if (outer['type'] === 'event' && outer['event']) {
+          // Unwrap the server's envelope: {type:"event", event:{...}} → emit inner event
+          this.publish(outer['event'] as AnyEvent)
+        } else if (outer['type'] === 'subscribed') {
+          this.emit('subscribed', outer)
+        }
+        // Other outer types (heartbeat, error) are intentionally ignored
       } catch {}
     })
 

--- a/packages/tui/src/tools/compile.ts
+++ b/packages/tui/src/tools/compile.ts
@@ -49,7 +49,7 @@ export async function runCompile(parsed: ParsedCommand): Promise<void> {
       form.append('file', new Blob([fileBytes], { type: 'application/octet-stream' }), basename(filePath))
       form.append('compiler', compiler)
 
-      const res = await client.postForm<JobSubmitResponse>('/api/compile', form)
+      const res = await client.postForm<JobSubmitResponse>('/compile', form)
       const jobId = res.job_id
 
       $activeJobId.set(jobId)
@@ -72,7 +72,7 @@ export async function runCompile(parsed: ParsedCommand): Promise<void> {
   if (!actualResumeId) {
     // No resume specified — fetch first resume
     try {
-      const list = await client.get<ResumeListResponse>('/api/resumes?limit=1')
+      const list = await client.get<ResumeListResponse>('/resumes?limit=1')
       actualResumeId = list.resumes[0]?.id
       if (!actualResumeId) {
         addMessage({ role: 'error', content: 'No resumes found. Create one first with /new.' })
@@ -93,10 +93,11 @@ export async function runCompile(parsed: ParsedCommand): Promise<void> {
   })
 
   try {
-    const res = await client.post<JobSubmitResponse>('/api/jobs/submit', {
+    const resume = await client.get<{ latex_content: string }>(`/resumes/${actualResumeId}`)
+    const res = await client.post<JobSubmitResponse>('/jobs/submit', {
       job_type: 'latex_compilation',
-      resume_id: actualResumeId,
-      settings: { compiler },
+      latex_content: resume.latex_content,
+      compiler,
     })
     const jobId = res.job_id
 

--- a/packages/tui/tsup.config.ts
+++ b/packages/tui/tsup.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'tsup'
+import { readFileSync } from 'node:fs'
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string }
 
 export default defineConfig({
   entry: { cli: 'src/cli.tsx' },
@@ -11,4 +14,7 @@ export default defineConfig({
   sourcemap: true,
   banner: { js: '#!/usr/bin/env node' },
   external: [],
+  define: {
+    __LATEXY_VERSION__: JSON.stringify(version),
+  },
 })


### PR DESCRIPTION
## Summary
Complete fix for all 26 bugs tracked across #732–#738. The TUI was shipping broken in every core flow.

- **#732** All API calls had a stale `/api` prefix → every request 404d
- **#733** Compile submissions never included `latex_content` → every job failed 422
- **#734** Cancel used `POST /api/jobs/{id}/cancel` → should be `DELETE /jobs/{id}`
- **#735** Headless compile hung 5 min — two root causes: (1) WS client published the outer envelope `{type:"event",event:{}}` directly instead of the inner event, so `ev.job_id` was always `undefined` and all events were filtered out; (2) file-path path called synchronous `/compile` (no WS events) then waited on WS forever — fixed by reading content and submitting via `/jobs/submit`
- **#736** TUI startup checked `/api/me` which didn't exist — added `GET /me` to backend
- **#737** Logout crashed — `@iarna/toml` can't encode `null`, now strips nulls before serialize
- **#738** Multiple UX bugs: listener leaks on WS connect/login, input not isolated across overlays, missing SIGINT handler, hardcoded compiler name, version read from wrong path at runtime

## Sub-PRs
- #750 — backend `GET /me` endpoint
- #751 — WS envelope unwrap + `JobCompletedEvent` flat fields
- #752 — API paths + `latex_content` across all compile paths
- #753 — Cancel HTTP method fix
- #754 — TOML null crash + build-time version injection
- #755 — UX guards, listener leaks, SIGINT, cosmetics

## Issues closed
closes #732 closes #733 closes #734 closes #735 closes #736 closes #737 closes #738

## Test plan
- [ ] 94/94 unit tests pass (`cd packages/tui && npx vitest run`)
- [ ] Headless compile file path: `CI=true latexy compile file.tex --json` exits 0 with pages/compiler/time
- [ ] Headless compile resume: `CI=true latexy compile --resume-id <uuid> --json` exits 0
- [ ] No-auth exits 2 with `"Not authenticated"` JSON error
- [ ] Bad resume ID exits 1 with `"Resume not found"` error
- [ ] Invalid LaTeX exits 1 with `error_code: "latex_error"`
- [ ] `--output out.pdf` downloads valid PDF
- [ ] Ctrl+C exits cleanly (exit 0 interactive, exit 130 headless)