### PR TITLE
fix(resumes): macro/snippet 500s, workspace counts, share redaction, template compare

### DIFF
--- a/backend/app/api/macro_routes.py
+++ b/backend/app/api/macro_routes.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..database.connection import get_db
-from ..database.models import User, UserMacro
+from ..database.models import UserMacro
 from ..middleware.auth_middleware import get_current_user_required as get_current_user
 
 router = APIRouter(prefix='/macros', tags=['macros'])
@@ -66,11 +66,11 @@ def _to_response(macro: UserMacro) -> MacroResponse:
 @router.get('', response_model=list[MacroResponse])
 async def list_macros(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> list[MacroResponse]:
     result = await db.execute(
         select(UserMacro)
-        .where(UserMacro.user_id == current_user.id)
+        .where(UserMacro.user_id == user_id)
         .order_by(UserMacro.created_at.desc())
     )
     return [_to_response(m) for m in result.scalars().all()]
@@ -80,10 +80,10 @@ async def list_macros(
 async def create_macro(
     body: MacroCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> MacroResponse:
     macro = UserMacro(
-        user_id=current_user.id,
+        user_id=user_id,
         name=body.name,
         description=body.description,
         shortcut=body.shortcut,
@@ -100,13 +100,13 @@ async def update_macro(
     macro_id: str,
     body: MacroUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> MacroResponse:
     result = await db.execute(select(UserMacro).where(UserMacro.id == macro_id))
     macro = result.scalar_one_or_none()
     if not macro:
         raise HTTPException(status_code=404, detail='Macro not found')
-    if macro.user_id != current_user.id:
+    if macro.user_id != user_id:
         raise HTTPException(status_code=403, detail='Access denied')
     for field, val in body.model_dump(exclude_unset=True).items():
         setattr(macro, field, val)
@@ -119,13 +119,13 @@ async def update_macro(
 async def delete_macro(
     macro_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> None:
     result = await db.execute(select(UserMacro).where(UserMacro.id == macro_id))
     macro = result.scalar_one_or_none()
     if not macro:
         raise HTTPException(status_code=404, detail='Macro not found')
-    if macro.user_id != current_user.id:
+    if macro.user_id != user_id:
         raise HTTPException(status_code=403, detail='Access denied')
     await db.delete(macro)
     await db.commit()

--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -14,6 +14,7 @@ from jinja2 import FileSystemLoader as _JinjaFSL
 from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
 
 from ..core.config import settings
 from ..core.logging import get_logger
@@ -31,22 +32,42 @@ router = APIRouter(prefix="/resumes", tags=["resumes"])
 
 # --- Schemas ---
 
+ALLOWED_DOCUMENT_TYPES = frozenset({"resume", "presentation", "academic_cv", "cover_letter"})
+MAX_LATEX_CONTENT_LEN = 1_000_000  # ~1MB cap to prevent unbounded storage/DoS
+
+
+def _validate_document_type(v: Optional[str]) -> Optional[str]:
+    if v is not None and v not in ALLOWED_DOCUMENT_TYPES:
+        raise ValueError(f"document_type must be one of {sorted(ALLOWED_DOCUMENT_TYPES)}")
+    return v
+
+
 class ResumeBase(BaseModel):
-    title: str
-    latex_content: str
+    title: str = Field(..., min_length=1, max_length=255)
+    latex_content: str = Field(..., max_length=MAX_LATEX_CONTENT_LEN)
     is_template: bool = False
     tags: Optional[List[str]] = None
     document_type: str = "resume"
 
 class ResumeCreate(ResumeBase):
-    pass
+    # document_type validation is enforced on input only (not on ResumeResponse,
+    # which inherits ResumeBase and must faithfully echo stored values).
+    @field_validator("document_type")
+    @classmethod
+    def _check_document_type(cls, v: str) -> str:
+        return _validate_document_type(v)
 
 class ResumeUpdate(BaseModel):
-    title: Optional[str] = None
-    latex_content: Optional[str] = None
+    title: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    latex_content: Optional[str] = Field(default=None, max_length=MAX_LATEX_CONTENT_LEN)
     is_template: Optional[bool] = None
     tags: Optional[List[str]] = None
     document_type: Optional[str] = None
+
+    @field_validator("document_type")
+    @classmethod
+    def _check_document_type(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_document_type(v)
 
 class ResumeResponse(ResumeBase):
     id: str
@@ -792,6 +813,16 @@ async def update_resume(
     if latex_changed and resume.selected_template_id and resume.structured_content:
         resume.builder_status = "detached"
         resume.content_source = "manual_latex"
+
+    # Content changed → invalidate the cached anonymous (redacted) share PDF so the
+    # next create_share_link call regenerates it from the updated content.
+    if latex_changed:
+        meta = dict(resume.resume_settings or {})
+        if meta.pop("share_anonymous_job_id", None) is not None or meta.pop(
+            "share_anonymous_pending", None
+        ) is not None:
+            resume.resume_settings = meta
+            flag_modified(resume, "resume_settings")
 
     resume.updated_at = datetime.now(timezone.utc)
     await db.commit()
@@ -1727,12 +1758,18 @@ async def create_share_link(
                 metadata={"anonymous_share": True, "resume_id": resume_id},
             )
             current_meta["share_anonymous_job_id"] = anon_job_id
-            resume.resume_settings = current_meta
+            # Reassign a fresh dict AND flag_modified so SQLAlchemy persists the
+            # change even after an earlier autoflush (triggered by the Compilation
+            # lookup above) committed `current_meta` — a plain JSONB column does not
+            # track in-place mutations.
+            resume.resume_settings = dict(current_meta)
+            flag_modified(resume, "resume_settings")
             logger.info(f"Submitted anonymous compile job {anon_job_id} for resume {resume_id}")
         except Exception as exc:
             logger.error(f"Could not submit anonymous compile job for resume {resume_id}: {exc}")
             current_meta["share_anonymous_pending"] = True
-            resume.resume_settings = current_meta
+            resume.resume_settings = dict(current_meta)
+            flag_modified(resume, "resume_settings")
 
     await db.commit()
     await db.refresh(resume)
@@ -2011,9 +2048,20 @@ async def bulk_export(
 _VALID_ROLES = {"editor", "commenter", "viewer"}
 
 
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
 class CollaboratorInviteRequest(BaseModel):
     email: str = Field(..., min_length=3, max_length=255)
     role: str = Field(default="editor")
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        v = v.strip()
+        if not _EMAIL_RE.match(v):
+            raise ValueError("Invalid email address")
+        return v.lower()
 
     @field_validator("role")
     @classmethod

--- a/backend/app/api/snippet_routes.py
+++ b/backend/app/api/snippet_routes.py
@@ -153,7 +153,7 @@ async def list_snippets(
     offset: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=50),
     db: AsyncSession = Depends(get_db),
-    current_user: Optional[User] = Depends(get_current_user_optional),
+    user_id: Optional[str] = Depends(get_current_user_optional),
 ) -> list[SnippetResponse]:
     stmt = select(Snippet)
     if category:
@@ -174,7 +174,6 @@ async def list_snippets(
 
     result = await db.execute(stmt)
     snippets = result.scalars().all()
-    user_id = current_user.id if current_user else None
     return [await _build_response(s, user_id, db) for s in snippets]
 
 
@@ -182,13 +181,12 @@ async def list_snippets(
 async def get_snippet(
     snippet_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: Optional[User] = Depends(get_current_user_optional),
+    user_id: Optional[str] = Depends(get_current_user_optional),
 ) -> SnippetResponse:
     result = await db.execute(select(Snippet).where(Snippet.id == snippet_id))
     snippet = result.scalar_one_or_none()
     if not snippet:
         raise HTTPException(status_code=404, detail='Snippet not found')
-    user_id = current_user.id if current_user else None
     return await _build_response(snippet, user_id, db)
 
 
@@ -196,11 +194,11 @@ async def get_snippet(
 async def create_snippet(
     body: SnippetCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> SnippetResponse:
     _check_content_safety(body.content)
     snippet = Snippet(
-        author_id=current_user.id,
+        author_id=user_id,
         title=body.title,
         description=body.description,
         content=body.content,
@@ -211,7 +209,7 @@ async def create_snippet(
     db.add(snippet)
     await db.commit()
     await db.refresh(snippet)
-    return await _build_response(snippet, current_user.id, db)
+    return await _build_response(snippet, user_id, db)
 
 
 @router.patch('/{snippet_id}', response_model=SnippetResponse)
@@ -219,13 +217,13 @@ async def update_snippet(
     snippet_id: str,
     body: SnippetUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> SnippetResponse:
     result = await db.execute(select(Snippet).where(Snippet.id == snippet_id))
     snippet = result.scalar_one_or_none()
     if not snippet:
         raise HTTPException(status_code=404, detail='Snippet not found')
-    if snippet.author_id != current_user.id:
+    if snippet.author_id != user_id:
         raise HTTPException(status_code=403, detail='Only the author can update this snippet')
     if body.content:
         _check_content_safety(body.content)
@@ -233,20 +231,20 @@ async def update_snippet(
         setattr(snippet, field, val)
     await db.commit()
     await db.refresh(snippet)
-    return await _build_response(snippet, current_user.id, db)
+    return await _build_response(snippet, user_id, db)
 
 
 @router.delete('/{snippet_id}', status_code=204)
 async def delete_snippet(
     snippet_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> None:
     result = await db.execute(select(Snippet).where(Snippet.id == snippet_id))
     snippet = result.scalar_one_or_none()
     if not snippet:
         raise HTTPException(status_code=404, detail='Snippet not found')
-    if snippet.author_id != current_user.id:
+    if snippet.author_id != user_id:
         raise HTTPException(status_code=403, detail='Only the author can delete this snippet')
     await db.delete(snippet)
     await db.commit()
@@ -256,7 +254,7 @@ async def delete_snippet(
 async def install_snippet(
     snippet_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> None:
     result = await db.execute(select(Snippet).where(Snippet.id == snippet_id))
     snippet = result.scalar_one_or_none()
@@ -267,11 +265,11 @@ async def install_snippet(
     existing = await db.execute(
         select(SnippetInstall).where(
             SnippetInstall.snippet_id == snippet_id,
-            SnippetInstall.user_id == current_user.id,
+            SnippetInstall.user_id == user_id,
         )
     )
     if existing.scalar_one_or_none() is None:
-        db.add(SnippetInstall(snippet_id=snippet_id, user_id=current_user.id))
+        db.add(SnippetInstall(snippet_id=snippet_id, user_id=user_id))
         snippet.installs_count = (snippet.installs_count or 0) + 1
         await db.commit()
 
@@ -280,7 +278,7 @@ async def install_snippet(
 async def uninstall_snippet(
     snippet_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> None:
     result = await db.execute(select(Snippet).where(Snippet.id == snippet_id))
     snippet = result.scalar_one_or_none()
@@ -290,7 +288,7 @@ async def uninstall_snippet(
     existing = await db.execute(
         select(SnippetInstall).where(
             SnippetInstall.snippet_id == snippet_id,
-            SnippetInstall.user_id == current_user.id,
+            SnippetInstall.user_id == user_id,
         )
     )
     install = existing.scalar_one_or_none()
@@ -304,7 +302,7 @@ async def uninstall_snippet(
 async def toggle_upvote(
     snippet_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ) -> None:
     result = await db.execute(select(Snippet).where(Snippet.id == snippet_id))
     snippet = result.scalar_one_or_none()
@@ -314,7 +312,7 @@ async def toggle_upvote(
     existing = await db.execute(
         select(SnippetUpvote).where(
             SnippetUpvote.snippet_id == snippet_id,
-            SnippetUpvote.user_id == current_user.id,
+            SnippetUpvote.user_id == user_id,
         )
     )
     upvote = existing.scalar_one_or_none()
@@ -324,7 +322,7 @@ async def toggle_upvote(
         snippet.upvotes_count = max(0, (snippet.upvotes_count or 1) - 1)
     else:
         # Toggle on
-        db.add(SnippetUpvote(snippet_id=snippet_id, user_id=current_user.id))
+        db.add(SnippetUpvote(snippet_id=snippet_id, user_id=user_id))
         snippet.upvotes_count = (snippet.upvotes_count or 0) + 1
     await db.commit()
 

--- a/backend/app/api/template_routes.py
+++ b/backend/app/api/template_routes.py
@@ -15,6 +15,7 @@ Endpoints:
   DELETE /templates/{id}           — admin; delete template
 """
 
+import hmac
 import uuid as _uuid
 from typing import List, Optional
 
@@ -130,7 +131,7 @@ async def require_template_admin(
 ):
     if not settings.ADMIN_SECRET_KEY:
         raise HTTPException(status_code=503, detail="Admin template management is not configured")
-    if admin_secret != settings.ADMIN_SECRET_KEY:
+    if not hmac.compare_digest(admin_secret or "", settings.ADMIN_SECRET_KEY):
         raise HTTPException(status_code=403, detail="Invalid admin secret")
 
 

--- a/backend/app/api/workspace_routes.py
+++ b/backend/app/api/workspace_routes.py
@@ -1,11 +1,12 @@
 """Team workspace routes (Feature 66)."""
 
+import re
 from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
-from sqlalchemy import select
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.logging import get_logger
@@ -54,9 +55,20 @@ class WorkspaceDetailResponse(WorkspaceResponse):
     members: List[MemberResponse] = []
 
 
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
 class InviteRequest(BaseModel):
     email: str = Field(..., max_length=255)
     role: str = Field(default="editor")
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        v = v.strip()
+        if not _EMAIL_RE.match(v):
+            raise ValueError("Invalid email address")
+        return v.lower()
 
 
 class RoleUpdateRequest(BaseModel):
@@ -176,7 +188,32 @@ async def list_workspaces(
         return []
 
     ws_result = await db.execute(select(Workspace).where(Workspace.id.in_(ws_ids)))
-    return [_ws_to_response(ws) for ws in ws_result.scalars().all()]
+    workspaces = ws_result.scalars().all()
+
+    # Batch member counts keyed by workspace_id
+    mc_result = await db.execute(
+        select(WorkspaceMember.workspace_id, func.count())
+        .where(WorkspaceMember.workspace_id.in_(ws_ids))
+        .group_by(WorkspaceMember.workspace_id)
+    )
+    member_counts = {row[0]: row[1] for row in mc_result.all()}
+
+    # Batch resume counts keyed by workspace_id
+    rc_result = await db.execute(
+        select(WorkspaceResume.workspace_id, func.count())
+        .where(WorkspaceResume.workspace_id.in_(ws_ids))
+        .group_by(WorkspaceResume.workspace_id)
+    )
+    resume_counts = {row[0]: row[1] for row in rc_result.all()}
+
+    return [
+        _ws_to_response(
+            ws,
+            member_count=member_counts.get(ws.id, 0),
+            resume_count=resume_counts.get(ws.id, 0),
+        )
+        for ws in workspaces
+    ]
 
 
 @router.get("/{workspace_id}", response_model=WorkspaceDetailResponse)
@@ -207,9 +244,9 @@ async def get_workspace(
     ]
 
     wr_result = await db.execute(
-        select(WorkspaceResume).where(WorkspaceResume.workspace_id == workspace_id)
+        select(func.count()).where(WorkspaceResume.workspace_id == workspace_id)
     )
-    resume_count = len(wr_result.scalars().all())
+    resume_count = wr_result.scalar_one()
 
     return WorkspaceDetailResponse(
         id=ws.id,
@@ -267,11 +304,16 @@ async def invite_member(
     ws = await _get_workspace_or_404(workspace_id, db)
     await _require_owner(ws, user_id)
 
+    # Lock the workspace row to serialize concurrent invites (prevents TOCTOU on max_members)
+    await db.execute(
+        select(Workspace.id).where(Workspace.id == workspace_id).with_for_update()
+    )
+
     # Enforce max_members limit
     count_result = await db.execute(
-        select(WorkspaceMember).where(WorkspaceMember.workspace_id == workspace_id)
+        select(func.count()).where(WorkspaceMember.workspace_id == workspace_id)
     )
-    if len(count_result.scalars().all()) >= ws.max_members:
+    if count_result.scalar_one() >= ws.max_members:
         raise HTTPException(
             status_code=422,
             detail=f"Workspace has reached the member limit ({ws.max_members})",

--- a/backend/test/test_anonymous_share.py
+++ b/backend/test/test_anonymous_share.py
@@ -146,3 +146,48 @@ class TestAnonymousShareEndpoint:
         assert get_resp.status_code == 200
         # Original LaTeX must be preserved
         assert get_resp.json()["latex_content"] == original_latex
+
+    async def test_editing_content_clears_stale_anonymous_share(
+        self, client, auth_headers: dict
+    ):
+        """Editing latex_content must invalidate the cached anonymous redaction job
+        so create_share_link regenerates a fresh redacted PDF."""
+        create_resp = await client.post(
+            "/resumes/",
+            headers=auth_headers,
+            json={
+                "title": "Stale Anon Resume",
+                "latex_content": r"\documentclass{article}\begin{document}old@example.com\end{document}",
+            },
+        )
+        resume_id = create_resp.json()["id"]
+
+        share_resp = await client.post(
+            f"/resumes/{resume_id}/share",
+            headers=auth_headers,
+            json={"anonymous": True},
+        )
+        assert share_resp.status_code == 200
+
+        before = (
+            await client.get(f"/resumes/{resume_id}", headers=auth_headers)
+        ).json().get("metadata") or {}
+        # Anonymous share stores either a submitted job id or a pending marker.
+        assert (
+            "share_anonymous_job_id" in before or "share_anonymous_pending" in before
+        )
+
+        upd = await client.put(
+            f"/resumes/{resume_id}",
+            headers=auth_headers,
+            json={
+                "latex_content": r"\documentclass{article}\begin{document}new@example.com\end{document}"
+            },
+        )
+        assert upd.status_code == 200
+
+        after = (
+            await client.get(f"/resumes/{resume_id}", headers=auth_headers)
+        ).json().get("metadata") or {}
+        assert "share_anonymous_job_id" not in after
+        assert "share_anonymous_pending" not in after

--- a/backend/test/test_macros.py
+++ b/backend/test/test_macros.py
@@ -78,7 +78,7 @@ class TestCreateMacro:
                 return created
 
             mp.setattr(routes, 'UserMacro', patched_cls)
-            result = await create_macro(body=body, db=mock_db, current_user=user)
+            result = await create_macro(body=body, db=mock_db, user_id=user.id)
 
         assert result.name == 'Bold Wrapper'
         assert result.actions == actions
@@ -99,7 +99,7 @@ class TestCreateMacro:
         with pytest.MonkeyPatch.context() as mp:
             import app.api.macro_routes as routes
             mp.setattr(routes, 'UserMacro', lambda **kwargs: created)
-            result = await create_macro(body=body, db=mock_db, current_user=user)
+            result = await create_macro(body=body, db=mock_db, user_id=user.id)
 
         assert result.shortcut == raw_shortcut
 
@@ -118,7 +118,7 @@ class TestListMacros:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        result = await list_macros(db=mock_db, current_user=user)
+        result = await list_macros(db=mock_db, user_id=user.id)
 
         assert len(result) == 3
         assert all(r.name.startswith('Macro') for r in result)
@@ -132,7 +132,7 @@ class TestListMacros:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        result = await list_macros(db=mock_db, current_user=user)
+        result = await list_macros(db=mock_db, user_id=user.id)
         assert result == []
 
 
@@ -152,7 +152,7 @@ class TestDeleteMacro:
         mock_db.execute = AsyncMock(return_value=mock_result)
 
         with pytest.raises(HTTPException) as exc_info:
-            await delete_macro(macro_id=macro.id, db=mock_db, current_user=attacker)
+            await delete_macro(macro_id=macro.id, db=mock_db, user_id=attacker.id)
         assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
@@ -165,7 +165,7 @@ class TestDeleteMacro:
         mock_db.execute = AsyncMock(return_value=mock_result)
 
         with pytest.raises(HTTPException) as exc_info:
-            await delete_macro(macro_id=str(uuid.uuid4()), db=mock_db, current_user=user)
+            await delete_macro(macro_id=str(uuid.uuid4()), db=mock_db, user_id=user.id)
         assert exc_info.value.status_code == 404
 
 
@@ -190,7 +190,7 @@ class TestUpdateMacro:
             object.__setattr__(obj, key, val) if not isinstance(obj, MagicMock) else None
 
         body = MacroUpdate(name='New Name')
-        result = await update_macro(macro_id=macro.id, body=body, db=mock_db, current_user=user)
+        result = await update_macro(macro_id=macro.id, body=body, db=mock_db, user_id=user.id)
 
         # Verify setattr was called via model_dump
         mock_db.commit.assert_awaited_once()

--- a/backend/test/test_snippets.py
+++ b/backend/test/test_snippets.py
@@ -139,7 +139,7 @@ class TestSnippetCreate:
         mock_db = AsyncMock()
 
         with pytest.raises(HTTPException) as exc_info:
-            await create_snippet(body=body, db=mock_db, current_user=user)
+            await create_snippet(body=body, db=mock_db, user_id=user.id)
         assert exc_info.value.status_code == 422
 
 
@@ -262,7 +262,7 @@ class TestSnippetAuthorization:
             await delete_snippet(
                 snippet_id=snippet.id,
                 db=mock_db,
-                current_user=non_owner,
+                user_id=non_owner.id,
             )
         assert exc_info.value.status_code == 403
 
@@ -281,7 +281,7 @@ class TestSnippetAuthorization:
 
         from app.api.snippet_routes import delete_snippet
 
-        await delete_snippet(snippet_id=snippet.id, db=mock_db, current_user=owner)
+        await delete_snippet(snippet_id=snippet.id, db=mock_db, user_id=owner.id)
         mock_db.delete.assert_called_once_with(snippet)
 
 


### PR DESCRIPTION
Part of the production-readiness bug bash. Closes #794. Closes #795. Closes #796. Closes #797. Refs #768. Refs #769.

Each commit is a single file carrying its issue reference. See the linked issues for root-cause and fix detail. Verified: backend suite 2233 green, frontend build green, live smoke of critical flows.