### PR TITLE
Runtime enforcement / bypass hardening (12 files)

### DIFF
--- a/backend/app/api/ai_routes.py
+++ b/backend/app/api/ai_routes.py
@@ -383,25 +383,17 @@ async def proofread_resume(request: ProofreadRequest) -> ProofreadResponse:
 @router.post("/explain-error", response_model=ExplainErrorResponse)
 async def explain_latex_error(
     request: ExplainErrorRequest,
+    http_request: Request,
     db: AsyncSession = Depends(get_db),
     user_id: Optional[str] = Depends(get_current_user_optional),
 ):
     """Explain a LaTeX compilation error using pattern matching or LLM."""
     try:
-        # Resolve API key: BYOK first, then system default
-        api_key: str | None = None
-        if user_id:
-            try:
-                from ..services.api_key_service import api_key_service
-
-                api_key = await api_key_service.get_user_provider(
-                    db, user_id, "openai"
-                )
-            except Exception:
-                pass
-
-        if not api_key and settings.OPENAI_API_KEY:
-            api_key = settings.OPENAI_API_KEY
+        # Resolve API key via the shared helper: BYOK first, then a platform-key
+        # fallback that is rate limited per identity — same metering as every other
+        # AI endpoint, so this path can't be used to drain the platform key.
+        client_ip = http_request.client.host if http_request.client else "unknown"
+        api_key = await _resolve_ai_api_key(db, user_id, client_ip)
 
         result = await error_explainer_service.explain(
             error_message=request.error_message,

--- a/backend/app/api/ats_routes.py
+++ b/backend/app/api/ats_routes.py
@@ -169,6 +169,14 @@ async def score_resume_ats(
 ):
     """Score a resume for ATS compatibility."""
     try:
+        # Per-IP rate limit (mirrors the sibling rule-based ATS endpoints) so an
+        # anonymous caller cannot flood the ats Celery queue / CPU-bound scoring.
+        if not await _rate_limit_ok(
+            f"ratelimit:ats-rule:score:{_client_ip(http_request)}",
+            _RULE_ENDPOINT_IP_LIMIT, _RULE_ENDPOINT_IP_WINDOW,
+        ):
+            raise HTTPException(status_code=429, detail="Too many requests. Please slow down.")
+
         # Extract user information
         ip_address = http_request.client.host if http_request.client else None
 
@@ -269,6 +277,13 @@ async def analyze_job_description_ats(
 ):
     """Analyze job description for ATS optimization insights."""
     try:
+        # Per-IP rate limit (mirrors the sibling rule-based ATS endpoints).
+        if not await _rate_limit_ok(
+            f"ratelimit:ats-rule:analyze-jd:{_client_ip(http_request)}",
+            _RULE_ENDPOINT_IP_LIMIT, _RULE_ENDPOINT_IP_WINDOW,
+        ):
+            raise HTTPException(status_code=429, detail="Too many requests. Please slow down.")
+
         # Extract user information
         ip_address = http_request.client.host if http_request.client else None
 

--- a/backend/app/api/developer_routes.py
+++ b/backend/app/api/developer_routes.py
@@ -106,6 +106,11 @@ async def create_developer_key(
     user_id: str = Depends(get_current_user_required),
     db: AsyncSession = Depends(get_db),
 ):
+    # NOTE: developer API access is intentionally available on all plans (free
+    # included) with per-plan daily limits (get_developer_api_daily_limit). The
+    # plan config's apiAccess flag is a UI hint, not a hard backend gate; making
+    # it a gate here would break the tested free-tier developer API. Restricting
+    # the API to paid plans is a product decision, not a bug fix.
     count_result = await db.execute(
         select(func.count())
         .select_from(DeveloperAPIKey)

--- a/backend/app/api/job_routes.py
+++ b/backend/app/api/job_routes.py
@@ -33,6 +33,7 @@ from ..middleware.auth_middleware import (
     require_admin,
 )
 from ..services.optimization_personas import VALID_PERSONA_KEYS
+from ..services.trial_service import trial_service
 from ..utils.file_utils import validate_job_id
 from ..workers.ats_worker import submit_ats_scoring
 from ..workers.cleanup_worker import submit_expired_jobs_cleanup, submit_temp_files_cleanup
@@ -41,6 +42,23 @@ from ..workers.llm_worker import submit_resume_optimization
 from ..workers.orchestrator import submit_optimize_and_compile
 
 logger = get_logger(__name__)
+
+# Anonymous, resource-consuming job types that count against the device trial.
+_TRIAL_JOB_TYPES = {"latex_compilation", "combined", "llm_optimization"}
+
+
+async def _resolve_user_plan(db: AsyncSession, user_id: Optional[str]) -> str:
+    """Server-derived subscription plan. NEVER trust a client-supplied plan — it
+    governs paid queue priority and compile timeout. Anonymous callers are 'free';
+    authenticated callers get their real users.subscription_plan."""
+    if not user_id:
+        return "free"
+    from sqlalchemy import select as sa_select
+    try:
+        row = await db.execute(sa_select(User.subscription_plan).where(User.id == user_id))
+        return row.scalar_one_or_none() or "free"
+    except Exception:
+        return "free"
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
 
@@ -232,6 +250,43 @@ async def submit_job(
         ip_address = http_request.client.host if http_request.client else None
         job_id = str(uuid.uuid4())
 
+        # Plan is server-derived (never trust request.user_plan — it governs paid
+        # queue priority + compile timeout). Client-chosen model is only honoured
+        # for paid/BYOK plans, else the default model runs on the platform key.
+        resolved_plan = await _resolve_user_plan(db, user_id)
+        safe_model = request.model if resolve_plan_family(resolved_plan) in {"pro", "byok", "team"} else None
+
+        # Server-side trial enforcement for ANONYMOUS resource-consuming jobs.
+        # This is the single source of truth: authenticated users are governed by
+        # their plan, but anonymous callers must pass the device trial here so the
+        # 3-use limit cannot be bypassed by calling /jobs/submit directly (skipping
+        # the frontend's separate track-usage call).
+        if user_id is None and request.job_type in _TRIAL_JOB_TYPES:
+            if not request.device_fingerprint:
+                raise HTTPException(
+                    status_code=400,
+                    detail="device_fingerprint is required for anonymous jobs.",
+                )
+            usage = await trial_service.check_and_track_usage(
+                db=db,
+                device_fingerprint=request.device_fingerprint,
+                action="optimize" if request.job_type in {"combined", "llm_optimization"} else "compile",
+                ip_address=ip_address,
+                user_agent=http_request.headers.get("user-agent"),
+                resource_type="resume",
+            )
+            if not usage.get("success"):
+                _trial_errors = {
+                    "trial_limit_exceeded": "Free trial limit reached. Please sign up to continue.",
+                    "cooldown": f"Please wait {int(usage.get('waitTime') or 0)} seconds before trying again.",
+                    "blocked": "Device blocked due to abuse. Please contact support.",
+                    "daily_limit_exceeded": "Daily request limit exceeded. Please try again tomorrow.",
+                }
+                raise HTTPException(
+                    status_code=429,
+                    detail=_trial_errors.get(usage.get("error", ""), "Trial limit reached."),
+                )
+
         estimated_times = {
             "latex_compilation": 30,
             "llm_optimization": 60,
@@ -241,7 +296,7 @@ async def submit_job(
             "cover_letter_generation": 60,
         }
         estimated_time = estimated_times.get(request.job_type, 60)
-        if resolve_plan_family(request.user_plan) in {"pro", "byok", "team"}:
+        if resolve_plan_family(resolved_plan) in {"pro", "byok", "team"}:
             estimated_time = int(estimated_time * 0.7)
 
         # Sanitise caller-supplied metadata: cap at 10 keys, 256 chars per value.
@@ -303,7 +358,7 @@ async def submit_job(
                 latex_content=request.latex_content,
                 job_id=job_id,
                 user_id=user_id,
-                user_plan=request.user_plan,
+                user_plan=resolved_plan,
                 device_fingerprint=request.device_fingerprint,
                 metadata=extra_meta,
                 compiler=compiler,
@@ -322,9 +377,9 @@ async def submit_job(
                 job_description=request.job_description,
                 job_id=job_id,
                 user_id=user_id,
-                user_plan=request.user_plan,
+                user_plan=resolved_plan,
                 optimization_level=request.optimization_level,
-                model=request.model,
+                model=safe_model,
                 metadata=extra_meta,
             )
 
@@ -345,12 +400,12 @@ async def submit_job(
                 job_description=request.job_description,
                 job_id=job_id,
                 user_id=user_id,
-                user_plan=request.user_plan,
+                user_plan=resolved_plan,
                 optimization_level=request.optimization_level,
                 device_fingerprint=request.device_fingerprint,
                 target_sections=request.target_sections,
                 custom_instructions=request.custom_instructions,
-                model=request.model,
+                model=safe_model,
                 metadata=extra_meta,
                 compiler=compiler,
                 persona=request.persona,
@@ -369,7 +424,7 @@ async def submit_job(
                 job_description=request.job_description,
                 industry=request.industry,
                 user_id=user_id,
-                user_plan=request.user_plan,
+                user_plan=resolved_plan,
                 device_fingerprint=request.device_fingerprint,
                 metadata=extra_meta,
             )
@@ -419,6 +474,7 @@ async def submit_job(
 async def compile_watermarked(
     request: WatermarkCompileRequest,
     http_request: Request,
+    db: AsyncSession = Depends(get_db),
     user_id: Optional[str] = Depends(get_current_user_optional),
 ):
     """
@@ -455,7 +511,8 @@ async def compile_watermarked(
     try:
         job_id = str(uuid.uuid4())
         ip_address = http_request.client.host if http_request.client else None
-        estimated_time = 30 if resolve_plan_family(request.user_plan) in {"pro", "byok", "team"} else 45
+        resolved_plan = await _resolve_user_plan(db, user_id)
+        estimated_time = 30 if resolve_plan_family(resolved_plan) in {"pro", "byok", "team"} else 45
 
         await _write_initial_redis_state(job_id, "latex_compilation", user_id, estimated_time)
 
@@ -463,7 +520,7 @@ async def compile_watermarked(
             latex_content=request.latex_content,
             job_id=job_id,
             user_id=user_id,
-            user_plan=request.user_plan,
+            user_plan=resolved_plan,
             device_fingerprint=request.device_fingerprint,
             metadata={"ip_address": ip_address, "submitted_via": "watermark"},
             compiler=compiler,
@@ -687,13 +744,16 @@ async def get_job_result(
     try:
         r = await get_redis_client()
 
-        # Ownership check via meta (meta may have expired before result TTL)
+        # Ownership check via meta. Meta and result share the same TTL, so a
+        # missing meta means the job is gone — deny rather than serve the result
+        # without an ownership check (closes a TTL-window IDOR).
         meta_raw = await r.get(f"latexy:job:{job_id}:meta")
-        if meta_raw:
-            meta = json.loads(meta_raw)
-            job_owner = meta.get("user_id")
-            if job_owner is not None and job_owner != user_id:
-                raise HTTPException(status_code=403, detail="Access denied")
+        if not meta_raw:
+            raise HTTPException(status_code=404, detail="Job not found")
+        meta = json.loads(meta_raw)
+        job_owner = meta.get("user_id")
+        if job_owner is not None and job_owner != user_id:
+            raise HTTPException(status_code=403, detail="Access denied")
 
         raw = await r.get(f"latexy:job:{job_id}:result")
         if not raw:
@@ -907,6 +967,12 @@ async def list_jobs(
             if raw:
                 state = json.loads(raw)
                 state["job_id"] = jid
+                # Merge job_type/submitted_at from meta so the list UI isn't blank.
+                meta_raw = await r.get(f"latexy:job:{jid}:meta")
+                if meta_raw:
+                    meta = json.loads(meta_raw)
+                    state["job_type"] = meta.get("job_type")
+                    state["created_at"] = meta.get("submitted_at")
                 jobs.append(state)
 
         return JobListResponse(jobs=jobs, total_count=len(jobs))

--- a/backend/app/middleware/rate_limiting.py
+++ b/backend/app/middleware/rate_limiting.py
@@ -22,6 +22,35 @@ _FAIL_OPEN_WARN_INTERVAL = 60.0
 _last_fail_open_warn = 0.0
 
 
+def _spoof_resistant_client_id(request: Request) -> str:
+    """Shared, spoofing-resistant client identifier used by all rate limiters.
+
+    Keys on the caller's own credential (session token / bearer) when present —
+    unforgeable, unlike a plain X-User-ID header. Falls back to the peer IP;
+    X-Forwarded-For is only honoured behind a trusted proxy (TRUST_PROXY_HEADERS).
+    """
+    token: Optional[str] = None
+    auth = request.headers.get("Authorization")
+    if auth and auth.lower().startswith("bearer "):
+        token = auth[7:].strip()
+    if not token:
+        cookie_tok = (
+            request.cookies.get("better-auth.session_token")
+            or request.cookies.get("__Secure-better-auth.session_token")
+        )
+        if cookie_tok:
+            token = cookie_tok.split(".", 1)[0]
+    if token:
+        return "user:" + hashlib.sha256(token.encode()).hexdigest()[:32]
+
+    client_ip = request.client.host if request.client else "unknown"
+    if getattr(settings, "TRUST_PROXY_HEADERS", False):
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            client_ip = forwarded_for.split(",")[0].strip()
+    return f"ip:{client_ip}"
+
+
 def _warn_fail_open(context: str) -> None:
     """Log a rate-limited WARNING that rate limiting is failing OPEN.
 
@@ -71,37 +100,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return response
 
     def get_client_id(self, request: Request) -> str:
-        """Get a spoofing-resistant client identifier for rate limiting.
-
-        Keys on the caller's OWN credential (session token / bearer) when present —
-        an attacker cannot forge another user's token, unlike a plain X-User-ID
-        header (which was previously trusted and let anyone evade limits). Falls back
-        to the peer IP; X-Forwarded-For is only honoured when TRUST_PROXY_HEADERS is
-        set (i.e. we are deployed behind a trusted reverse proxy), otherwise it is
-        attacker-controlled and spoofable.
-        """
-        token: Optional[str] = None
-        auth = request.headers.get("Authorization")
-        if auth and auth.lower().startswith("bearer "):
-            token = auth[7:].strip()
-        if not token:
-            cookie_tok = (
-                request.cookies.get("better-auth.session_token")
-                or request.cookies.get("__Secure-better-auth.session_token")
-            )
-            if cookie_tok:
-                token = cookie_tok.split(".", 1)[0]
-        if token:
-            return "user:" + hashlib.sha256(token.encode()).hexdigest()[:32]
-
-        # Fall back to IP address.
-        client_ip = request.client.host if request.client else "unknown"
-        if getattr(settings, "TRUST_PROXY_HEADERS", False):
-            forwarded_for = request.headers.get("X-Forwarded-For")
-            if forwarded_for:
-                client_ip = forwarded_for.split(",")[0].strip()
-
-        return f"ip:{client_ip}"
+        """Get a spoofing-resistant client identifier for rate limiting."""
+        return _spoof_resistant_client_id(request)
 
     # Lua script: atomic INCR + EXPIRE for new keys (prevents GET-then-INCR race)
     _LUA_INCR_EXPIRE = """
@@ -205,17 +205,8 @@ class APIKeyRateLimitMiddleware(BaseHTTPMiddleware):
         return None
 
     def get_client_id(self, request: Request) -> str:
-        """Get client identifier for rate limiting."""
-        user_id = request.headers.get("X-User-ID")
-        if user_id:
-            return f"user:{user_id}"
-
-        client_ip = request.client.host if request.client else "unknown"
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        if forwarded_for:
-            client_ip = forwarded_for.split(",")[0].strip()
-
-        return f"ip:{client_ip}"
+        """Get a spoofing-resistant client identifier (shared with the main limiter)."""
+        return _spoof_resistant_client_id(request)
 
     async def check_operation_limit(self, client_id: str, operation: str):
         """Check operation-specific rate limits."""

--- a/backend/app/services/trial_service.py
+++ b/backend/app/services/trial_service.py
@@ -121,8 +121,8 @@ class TrialService:
             trial = result.scalar_one_or_none()
 
             if trial:
-                # Check cooldown period
-                if trial.last_used:
+                # Check cooldown period (never on the first use — see check_and_track_usage)
+                if trial.usage_count > 0 and trial.last_used:
                     time_since_last = (now - trial.last_used).total_seconds()
                     if time_since_last < COOLDOWN_PERIOD:
                         return {
@@ -233,8 +233,11 @@ class TrialService:
                     # savepoint before we check the count below.
                     await db.flush()
 
-                # Check cooldown
-                if trial.last_used:
+                # Check cooldown — but never on the first use. A freshly-created
+                # row has last_used defaulted to now (server_default), so applying
+                # cooldown when usage_count == 0 would wrongly block a device's
+                # very first trial.
+                if trial.usage_count > 0 and trial.last_used:
                     time_since_last = (now - trial.last_used).total_seconds()
                     if time_since_last < COOLDOWN_PERIOD:
                         return {
@@ -259,6 +262,14 @@ class TrialService:
                         "error": "trial_limit_exceeded",
                         "waitTime": None,
                     }
+
+                # NOTE: device-fingerprint rotation (a fresh fingerprint grants a
+                # new 3-use trial) is an inherent limitation of anonymous trials.
+                # A hard per-IP daily cap was considered but rejected: it blocks
+                # legitimate shared-IP users (offices / CGNAT / mobile) far more
+                # than it stops bounded abuse. Real enforcement is signup. Defense
+                # in depth remains: per-device 3-use limit, 5-min cooldown, and the
+                # per-IP request rate limit on the submit endpoints.
 
                 # Safe to increment
                 trial.usage_count += 1

--- a/backend/test/test_auth.py
+++ b/backend/test/test_auth.py
@@ -36,7 +36,7 @@ class TestAuthProtection:
             json={
                 "job_type": "latex_compilation",
                 "latex_content": r"\documentclass{article}\begin{document}Hi\end{document}",
-                "device_fingerprint": "test_fp_anonymous",
+                "device_fingerprint": uuid.uuid4().hex,
             },
         )
         # 200 = queued, 400 = trial exhausted, 422 = validation error

--- a/backend/test/test_integration.py
+++ b/backend/test/test_integration.py
@@ -52,7 +52,7 @@ async def _submit_latex_job(client: AsyncClient) -> dict | None:
     with patch("app.workers.latex_worker.submit_latex_compilation", return_value=None):
         resp = await client.post(
             "/jobs/submit",
-            json={"job_type": "latex_compilation", "latex_content": _VALID_LATEX},
+            json={"job_type": "latex_compilation", "latex_content": _VALID_LATEX, "device_fingerprint": uuid.uuid4().hex},
         )
     if resp.status_code not in (200, 202):
         return None
@@ -424,6 +424,7 @@ class TestJobTypeRouting:
                     "job_type": "combined",
                     "latex_content": _VALID_LATEX,
                     "job_description": _JOB_DESCRIPTION,
+                    "device_fingerprint": uuid.uuid4().hex,
                 },
             )
         assert resp.status_code in (200, 202)
@@ -453,6 +454,7 @@ class TestJobTypeRouting:
                     "job_type": "combined",
                     "latex_content": _VALID_LATEX,
                     "job_description": _JOB_DESCRIPTION,
+                    "device_fingerprint": uuid.uuid4().hex,
                 },
             )
         if resp.status_code not in (200, 202):
@@ -495,6 +497,7 @@ class TestJobResultWhenAvailable:
             "tokens_used": 320,
         })
         await r.setex(f"latexy:job:{job_id}:result", 3600, result_payload)
+        await r.setex(f"latexy:job:{job_id}:meta", 3600, json.dumps({"job_id": job_id, "user_id": None}))
 
         resp = await client.get(f"/jobs/{job_id}/result")
         assert resp.status_code == 200
@@ -504,6 +507,7 @@ class TestJobResultWhenAvailable:
         r = await get_redis_client()
         result_payload = json.dumps({"success": True, "job_id": job_id})
         await r.setex(f"latexy:job:{job_id}:result", 3600, result_payload)
+        await r.setex(f"latexy:job:{job_id}:meta", 3600, json.dumps({"job_id": job_id, "user_id": None}))
 
         resp = await client.get(f"/jobs/{job_id}/result")
         assert resp.json()["success"] is True
@@ -513,6 +517,7 @@ class TestJobResultWhenAvailable:
         r = await get_redis_client()
         result_payload = json.dumps({"success": True, "job_id": job_id})
         await r.setex(f"latexy:job:{job_id}:result", 3600, result_payload)
+        await r.setex(f"latexy:job:{job_id}:meta", 3600, json.dumps({"job_id": job_id, "user_id": None}))
 
         resp = await client.get(f"/jobs/{job_id}/result")
         assert resp.json()["job_id"] == job_id
@@ -527,6 +532,7 @@ class TestJobResultWhenAvailable:
             "error": "pdflatex exited with code 1",
         })
         await r.setex(f"latexy:job:{job_id}:result", 3600, result_payload)
+        await r.setex(f"latexy:job:{job_id}:meta", 3600, json.dumps({"job_id": job_id, "user_id": None}))
 
         resp = await client.get(f"/jobs/{job_id}/result")
         assert resp.status_code == 200
@@ -611,3 +617,36 @@ class TestRedisKeyTTLs:
         r = await get_redis_client()
         ttl = await r.ttl(f"latexy:stream:{job_id}")
         assert ttl > 0
+
+
+# ---------------------------------------------------------------------------
+# Anonymous trial enforcement on /jobs/submit (bypass regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAnonymousTrialEnforcement:
+    """Anonymous trial-eligible jobs must carry a device_fingerprint so the 3-use
+    trial cannot be bypassed by calling /jobs/submit directly."""
+
+    async def test_anon_compile_without_fingerprint_rejected(self, client: AsyncClient):
+        with patch("app.workers.latex_worker.submit_latex_compilation", return_value=None):
+            resp = await client.post(
+                "/jobs/submit",
+                json={"job_type": "latex_compilation", "latex_content": _VALID_LATEX},
+            )
+        assert resp.status_code == 400, resp.text
+        assert "device_fingerprint" in resp.text
+
+    async def test_anon_compile_with_fresh_fingerprint_accepted(self, client: AsyncClient):
+        with patch("app.workers.latex_worker.submit_latex_compilation", return_value=None):
+            resp = await client.post(
+                "/jobs/submit",
+                json={
+                    "job_type": "latex_compilation",
+                    "latex_content": _VALID_LATEX,
+                    "device_fingerprint": uuid.uuid4().hex,
+                },
+            )
+        assert resp.status_code in (200, 202), resp.text
+        assert resp.json().get("job_id")

--- a/backend/test/test_jobs.py
+++ b/backend/test/test_jobs.py
@@ -375,7 +375,9 @@ class TestEstimatedTime:
             )
         if free_resp.status_code not in (200, 202) or pro_resp.status_code not in (200, 202):
             pytest.skip("Submit failed")
-        assert pro_resp.json()["estimated_time"] < free_resp.json()["estimated_time"]
+        # Client-supplied user_plan is now IGNORED (server derives plan from the
+        # authenticated user), so a "pro" body value no longer buys a lower time.
+        assert pro_resp.json()["estimated_time"] == free_resp.json()["estimated_time"]
 
     async def test_ats_scoring_has_expected_estimated_time(
         self, client: AsyncClient, auth_headers: dict

--- a/backend/test/test_optimization_personas.py
+++ b/backend/test/test_optimization_personas.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -73,6 +74,7 @@ class TestPersonaJobSubmission:
                 json={
                     "job_type": "combined",
                     "latex_content": r"\documentclass{article}\begin{document}Hello\end{document}",
+                    "device_fingerprint": uuid.uuid4().hex,
                     "persona": "startup",
                 },
             )
@@ -90,6 +92,7 @@ class TestPersonaJobSubmission:
                 json={
                     "job_type": "combined",
                     "latex_content": r"\documentclass{article}\begin{document}Hello\end{document}",
+                    "device_fingerprint": uuid.uuid4().hex,
                     "persona": "not_a_real_persona",
                 },
             )
@@ -103,6 +106,7 @@ class TestPersonaJobSubmission:
                 json={
                     "job_type": "combined",
                     "latex_content": r"\documentclass{article}\begin{document}Hello\end{document}",
+                    "device_fingerprint": uuid.uuid4().hex,
                 },
             )
 

--- a/frontend/src/app/try/page.tsx
+++ b/frontend/src/app/try/page.tsx
@@ -138,7 +138,7 @@ export default function TryPage() {
     if (!resolvedSession && !effectiveCanRun) { toast.error('Trial limit reached. Upgrade to continue.'); return }
     setIsSubmitting(true)
     try {
-      if (!resolvedSession) await apiClient.trackUsage(trialStatus.fingerprint, mode)
+      // Trial usage is now enforced+counted server-side in /jobs/submit for anonymous users.
       const response =
         mode === 'compile'
           ? await apiClient.compileLatex({ latex_content: currentContent, device_fingerprint: trialStatus.fingerprint })
@@ -184,7 +184,7 @@ export default function TryPage() {
     if (!resolvedSession && !effectiveCanRun) return
     setIsSubmitting(true)
     try {
-      if (!resolvedSession) await apiClient.trackUsage(trialStatus.fingerprint, 'compile')
+      // Trial usage is now enforced+counted server-side in /jobs/submit for anonymous users.
       const response = await apiClient.compileLatex({ latex_content: content, device_fingerprint: trialStatus.fingerprint })
       if (!response.success || !response.job_id) throw new Error(response.message || 'Failed')
       setActiveJobId(response.job_id)
@@ -255,7 +255,7 @@ export default function TryPage() {
     if (!resolvedSession && !effectiveCanRun) { toast.error('Trial limit reached. Upgrade to continue.'); return }
     setIsSubmitting(true)
     try {
-      if (!resolvedSession) await apiClient.trackUsage(trialStatus.fingerprint, 'combined')
+      // Trial usage is now enforced+counted server-side in /jobs/submit for anonymous users.
       const response = await apiClient.optimizeAndCompile({
         latex_content: currentContent,
         job_description: jobDescription,

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -975,7 +975,20 @@ class ApiClient {
   }
 
   async getJobResult(jobId: string): Promise<JobResultResponse> {
-    return this.request<JobResultResponse>(`/jobs/${encodeURIComponent(jobId)}/result`)
+    // Backend shape is { success, job_id, result: {...}, error }. Unwrap `result`
+    // into the flat JobResultResponse the rest of the app expects.
+    const raw = await this.request<{
+      success: boolean
+      job_id: string
+      result?: Record<string, unknown>
+      error?: string
+    }>(`/jobs/${encodeURIComponent(jobId)}/result`)
+    return {
+      success: raw.success,
+      job_id: raw.job_id,
+      error: raw.error,
+      ...(raw.result || {}),
+    } as JobResultResponse
   }
 
   async listJobs(): Promise<{ jobs: JobStateResponse[] }> {


### PR DESCRIPTION
Runtime enforcement / bypass hardening — a targeted hunt for the bug class a static review misses (client-only enforcement, split enforcement, boundary/first-use, plan-gate bypass, contract mismatch). One file per commit.

Closes #826 #827 #828 #829 #830 #831 #832 #833. Refs #825.

## Fixes
- Trial: /jobs/submit now enforces the device trial server-side for anonymous compile/optimize (no-fingerprint→400, fresh→200, repeat→429); first-use cooldown fixed; frontend double-count removed.
- Plan-gate: /jobs/submit + /compile-watermarked now derive user_plan server-side (client value ignored); client model only honoured for paid/BYOK.
- /ai/explain-error routed through the metered key resolver (financial-DoS closed).
- /ats/score + /analyze-job-description now per-IP rate limited.
- BYOK op limiter shares the hardened spoof-resistant client id.
- get_job_result denies on missing meta (TTL-window IDOR); /jobs/ list returns job_type.
- Frontend getJobResult unwraps the nested result.
- Documented that free developer-API access is intentional.

## Verification
Backend: 2235 tests pass, ruff clean. Frontend: typecheck clean. Trial enforcement verified live (400/200/429).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Anonymous job submissions now require a device fingerprint and are tracked more consistently to support trial usage limits.
  - Job result lookups now return a more complete result payload.

- **Bug Fixes**
  - Fixed cooldown behavior so first-time trial users aren’t blocked unexpectedly.
  - Improved job access checks to avoid exposing results without the right ownership context.
  - Anonymous ATS and AI requests now have tighter rate limits to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->