### PR TITLE
feat(observability): metrics module and tracing helpers

### DIFF
--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar, Token
 from time import perf_counter
 from typing import Any
 
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
 
 _request_id: ContextVar[str | None] = ContextVar("request_id", default=None)
 _route_path: ContextVar[str | None] = ContextVar("route_path", default=None)
@@ -49,6 +49,96 @@ FRONTEND_WEB_VITAL_VALUE = Histogram(
     "Distribution of frontend web vital values by metric and route.",
     ["name", "route"],
     buckets=(1, 10, 50, 100, 250, 500, 1000, 2500, 5000, 10000),
+)
+
+# ── LLM / AI metrics ─────────────────────────────────────────────────────────
+# Labelled by provider TYPE and model only (never per-key/per-user) to avoid
+# cardinality blow-up and PII leakage.
+LLM_REQUESTS_TOTAL = Counter(
+    "latexy_llm_requests_total",
+    "Total LLM calls by provider, model and outcome.",
+    ["provider", "model", "status"],
+)
+LLM_LATENCY_SECONDS = Histogram(
+    "latexy_llm_latency_seconds",
+    "LLM operation latency by provider, model and phase (prompt_build|provider_call|total).",
+    ["provider", "model", "phase"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 40, 60, 120),
+)
+LLM_TOKENS_TOTAL = Counter(
+    "latexy_llm_tokens_total",
+    "Total tokens consumed by LLM calls.",
+    ["provider", "model", "kind"],  # kind: prompt|completion|total
+)
+LLM_COST_USD_TOTAL = Counter(
+    "latexy_llm_cost_usd_total",
+    "Estimated LLM spend in USD.",
+    ["provider", "model"],
+)
+
+# ── LaTeX compile metrics ────────────────────────────────────────────────────
+COMPILES_TOTAL = Counter(
+    "latexy_compiles_total",
+    "Total LaTeX compilations by outcome.",
+    ["status"],
+)
+COMPILE_DURATION_SECONDS = Histogram(
+    "latexy_compile_duration_seconds",
+    "LaTeX compilation duration.",
+    ["status"],
+    buckets=(0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120),
+)
+COMPILE_PDF_BYTES = Histogram(
+    "latexy_compile_pdf_bytes",
+    "Size of produced PDFs in bytes.",
+    buckets=(1_000, 10_000, 50_000, 100_000, 250_000, 500_000, 1_000_000, 5_000_000),
+)
+COMPILE_PAGES = Histogram(
+    "latexy_compile_pages",
+    "Page count of produced PDFs.",
+    buckets=(1, 2, 3, 4, 5, 8, 12, 20),
+)
+
+# ── ATS scoring metrics ──────────────────────────────────────────────────────
+ATS_SCORES_TOTAL = Counter(
+    "latexy_ats_scores_total",
+    "Total ATS scoring runs by scorer and outcome.",
+    ["scorer", "status"],
+)
+ATS_SCORE_DURATION_SECONDS = Histogram(
+    "latexy_ats_score_duration_seconds",
+    "ATS scoring duration by scorer.",
+    ["scorer"],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10),
+)
+
+# ── Business metrics ─────────────────────────────────────────────────────────
+JOBS_SUBMITTED_TOTAL = Counter(
+    "latexy_jobs_submitted_total",
+    "Jobs submitted to the async queue by type and authentication state.",
+    ["job_type", "auth"],  # auth: user|anonymous
+)
+TRIAL_USES_TOTAL = Counter(
+    "latexy_trial_uses_total",
+    "Anonymous trial uses recorded by outcome.",
+    ["outcome"],  # allowed|limit_exceeded|cooldown|blocked
+)
+BUSINESS_EVENTS_TOTAL = Counter(
+    "latexy_business_events_total",
+    "Business lifecycle events (signups, subscription changes, etc.).",
+    ["event", "detail"],
+)
+
+# ── Infrastructure gauges ────────────────────────────────────────────────────
+CELERY_QUEUE_DEPTH = Gauge(
+    "latexy_celery_queue_depth",
+    "Number of pending messages in each Celery queue.",
+    ["queue"],
+)
+DB_POOL_CONNECTIONS = Gauge(
+    "latexy_db_pool_connections",
+    "SQLAlchemy async engine connection-pool state.",
+    ["state"],  # size|checked_out|overflow
 )
 
 
@@ -145,6 +235,107 @@ def record_frontend_event(kind: str, name: str, route: str, value: float | None 
     FRONTEND_TELEMETRY_EVENTS_TOTAL.labels(kind=kind, name=name, route=normalized_route).inc()
     if kind == "web_vital" and value is not None:
         FRONTEND_WEB_VITAL_VALUE.labels(name=name, route=normalized_route).observe(value)
+
+
+def _as_number(value: Any) -> float | None:
+    """Coerce a value to float, or None if it is not a real finite number.
+
+    Guards the metric layer against non-numeric inputs (e.g. mock usage objects,
+    a provider returning an unexpected usage payload) so instrumentation can
+    never raise into a request/task path.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float)):
+        return None
+    numeric = float(value)
+    if numeric != numeric or numeric in (float("inf"), float("-inf")):  # NaN/inf
+        return None
+    return numeric
+
+
+def record_llm_call(
+    provider: str,
+    model: str,
+    status: str,
+    *,
+    total_seconds: float | None = None,
+    prompt_build_seconds: float | None = None,
+    provider_call_seconds: float | None = None,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    total_tokens: int | None = None,
+    cost_usd: float | None = None,
+) -> None:
+    """Record a single LLM call: outcome, phase latencies, tokens and cost."""
+    provider = provider or "unknown"
+    model = model or "unknown"
+    LLM_REQUESTS_TOTAL.labels(provider=provider, model=model, status=status).inc()
+    for phase, seconds in (
+        ("total", _as_number(total_seconds)),
+        ("prompt_build", _as_number(prompt_build_seconds)),
+        ("provider_call", _as_number(provider_call_seconds)),
+    ):
+        if seconds is not None:
+            LLM_LATENCY_SECONDS.labels(provider=provider, model=model, phase=phase).observe(max(0.0, seconds))
+    for kind, tokens in (
+        ("prompt", _as_number(prompt_tokens)),
+        ("completion", _as_number(completion_tokens)),
+        ("total", _as_number(total_tokens)),
+    ):
+        if tokens and tokens > 0:
+            LLM_TOKENS_TOTAL.labels(provider=provider, model=model, kind=kind).inc(tokens)
+    cost = _as_number(cost_usd)
+    if cost and cost > 0:
+        LLM_COST_USD_TOTAL.labels(provider=provider, model=model).inc(cost)
+
+
+def record_compile(status: str, duration_seconds: float | None = None, pdf_bytes: int | None = None, pages: int | None = None) -> None:
+    """Record a LaTeX compilation outcome and artifact metrics."""
+    COMPILES_TOTAL.labels(status=status).inc()
+    duration = _as_number(duration_seconds)
+    if duration is not None:
+        COMPILE_DURATION_SECONDS.labels(status=status).observe(max(0.0, duration))
+    size = _as_number(pdf_bytes)
+    if size and size > 0:
+        COMPILE_PDF_BYTES.observe(size)
+    page_count = _as_number(pages)
+    if page_count and page_count > 0:
+        COMPILE_PAGES.observe(page_count)
+
+
+def record_ats_score(scorer: str, status: str, duration_seconds: float | None = None) -> None:
+    """Record an ATS scoring run."""
+    ATS_SCORES_TOTAL.labels(scorer=scorer, status=status).inc()
+    if duration_seconds is not None:
+        ATS_SCORE_DURATION_SECONDS.labels(scorer=scorer).observe(max(0.0, duration_seconds))
+
+
+def record_job_submitted(job_type: str, authenticated: bool) -> None:
+    """Record a job submission for product KPIs."""
+    JOBS_SUBMITTED_TOTAL.labels(job_type=job_type or "unknown", auth="user" if authenticated else "anonymous").inc()
+
+
+def record_trial_use(outcome: str) -> None:
+    """Record an anonymous trial-use outcome."""
+    TRIAL_USES_TOTAL.labels(outcome=outcome or "unknown").inc()
+
+
+def record_business_event(event: str, detail: str = "") -> None:
+    """Record a business lifecycle event (signup, subscription change, ...)."""
+    BUSINESS_EVENTS_TOTAL.labels(event=event, detail=detail or "none").inc()
+
+
+def set_queue_depth(queue: str, depth: int) -> None:
+    """Set the current pending-message depth for a Celery queue."""
+    CELERY_QUEUE_DEPTH.labels(queue=queue).set(depth)
+
+
+def set_db_pool_stats(size: int, checked_out: int, overflow: int) -> None:
+    """Publish SQLAlchemy connection-pool saturation."""
+    DB_POOL_CONNECTIONS.labels(state="size").set(size)
+    DB_POOL_CONNECTIONS.labels(state="checked_out").set(checked_out)
+    DB_POOL_CONNECTIONS.labels(state="overflow").set(overflow)
 
 
 def request_timer() -> float:

--- a/backend/app/core/tracing.py
+++ b/backend/app/core/tracing.py
@@ -10,7 +10,8 @@ no-op and current_trace_context() returns an empty dict.
 from __future__ import annotations
 
 import logging
-from typing import Dict
+from contextlib import contextmanager
+from typing import Any, Dict
 
 try:
     from opentelemetry import trace
@@ -36,6 +37,7 @@ _provider_initialized = False
 _fastapi_instrumented = False
 _celery_instrumented = False
 _redis_instrumented = False
+_httpx_instrumented = False
 _sqlalchemy_instrumented_engines: set[int] = set()
 
 
@@ -96,6 +98,18 @@ def setup_telemetry(component: str) -> None:
         RedisInstrumentor().instrument()
         _redis_instrumented = True
 
+    # Outbound HTTP (LLM providers, scraper, embeddings) — optional package, so
+    # guard independently: a missing instrumentor must not disable all tracing.
+    global _httpx_instrumented
+    if not _httpx_instrumented:
+        try:
+            from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+            HTTPXClientInstrumentor().instrument()
+            _httpx_instrumented = True
+        except Exception as exc:  # pragma: no cover - optional dep
+            logger.debug("httpx instrumentation unavailable: %s", exc)
+
     _provider_initialized = True
     logger.info(
         "telemetry_initialized",
@@ -148,3 +162,63 @@ def current_trace_context() -> dict[str, str]:
         "trace_id": format_trace_id(context.trace_id),
         "span_id": format_span_id(context.span_id),
     }
+
+
+@contextmanager
+def traced(name: str, **attributes: Any):
+    """Context manager creating a custom span (no-op when OTEL is disabled).
+
+    Usage:
+        with traced("llm.optimize", model="gpt-4o-mini"):
+            ...
+    """
+    if not HAS_OTEL or not settings.OTEL_ENABLED:
+        yield None
+        return
+    tracer = trace.get_tracer("latexy")
+    with tracer.start_as_current_span(name) as span:
+        for key, value in attributes.items():
+            if value is not None:
+                try:
+                    span.set_attribute(key, value)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+        yield span
+
+
+def set_span_attributes(**attributes: Any) -> None:
+    """Attach attributes to the current span (no-op when OTEL is disabled)."""
+    if not HAS_OTEL or not settings.OTEL_ENABLED:
+        return
+    span = trace.get_current_span()
+    for key, value in attributes.items():
+        if value is not None:
+            try:
+                span.set_attribute(key, value)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+
+def inject_trace_context(carrier: dict) -> dict:
+    """Inject the current trace context into a carrier dict (for Modal .spawn payloads)."""
+    if not HAS_OTEL or not settings.OTEL_ENABLED:
+        return carrier
+    try:
+        from opentelemetry.propagate import inject
+
+        inject(carrier)
+    except Exception:  # pragma: no cover - defensive
+        pass
+    return carrier
+
+
+def extract_trace_context(carrier: dict):
+    """Extract a trace context from a carrier dict (for Modal worker entrypoints)."""
+    if not HAS_OTEL or not settings.OTEL_ENABLED:
+        return None
+    try:
+        from opentelemetry.propagate import extract
+
+        return extract(carrier or {})
+    except Exception:  # pragma: no cover - defensive
+        return None


### PR DESCRIPTION
Central Prometheus metrics module (record_* helpers, numeric guards) and OpenTelemetry span/propagation helpers with HTTPX instrumentation.

Closes #836, #837, #838, #839.
Part of #835.