### PR TITLE
feat(hardening): error envelope and request-limit middleware

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -1,0 +1,91 @@
+"""Consistent API error envelope and global exception handlers.
+
+Every error response has the shape:
+    {"error": {"code": str, "message": str, "request_id": str|null, "details": ...}}
+
+Internal exceptions never leak stack traces or raw messages to the client; the
+traceback is logged server-side with the request_id for correlation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from .logging import get_logger
+from .observability import get_log_context
+
+logger = get_logger(__name__)
+
+
+def _request_id(request: Request) -> str | None:
+    rid = getattr(request.state, "request_id", None)
+    if rid:
+        return rid
+    return get_log_context().get("request_id")
+
+
+def error_body(code: str, message: str, request_id: str | None, details: Any = None, *, detail_compat: Any = None) -> dict:
+    """Build the error envelope.
+
+    A top-level ``detail`` key is preserved for backwards compatibility with the
+    original FastAPI contract (existing clients read ``detail``); the structured
+    ``error`` object is the forward-looking shape.
+    """
+    body: dict[str, Any] = {"error": {"code": code, "message": message, "request_id": request_id}}
+    if details is not None:
+        body["error"]["details"] = details
+    if detail_compat is not None:
+        body["detail"] = detail_compat
+    return body
+
+
+async def _validation_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    # jsonable_encoder mirrors FastAPI's default handler: pydantic error dicts can
+    # carry non-serializable objects (e.g. a ValueError in `ctx`).
+    details = jsonable_encoder(exc.errors())
+    return JSONResponse(
+        status_code=422,
+        content=error_body(
+            "validation_error", "Request validation failed.", _request_id(request),
+            details=details, detail_compat=details,
+        ),
+    )
+
+
+async def _http_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+    # HTTPException.detail is developer-authored (safe to surface). Preserve any
+    # headers (e.g. WWW-Authenticate, Retry-After) the raising code attached.
+    detail = exc.detail if isinstance(exc.detail, (str, list, dict)) else str(exc.detail)
+    message = detail if isinstance(detail, str) else "Request failed."
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=error_body("http_error", message, _request_id(request), detail_compat=detail),
+        headers=getattr(exc, "headers", None),
+    )
+
+
+async def _unhandled_handler(request: Request, exc: Exception) -> JSONResponse:
+    rid = _request_id(request)
+    # Log the full exception server-side; return a generic message to the client.
+    logger.error(
+        "unhandled_exception",
+        exc_info=exc,
+        extra={"path": request.url.path, "method": request.method, "request_id": rid},
+    )
+    return JSONResponse(
+        status_code=500,
+        content=error_body("internal_error", "An internal error occurred.", rid, detail_compat="Internal Server Error"),
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register the global exception handlers on the FastAPI app."""
+    app.add_exception_handler(RequestValidationError, _validation_handler)
+    app.add_exception_handler(StarletteHTTPException, _http_handler)
+    app.add_exception_handler(Exception, _unhandled_handler)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,14 +7,17 @@ from contextlib import asynccontextmanager
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 
 from .api.routes import _check_cors_origins_on_startup, router
 from .core.config import settings
+from .core.errors import register_exception_handlers
 from .core.event_bus import event_bus
 from .core.logging import get_logger, setup_logging
 from .core.redis import get_redis_client, redis_manager
 from .core.tracing import instrument_fastapi, setup_telemetry
 from .database.connection import close_db, init_db
+from .middleware.limits import BodySizeLimitMiddleware, TimeoutMiddleware
 from .middleware.rate_limiting import APIKeyRateLimitMiddleware, RateLimitMiddleware
 from .middleware.request_context import RequestContextMiddleware
 from .middleware.security_headers import SecurityHeadersMiddleware
@@ -106,6 +109,7 @@ app = FastAPI(
     openapi_url="/openapi.json" if _docs_enabled else None,
 )
 instrument_fastapi(app)
+register_exception_handlers(app)
 
 # Configure CORS.
 # effective_cors_origins() strips localhost/127.0.0.1 in production-like envs so
@@ -121,8 +125,15 @@ app.add_middleware(
     allow_headers=["Content-Type", "Authorization", "X-Request-ID", "X-Device-Fingerprint", "X-Tenant-Slug", "traceparent", "tracestate"],
 )
 
+# Compress large JSON/PDF responses (added early so it wraps the response last).
+app.add_middleware(GZipMiddleware, minimum_size=settings.GZIP_MIN_SIZE)
+
 # Baseline security headers on every response (does not affect CORS/JSON).
 app.add_middleware(SecurityHeadersMiddleware)
+
+# Reject oversized bodies (413) and time out slow requests (504).
+app.add_middleware(BodySizeLimitMiddleware, max_bytes=settings.MAX_REQUEST_BODY_BYTES)
+app.add_middleware(TimeoutMiddleware, timeout_seconds=settings.REQUEST_TIMEOUT_SECONDS)
 
 if settings.RATE_LIMIT_ENABLED:
     app.add_middleware(

--- a/backend/app/middleware/limits.py
+++ b/backend/app/middleware/limits.py
@@ -1,0 +1,75 @@
+"""Request body-size limit and request-timeout middleware."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import Request, status
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose declared body exceeds a global byte ceiling (413).
+
+    Guards against memory exhaustion from oversized uploads/JSON before the
+    handler reads the body. Clients uploading files send Content-Length, so this
+    is enforced up front.
+    """
+
+    def __init__(self, app, max_bytes: int) -> None:
+        super().__init__(app)
+        self.max_bytes = max_bytes
+
+    async def dispatch(self, request: Request, call_next):
+        content_length = request.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > self.max_bytes:
+                    return JSONResponse(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        content={
+                            "error": {
+                                "code": "payload_too_large",
+                                "message": f"Request body exceeds the {self.max_bytes} byte limit.",
+                                "request_id": getattr(request.state, "request_id", None),
+                            }
+                        },
+                    )
+            except ValueError:
+                pass
+        return await call_next(request)
+
+
+class TimeoutMiddleware(BaseHTTPMiddleware):
+    """Abort a request that exceeds a wall-clock timeout with 504.
+
+    Prevents a slow LaTeX/LLM/scraper handler from tying up a worker forever.
+    """
+
+    def __init__(self, app, timeout_seconds: float) -> None:
+        super().__init__(app)
+        self.timeout_seconds = timeout_seconds
+
+    async def dispatch(self, request: Request, call_next):
+        try:
+            return await asyncio.wait_for(call_next(request), timeout=self.timeout_seconds)
+        except (asyncio.TimeoutError, TimeoutError):
+            logger.warning(
+                "request_timeout",
+                extra={"path": request.url.path, "method": request.method, "timeout_s": self.timeout_seconds},
+            )
+            return JSONResponse(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                content={
+                    "error": {
+                        "code": "request_timeout",
+                        "message": "The request took too long to process.",
+                        "request_id": getattr(request.state, "request_id", None),
+                    }
+                },
+            )


### PR DESCRIPTION
Consistent error envelope with global handlers (backward-compatible detail key), body-size (413) and timeout (504) middleware, wired into the app with gzip.

Closes #849, #850, #851.
Part of #835.