### PR TITLE
feat(performance): embedding cache and bounded pagination

### DIFF
--- a/backend/app/api/application_routes.py
+++ b/backend/app/api/application_routes.py
@@ -17,7 +17,7 @@ from typing import Optional
 from uuid import uuid4
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -501,8 +501,8 @@ async def apply_lever(
 async def list_submissions(
     platform: Optional[str] = None,
     status: Optional[str] = None,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
     user_id: str = Depends(get_current_user_required),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -532,8 +532,8 @@ def _variant_count_subquery():
 
 @router.get("/")
 async def list_resumes(
-    page: int = 1,
-    limit: int = 20,
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=200),
     parent_id: Optional[str] = Query(None),
     archived: bool = Query(False),
     document_type: Optional[str] = Query(None),

--- a/backend/app/services/embedding_service.py
+++ b/backend/app/services/embedding_service.py
@@ -18,8 +18,14 @@ from typing import Any, Dict, List, Optional
 
 from ..core.config import settings
 from ..core.logging import get_logger
+from ..core.redis import cache_manager
 
 logger = get_logger(__name__)
+
+# Embedding cache: identical texts reuse the stored vector for 7 days so we do
+# not re-hit the embedding provider. Key namespace is separate from other caches.
+_EMBEDDING_CACHE_TTL = 604800  # 7 days
+_EMBEDDING_MODEL = "text-embedding-3-small"
 
 # Stopwords for keyword extraction
 _STOPWORDS = {
@@ -58,15 +64,39 @@ class EmbeddingService:
     # ------------------------------------------------------------------ #
 
     async def embed_text(self, text: str) -> List[float]:
-        """Embed a text string using text-embedding-3-small (1536 dims)."""
-        client = self._get_client()
+        """Embed a text string using text-embedding-3-small (1536 dims).
+
+        Results are cached in Redis keyed on a sha256 of the (truncated) input
+        text plus model name, so identical texts do not re-hit the provider.
+        Cache errors never break the embedding path.
+        """
         # Truncate to ~32K chars to stay within model limits
         truncated = text[:32000]
+
+        text_hash = hashlib.sha256(truncated.encode("utf-8")).hexdigest()
+        cache_key = f"latexy:embcache:{_EMBEDDING_MODEL}:{text_hash}"
+
+        # Cache lookup — fall back to computing on any error / cold cache.
+        try:
+            cached = await cache_manager.get(cache_key)
+            if cached:
+                return cached
+        except Exception as exc:  # noqa: BLE001 — caching must never break embedding
+            logger.debug(f"Embedding cache get failed: {exc}")
+
+        client = self._get_client()
         response = await client.embeddings.create(
-            model="text-embedding-3-small",
+            model=_EMBEDDING_MODEL,
             input=truncated,
         )
-        return response.data[0].embedding
+        embedding = response.data[0].embedding
+
+        try:
+            await cache_manager.set(cache_key, embedding, ttl=_EMBEDDING_CACHE_TTL)
+        except Exception as exc:  # noqa: BLE001 — caching must never break embedding
+            logger.debug(f"Embedding cache set failed: {exc}")
+
+        return embedding
 
     async def embed_resume(
         self, resume_id: str, latex_content: str, db


### PR DESCRIPTION
sha256-keyed embedding cache with graceful fallback and Query() bounds on resume/application list endpoints.

Closes #855, #856.
Part of #835.