### PR TITLE
feat(admin): control-plane API + config endpoint + ADMIN_EMAILS

### DIFF
--- a/backend/app/api/admin_routes.py
+++ b/backend/app/api/admin_routes.py
@@ -6,17 +6,24 @@ PATCH /admin/feature-flags/{key} — admin only — {enabled: bool}
 """
 
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..core.errors import error_body
 from ..database.connection import get_db
+from ..database.models import User
 from ..middleware.auth_middleware import require_admin
+from ..services.entitlement_service import entitlement_service
 from ..services.feature_flag_service import feature_flag_service
 
 router = APIRouter()
+
+# RBAC roles assignable via the admin API.
+_ASSIGNABLE_ROLES = frozenset({"user", "support", "admin"})
 
 # Flags that are safe to expose to unauthenticated clients. Everything else is
 # admin-only, so unreleased/internal flag names are not disclosed publicly.
@@ -99,3 +106,204 @@ async def update_feature_flag(
         description=flag.description,
         updated_at=flag.updated_at,
     )
+
+
+# ------------------------------------------------------------------ #
+#  Admin — entitlements (kill-switches + per-plan matrix)             #
+# ------------------------------------------------------------------ #
+
+class KillSwitchUpdateRequest(BaseModel):
+    enabled: bool
+
+
+class MatrixUpdateRequest(BaseModel):
+    plan_family: str
+    feature_key: str
+    enabled: bool
+
+
+@router.get("/admin/entitlements")
+async def get_entitlements(
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(require_admin),
+) -> dict:
+    """Return full entitlement state (registry + kill_switches + matrix + plan_families). Admin only."""
+    return await entitlement_service.get_state(db)
+
+
+@router.patch("/admin/entitlements/kill-switch/{key}")
+async def update_kill_switch(
+    key: str,
+    body: KillSwitchUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(require_admin),
+) -> dict:
+    """Toggle a global feature kill-switch. Admin only. 404 if the key is not gateable."""
+    try:
+        await entitlement_service.set_kill_switch(key, body.enabled, db)
+    except KeyError:
+        raise HTTPException(
+            status_code=404,
+            detail=error_body(
+                "feature_not_found",
+                f"Unknown or non-gateable feature: {key!r}",
+                None,
+            ),
+        )
+    return await entitlement_service.get_state(db)
+
+
+@router.patch("/admin/entitlements/matrix")
+async def update_matrix_cell(
+    body: MatrixUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(require_admin),
+) -> dict:
+    """Set a per-plan-family feature cell. Admin only.
+
+    400 on an unknown plan family, 404 on an unknown/non-gateable feature key.
+    """
+    from ..core.feature_registry import PLAN_FAMILIES, is_gateable
+
+    if body.plan_family not in PLAN_FAMILIES:
+        raise HTTPException(
+            status_code=400,
+            detail=error_body(
+                "invalid_plan_family",
+                f"Unknown plan family: {body.plan_family!r}",
+                None,
+            ),
+        )
+    if not is_gateable(body.feature_key):
+        raise HTTPException(
+            status_code=404,
+            detail=error_body(
+                "feature_not_found",
+                f"Unknown or non-gateable feature: {body.feature_key!r}",
+                None,
+            ),
+        )
+    await entitlement_service.set_matrix_cell(
+        body.plan_family, body.feature_key, body.enabled, db
+    )
+    return await entitlement_service.get_state(db)
+
+
+# ------------------------------------------------------------------ #
+#  Admin — user management                                            #
+# ------------------------------------------------------------------ #
+
+class UserSummary(BaseModel):
+    id: str
+    email: str
+    name: Optional[str]
+    role: str
+    subscription_plan: str
+    email_verified: bool
+    created_at: Optional[datetime]
+
+
+class UserListResponse(BaseModel):
+    users: List[UserSummary]
+    total: int
+
+
+class RoleUpdateRequest(BaseModel):
+    role: str
+
+
+def _user_summary(user: User) -> UserSummary:
+    return UserSummary(
+        id=user.id,
+        email=user.email,
+        name=user.name,
+        role=user.role,
+        subscription_plan=user.subscription_plan,
+        email_verified=bool(user.email_verified),
+        created_at=user.created_at,
+    )
+
+
+@router.get("/admin/users", response_model=UserListResponse)
+async def list_users(
+    q: Optional[str] = Query(None, description="Email (or name) search substring"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(require_admin),
+):
+    """List users with optional email search + pagination. Admin only."""
+    filters = []
+    if q:
+        pattern = f"%{q.strip()}%"
+        filters.append(or_(User.email.ilike(pattern), User.name.ilike(pattern)))
+
+    count_stmt = select(func.count()).select_from(User)
+    list_stmt = select(User).order_by(User.created_at.desc()).limit(limit).offset(offset)
+    for f in filters:
+        count_stmt = count_stmt.where(f)
+        list_stmt = list_stmt.where(f)
+
+    total = (await db.execute(count_stmt)).scalar_one()
+    rows = (await db.execute(list_stmt)).scalars().all()
+    return UserListResponse(
+        users=[_user_summary(u) for u in rows],
+        total=int(total),
+    )
+
+
+@router.patch("/admin/users/{user_id}/role", response_model=UserSummary)
+async def update_user_role(
+    user_id: str,
+    body: RoleUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    admin_user_id: str = Depends(require_admin),
+):
+    """Change a user's RBAC role. Admin only.
+
+    Guards:
+      - 400 on an invalid role.
+      - 409 when the change would remove the last remaining admin (including an
+        admin demoting themselves as the last admin).
+    """
+    new_role = body.role.strip().lower()
+    if new_role not in _ASSIGNABLE_ROLES:
+        raise HTTPException(
+            status_code=400,
+            detail=error_body(
+                "invalid_role",
+                f"Role must be one of {sorted(_ASSIGNABLE_ROLES)}",
+                None,
+            ),
+        )
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(
+            status_code=404,
+            detail=error_body("user_not_found", f"User {user_id!r} not found", None),
+        )
+
+    # Last-admin guard: block demoting the only remaining admin (covers an admin
+    # demoting themselves). No-op if the role is unchanged.
+    if user.role == "admin" and new_role != "admin":
+        admin_count = (
+            await db.execute(
+                select(func.count()).select_from(User).where(User.role == "admin")
+            )
+        ).scalar_one()
+        if int(admin_count) <= 1:
+            raise HTTPException(
+                status_code=409,
+                detail=error_body(
+                    "last_admin",
+                    "Cannot remove the last remaining admin.",
+                    None,
+                ),
+            )
+
+    user.role = new_role
+    await db.commit()
+    await db.refresh(user)
+    return _user_summary(user)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -19,6 +19,7 @@ from ..database.connection import get_async_db_session, get_db
 from ..database.models import Compilation, Resume, User
 from ..middleware.auth_middleware import get_current_user_optional
 from ..middleware.auth_middleware import get_current_user_required as _require_user
+from ..middleware.entitlements import require_feature_optional
 from ..models.llm_schemas import OptimizationRequest, OptimizationResponse
 from ..models.schemas import CompilationResponse, HealthResponse, LogsResponse
 from ..services.feature_flag_service import feature_flag_service
@@ -229,6 +230,21 @@ async def get_me(
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     return MeResponse(id=user.id, email=user.email, plan=user.subscription_plan)
+
+
+@router.get("/config/entitlements")
+async def get_entitlements_for_user(
+    db: AsyncSession = Depends(get_db),
+    user_id: Optional[str] = Depends(get_current_user_optional),
+) -> dict:
+    """Return the effective per-feature allow map for the current user.
+
+    Anonymous callers get the free-plan family map. Drives frontend gating.
+    """
+    from ..services.entitlement_service import entitlement_service
+
+    features = await entitlement_service.effective_features(user_id, db)
+    return {"features": features}
 
 
 @router.get("/health", response_model=HealthResponse)
@@ -533,7 +549,11 @@ async def get_compilation_logs(
         raise HTTPException(status_code=500, detail="Error reading log file")
 
 
-@router.post("/optimize", response_model=OptimizationResponse)
+@router.post(
+    "/optimize",
+    response_model=OptimizationResponse,
+    dependencies=[Depends(require_feature_optional("llm_optimize"))],
+)
 async def optimize_resume(request: OptimizationRequest):
     """Optimize resume using LLM for better ATS compatibility."""
 
@@ -570,7 +590,11 @@ async def optimize_resume(request: OptimizationRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/optimize-and-compile", response_model=dict)
+@router.post(
+    "/optimize-and-compile",
+    response_model=dict,
+    dependencies=[Depends(require_feature_optional("llm_optimize"))],
+)
 async def optimize_and_compile_resume(request: OptimizationRequest):
     """Optimize resume and compile to PDF in one step."""
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -173,6 +173,7 @@ class Settings(BaseSettings):
 
     # Admin email — user with this email can access /admin/* endpoints
     ADMIN_EMAIL: str = Field(default="", description="Email of the admin user for /admin/* access")
+    ADMIN_EMAILS: str = Field(default="", description="Comma-separated list of admin emails for /admin/* access")
     ADMIN_SECRET_KEY: str = Field(default="", description="Shared secret for template/admin utility endpoints")
 
     # Comma-separated list of emails that get TEST_TRIAL_LIMIT instead of TRIAL_LIMIT
@@ -568,6 +569,19 @@ class Settings(BaseSettings):
                 "REDIS_URL is %s — using a localhost Redis in production is likely misconfigured",
                 repr(self.REDIS_URL) if self.REDIS_URL else "empty",
             )
+
+    def admin_email_set(self) -> set[str]:
+        """Return the union of ADMIN_EMAIL + ADMIN_EMAILS, lowercased and stripped.
+
+        Empty entries are dropped. Backward-compatible: ADMIN_EMAIL alone still
+        works.
+        """
+        emails: set[str] = set()
+        for raw in [self.ADMIN_EMAIL, *self.ADMIN_EMAILS.split(",")]:
+            cleaned = (raw or "").strip().lower()
+            if cleaned:
+                emails.add(cleaned)
+        return emails
 
 
 # Global settings instance


### PR DESCRIPTION
Admin entitlements/users API, GET /config/entitlements, and multi-admin ADMIN_EMAILS.

Closes #885, #884. Part of #877.