### PR TITLE
test(entitlements): control-plane backend tests + wiring guard

### DIFF
--- a/backend/test/_entitlement_reset.py
+++ b/backend/test/_entitlement_reset.py
@@ -1,0 +1,72 @@
+"""Shared entitlement test-isolation helpers.
+
+The Admin Control Plane has GLOBAL mutable state that leaks across tests:
+
+  * ``plan_features`` rows (per-plan matrix) in the shared test DB,
+  * ``feature_flags`` kill-switch rows for gateable features in the test DB,
+  * the module-level ``entitlement_service._cache`` (60s TTL blob cache),
+  * the Redis JSON blob ``latexy:entitlements``.
+
+Any test that disables a feature MUST rely on the reset performed here so the
+rest of the suite always starts from a clean, all-enabled baseline. Mutations
+in the service go through a DEDICATED session (``get_async_db_session`` on the
+app's real SessionLocal — NOT the overridden ``db_session`` fixture), so the
+reset must likewise commit through a real session and delete the Redis key on
+the same Redis the app uses (``settings.REDIS_URL``).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from app.core.feature_registry import gateable_keys
+
+
+async def reset_entitlements_baseline() -> None:
+    """Restore the all-enabled baseline for every entitlement axis.
+
+    * ``plan_features.enabled = true`` for all rows.
+    * gateable ``feature_flags.enabled = true`` (kill-switches re-enabled).
+    * clears the in-process ``entitlement_service`` cache.
+    * deletes the Redis ``latexy:entitlements`` blob.
+
+    Uses a real committed session (the app SessionLocal via
+    ``get_async_db_session``) so reads across the suite see committed data.
+    """
+    from app.database.connection import get_async_db_session
+    from app.services.entitlement_service import (
+        REDIS_BLOB_KEY,
+        _clear_cache,
+        entitlement_service,  # noqa: F401  (imported for clarity / future use)
+    )
+
+    gateable = list(gateable_keys())
+
+    # 1. DB: reset the matrix + gateable kill-switches to enabled, committed.
+    async with get_async_db_session() as db:
+        await db.execute(text("UPDATE plan_features SET enabled = true WHERE enabled = false"))
+        if gateable:
+            await db.execute(
+                text(
+                    "UPDATE feature_flags SET enabled = true "
+                    "WHERE enabled = false AND key = ANY(:keys)"
+                ),
+                {"keys": gateable},
+            )
+        await db.commit()
+
+    # 2. In-process cache: drop the stale blob so the next read rebuilds.
+    _clear_cache()
+
+    # 3. Redis blob: delete so sync/async readers rebuild from the clean DB.
+    try:
+        import redis as _redis
+
+        from app.core.config import settings
+
+        r = _redis.from_url(settings.REDIS_URL, decode_responses=True)
+        r.delete(REDIS_BLOB_KEY)
+        r.close()
+    except Exception:
+        # Best-effort — the cache clear + DB reset already restore baseline.
+        pass

--- a/backend/test/test_admin_control_plane_api.py
+++ b/backend/test/test_admin_control_plane_api.py
@@ -1,0 +1,343 @@
+"""Admin Control Plane API tests (entitlements + users/roles + config).
+
+Auth model: users now carry an RBAC ``role`` column. ``require_admin`` grants
+access when ``role == 'admin'``, so these tests create admin users directly with
+role='admin' (no ADMIN_EMAIL patching needed). Non-admin users get 403.
+
+GLOBAL STATE: mutations here toggle kill-switches / matrix cells in the shared
+test DB + Redis blob + cache. The autouse ``_reset`` fixture restores the
+all-enabled baseline AFTER every test.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from _entitlement_reset import reset_entitlements_baseline
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture(autouse=True)
+async def _reset():
+    yield
+    await reset_entitlements_baseline()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+async def _create_user(
+    db: AsyncSession,
+    *,
+    role: str = "user",
+    plan: str = "free",
+    name: str = "CP User",
+    email: str | None = None,
+) -> tuple[str, str]:
+    user_id = str(uuid.uuid4())
+    if email is None:
+        email = f"test_{user_id.replace('-', '')}@example.com"
+    await db.execute(
+        text(
+            "INSERT INTO users (id, email, name, role, email_verified, "
+            "subscription_plan, subscription_status, trial_used) "
+            "VALUES (:id, :email, :name, :role, true, :plan, 'active', false)"
+        ),
+        {"id": user_id, "email": email, "name": name, "role": role, "plan": plan},
+    )
+    await db.commit()
+    return user_id, email
+
+
+async def _create_session(db: AsyncSession, user_id: str) -> str:
+    token = f"test_sess_{uuid.uuid4().hex}"
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    await db.execute(
+        text(
+            'INSERT INTO session (id, "userId", "expiresAt", token) '
+            "VALUES (:id, :uid, :exp, :tok)"
+        ),
+        {"id": str(uuid.uuid4()), "uid": user_id, "exp": expires_at, "tok": token},
+    )
+    await db.commit()
+    return token
+
+
+async def _admin_headers(db: AsyncSession) -> dict:
+    user_id, _ = await _create_user(db, role="admin", name="Admin User")
+    token = await _create_session(db, user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _user_headers(db: AsyncSession, role: str = "user") -> tuple[str, dict]:
+    user_id, _ = await _create_user(db, role=role)
+    token = await _create_session(db, user_id)
+    return user_id, {"Authorization": f"Bearer {token}"}
+
+
+# ── GET /admin/entitlements ──────────────────────────────────────────────────
+
+class TestGetEntitlements:
+
+    async def test_non_admin_403(self, client: AsyncClient, db_session: AsyncSession):
+        _, headers = await _user_headers(db_session)
+        resp = await client.get("/admin/entitlements", headers=headers)
+        assert resp.status_code == 403
+
+    async def test_admin_200_shape(self, client: AsyncClient, db_session: AsyncSession):
+        headers = await _admin_headers(db_session)
+        resp = await client.get("/admin/entitlements", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {"registry", "kill_switches", "matrix", "plan_families"}
+        assert body["plan_families"] == ["free", "basic", "pro", "byok", "team"]
+        assert len(body["registry"]) == 27
+
+
+# ── PATCH /admin/entitlements/kill-switch/{key} ──────────────────────────────
+
+class TestKillSwitch:
+
+    async def test_toggle_reflected_in_get(self, client: AsyncClient, db_session: AsyncSession):
+        headers = await _admin_headers(db_session)
+
+        resp = await client.patch(
+            "/admin/entitlements/kill-switch/cover_letters",
+            json={"enabled": False},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["kill_switches"]["cover_letters"] is False
+
+        # Confirmed via a subsequent GET.
+        get_resp = await client.get("/admin/entitlements", headers=headers)
+        assert get_resp.json()["kill_switches"]["cover_letters"] is False
+
+    async def test_non_gateable_key_404(self, client: AsyncClient, db_session: AsyncSession):
+        headers = await _admin_headers(db_session)
+        resp = await client.patch(
+            "/admin/entitlements/kill-switch/compile",  # non-gateable
+            json={"enabled": False},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_unknown_key_404(self, client: AsyncClient, db_session: AsyncSession):
+        headers = await _admin_headers(db_session)
+        resp = await client.patch(
+            "/admin/entitlements/kill-switch/no_such_key",
+            json={"enabled": False},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+
+# ── PATCH /admin/entitlements/matrix ─────────────────────────────────────────
+
+class TestMatrix:
+
+    async def test_toggle_cell(self, client: AsyncClient, db_session: AsyncSession):
+        headers = await _admin_headers(db_session)
+        resp = await client.patch(
+            "/admin/entitlements/matrix",
+            json={"plan_family": "free", "feature_key": "cover_letters", "enabled": False},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["matrix"]["free"]["cover_letters"] is False
+        # Other families unaffected.
+        assert resp.json()["matrix"]["pro"]["cover_letters"] is True
+
+    async def test_invalid_family_400(self, client: AsyncClient, db_session: AsyncSession):
+        headers = await _admin_headers(db_session)
+        resp = await client.patch(
+            "/admin/entitlements/matrix",
+            json={"plan_family": "platinum", "feature_key": "cover_letters", "enabled": False},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+    async def test_non_gateable_key_404(self, client: AsyncClient, db_session: AsyncSession):
+        headers = await _admin_headers(db_session)
+        resp = await client.patch(
+            "/admin/entitlements/matrix",
+            json={"plan_family": "free", "feature_key": "compile", "enabled": False},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+
+# ── GET /admin/users ─────────────────────────────────────────────────────────
+
+class TestListUsers:
+
+    async def test_returns_created_users_with_role(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        admin_headers = await _admin_headers(db_session)
+        target_id, target_email = await _create_user(db_session, role="support")
+
+        resp = await client.get("/admin/users?limit=200", headers=admin_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "users" in body and "total" in body
+        found = {u["id"]: u for u in body["users"]}
+        assert target_id in found
+        assert found[target_id]["role"] == "support"
+        assert found[target_id]["email"] == target_email
+
+    async def test_search_filters(self, client: AsyncClient, db_session: AsyncSession):
+        admin_headers = await _admin_headers(db_session)
+        unique = uuid.uuid4().hex[:10]
+        target_id, _ = await _create_user(
+            db_session, name=f"Zephyr {unique}", email=f"test_{unique}@example.com"
+        )
+
+        resp = await client.get(f"/admin/users?q={unique}", headers=admin_headers)
+        assert resp.status_code == 200
+        ids = [u["id"] for u in resp.json()["users"]]
+        assert target_id in ids
+        # A non-matching query should not return the target.
+        resp2 = await client.get("/admin/users?q=no_such_substring_xyzzy", headers=admin_headers)
+        assert target_id not in [u["id"] for u in resp2.json()["users"]]
+
+    async def test_pagination_bounds(self, client: AsyncClient, db_session: AsyncSession):
+        admin_headers = await _admin_headers(db_session)
+        # limit within bounds
+        ok = await client.get("/admin/users?limit=1&offset=0", headers=admin_headers)
+        assert ok.status_code == 200
+        assert len(ok.json()["users"]) <= 1
+        # limit above max (200) → 422 validation error
+        too_big = await client.get("/admin/users?limit=500", headers=admin_headers)
+        assert too_big.status_code == 422
+        # negative offset → 422
+        neg = await client.get("/admin/users?offset=-1", headers=admin_headers)
+        assert neg.status_code == 422
+
+    async def test_non_admin_403(self, client: AsyncClient, db_session: AsyncSession):
+        _, headers = await _user_headers(db_session)
+        resp = await client.get("/admin/users", headers=headers)
+        assert resp.status_code == 403
+
+
+# ── PATCH /admin/users/{id}/role ─────────────────────────────────────────────
+
+class TestUpdateRole:
+
+    async def test_change_role(self, client: AsyncClient, db_session: AsyncSession):
+        admin_headers = await _admin_headers(db_session)
+        target_id, _ = await _create_user(db_session, role="user")
+
+        resp = await client.patch(
+            f"/admin/users/{target_id}/role",
+            json={"role": "support"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["role"] == "support"
+
+    async def test_invalid_role_400(self, client: AsyncClient, db_session: AsyncSession):
+        admin_headers = await _admin_headers(db_session)
+        target_id, _ = await _create_user(db_session, role="user")
+        resp = await client.patch(
+            f"/admin/users/{target_id}/role",
+            json={"role": "superuser"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 400
+
+    async def test_last_admin_guard_409(self, client: AsyncClient, db_session: AsyncSession):
+        """Demoting the only admin returns 409.
+
+        Guarantee there is exactly ONE admin: demote every pre-existing admin to
+        'user' first (via a second admin), then attempt to demote the last one.
+        """
+        # Two admins so we can safely clear any other admins in the shared DB.
+        admin_a_id, _ = await _create_user(db_session, role="admin", name="Admin A")
+        token_a = await _create_session(db_session, admin_a_id)
+        headers_a = {"Authorization": f"Bearer {token_a}"}
+
+        admin_b_id, _ = await _create_user(db_session, role="admin", name="Admin B")
+
+        # Demote all admins EXCEPT admin_a to 'user' so admin_a is the last admin.
+        await db_session.execute(
+            text("UPDATE users SET role = 'user' WHERE role = 'admin' AND id != :keep"),
+            {"keep": admin_a_id},
+        )
+        await db_session.commit()
+        # admin_b was just demoted in the DB; irrelevant now.
+        assert admin_b_id  # referenced
+
+        # Now demoting admin_a (the last admin) must 409.
+        resp = await client.patch(
+            f"/admin/users/{admin_a_id}/role",
+            json={"role": "user"},
+            headers=headers_a,
+        )
+        assert resp.status_code == 409
+
+        # Restore admin_a so teardown / other tests are unaffected.
+        await db_session.execute(
+            text("UPDATE users SET role = 'admin' WHERE id = :id"), {"id": admin_a_id}
+        )
+        await db_session.commit()
+
+    async def test_non_admin_403(self, client: AsyncClient, db_session: AsyncSession):
+        _, headers = await _user_headers(db_session)
+        target_id, _ = await _create_user(db_session, role="user")
+        resp = await client.patch(
+            f"/admin/users/{target_id}/role",
+            json={"role": "admin"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+# ── GET /config/entitlements (auth optional) ─────────────────────────────────
+
+class TestConfigEntitlements:
+
+    async def test_authed_user(self, client: AsyncClient, db_session: AsyncSession):
+        _, headers = await _user_headers(db_session)
+        resp = await client.get("/config/entitlements", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "features" in body
+        assert len(body["features"]) == 27
+        assert body["features"]["compile"] is True
+
+    async def test_anonymous(self, client: AsyncClient):
+        resp = await client.get("/config/entitlements")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "features" in body
+        assert len(body["features"]) == 27
+
+    async def test_anonymous_reflects_free_matrix_disable(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        from app.services.entitlement_service import entitlement_service
+
+        await entitlement_service.set_matrix_cell("free", "cover_letters", False, db_session)
+        resp = await client.get("/config/entitlements")
+        assert resp.status_code == 200
+        assert resp.json()["features"]["cover_letters"] is False
+
+
+# ── require_role factory (optional coverage) ─────────────────────────────────
+
+class TestRequireRole:
+
+    async def test_require_role_support_admin_route_behaviour(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A 'support' user is granted admin-plane read via the role path only if
+        role=='admin'; here we assert a support user is still blocked from an
+        admin-only route (require_admin requires role=='admin')."""
+        _, headers = await _user_headers(db_session, role="support")
+        resp = await client.get("/admin/entitlements", headers=headers)
+        # support is NOT admin → 403 on the admin-only route.
+        assert resp.status_code == 403

--- a/backend/test/test_entitlement_enforcement.py
+++ b/backend/test/test_entitlement_enforcement.py
@@ -1,0 +1,144 @@
+"""End-to-end entitlement enforcement via a real gated endpoint.
+
+The gated route under test is ``POST /cover-letters/generate`` which declares
+``dependencies=[Depends(require_feature("cover_letters"))]``. ``require_feature``
+authenticates via ``get_current_user_required`` (a user_id string) and calls
+``entitlement_service.has_feature`` which loads role/plan from the DB, so these
+tests use REAL user + session rows.
+
+GLOBAL STATE: the autouse ``_reset`` fixture restores the all-enabled baseline
+AFTER every test so the plain cover-letter tests never see a disabled feature.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from _entitlement_reset import reset_entitlements_baseline
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.entitlement_service import entitlement_service
+
+
+@pytest.fixture(autouse=True)
+async def _reset():
+    yield
+    await reset_entitlements_baseline()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+async def _create_user(
+    db: AsyncSession, *, role: str = "user", plan: str = "free"
+) -> tuple[str, str]:
+    user_id = str(uuid.uuid4())
+    email = f"test_{user_id.replace('-', '')}@example.com"
+    await db.execute(
+        text(
+            "INSERT INTO users (id, email, name, role, email_verified, "
+            "subscription_plan, subscription_status, trial_used) "
+            "VALUES (:id, :email, 'Enf User', :role, true, :plan, 'active', false)"
+        ),
+        {"id": user_id, "email": email, "role": role, "plan": plan},
+    )
+    await db.commit()
+    return user_id, email
+
+
+async def _create_session(db: AsyncSession, user_id: str) -> str:
+    token = f"test_sess_{uuid.uuid4().hex}"
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    await db.execute(
+        text(
+            'INSERT INTO session (id, "userId", "expiresAt", token) '
+            "VALUES (:id, :uid, :exp, :tok)"
+        ),
+        {"id": str(uuid.uuid4()), "uid": user_id, "exp": expires_at, "tok": token},
+    )
+    await db.commit()
+    return token
+
+
+def _generate_payload() -> dict:
+    # A well-formed body (passes pydantic validation) referencing a resume that
+    # does not exist — so an ENABLED feature falls through to a 404, never a 403.
+    return {
+        "resume_id": str(uuid.uuid4()),
+        "job_description": "We are hiring a backend engineer with strong Python skills.",
+        "company_name": "Acme",
+        "role_title": "Backend Engineer",
+        "tone": "formal",
+        "length_preference": "3_paragraphs",
+    }
+
+
+# ── (a) Enabled (default) → NOT a feature_disabled 403 ───────────────────────
+
+async def test_enabled_feature_does_not_403(
+    client: AsyncClient, db_session: AsyncSession
+):
+    user_id, _ = await _create_user(db_session, role="user", plan="free")
+    token = await _create_session(db_session, user_id)
+
+    resp = await client.post(
+        "/cover-letters/generate",
+        json=_generate_payload(),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Feature is enabled → the entitlement gate passes. It may 404 (resume
+    # missing) but must NOT be the feature_disabled 403.
+    assert resp.status_code != 403
+    assert resp.status_code == 404  # resume not found (gate passed)
+
+
+# ── (b) Matrix-disabled for free → 403 feature_disabled ──────────────────────
+
+async def test_disabled_matrix_returns_feature_disabled_403(
+    client: AsyncClient, db_session: AsyncSession
+):
+    user_id, _ = await _create_user(db_session, role="user", plan="free")
+    token = await _create_session(db_session, user_id)
+
+    await entitlement_service.set_matrix_cell("free", "cover_letters", False, db_session)
+
+    resp = await client.post(
+        "/cover-letters/generate",
+        json=_generate_payload(),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 403
+    body = resp.json()
+    detail = body.get("detail", body)
+    # error_body envelope → {"error": {"code": "feature_disabled", ...}} or flat.
+    code = None
+    if isinstance(detail, dict):
+        code = detail.get("code") or (detail.get("error") or {}).get("code")
+    assert code == "feature_disabled", body
+
+
+# ── (c) Admin role bypasses the disabled feature ─────────────────────────────
+
+async def test_admin_role_bypasses_disabled_feature(
+    client: AsyncClient, db_session: AsyncSession
+):
+    user_id, _ = await _create_user(db_session, role="admin", plan="free")
+    token = await _create_session(db_session, user_id)
+
+    # Disable via kill-switch (global) — admin must still pass the gate.
+    await entitlement_service.set_kill_switch("cover_letters", False, db_session)
+
+    resp = await client.post(
+        "/cover-letters/generate",
+        json=_generate_payload(),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Admin bypasses entitlement → gate passes → 404 (resume missing), not 403.
+    assert resp.status_code != 403
+    assert resp.status_code == 404

--- a/backend/test/test_entitlement_service.py
+++ b/backend/test/test_entitlement_service.py
@@ -1,0 +1,215 @@
+"""EntitlementService resolution tests (Admin Control Plane).
+
+Exercises ``entitlement_service`` directly (async). Uses lightweight user-like
+objects (role/subscription_plan attributes) so we avoid DB round-trips where the
+service reads attributes directly.
+
+GLOBAL STATE: these tests toggle kill-switches / matrix cells that live in the
+shared test DB + Redis blob + in-process cache. The autouse ``_reset`` fixture
+restores the all-enabled baseline AFTER every test so no other test in the whole
+suite ever observes a disabled feature.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from _entitlement_reset import reset_entitlements_baseline
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.feature_registry import FEATURE_REGISTRY, PLAN_FAMILIES, gateable_keys
+from app.services.entitlement_service import (
+    REDIS_BLOB_KEY,
+    entitlement_service,
+)
+
+# ── Isolation: reset the all-enabled baseline after every test ───────────────
+
+@pytest.fixture(autouse=True)
+async def _reset():
+    yield
+    await reset_entitlements_baseline()
+
+
+# ── User-like helpers ────────────────────────────────────────────────────────
+
+def _user(role: str | None = None, plan: str | None = "free"):
+    """A minimal user-like object exposing role + subscription_plan."""
+    return SimpleNamespace(role=role, subscription_plan=plan)
+
+
+FREE_USER = None  # sentinel replaced per-test via _user()
+
+
+# ── has_feature: trivial / bypass paths ──────────────────────────────────────
+
+class TestHasFeatureTrivial:
+
+    async def test_non_gateable_key_always_true(self):
+        assert await entitlement_service.has_feature("compile", user=_user(plan="free")) is True
+
+    async def test_unknown_key_always_true(self):
+        assert await entitlement_service.has_feature("no_such_feature", user=_user()) is True
+
+    async def test_admin_role_true_even_when_disabled(self, db_session: AsyncSession):
+        await entitlement_service.set_kill_switch("cover_letters", False, db_session)
+        admin = _user(role="admin", plan="free")
+        assert await entitlement_service.has_feature("cover_letters", user=admin) is True
+
+    async def test_support_role_true_even_when_disabled(self, db_session: AsyncSession):
+        await entitlement_service.set_kill_switch("cover_letters", False, db_session)
+        support = _user(role="support", plan="free")
+        assert await entitlement_service.has_feature("cover_letters", user=support) is True
+
+    async def test_anonymous_uses_free_family(self, db_session: AsyncSession):
+        # Disable cover_letters only for the free family → anonymous (None) blocked.
+        await entitlement_service.set_matrix_cell("free", "cover_letters", False, db_session)
+        assert await entitlement_service.has_feature("cover_letters", user=None) is False
+
+
+# ── has_feature: kill-switch + matrix ────────────────────────────────────────
+
+class TestHasFeatureToggles:
+
+    async def test_kill_switch_disables_then_reenables(self, db_session: AsyncSession):
+        free = _user(plan="free")
+
+        await entitlement_service.set_kill_switch("cover_letters", False, db_session)
+        assert await entitlement_service.has_feature("cover_letters", user=free) is False
+
+        await entitlement_service.set_kill_switch("cover_letters", True, db_session)
+        assert await entitlement_service.has_feature("cover_letters", user=free) is True
+
+    async def test_matrix_cell_only_affects_that_family(self, db_session: AsyncSession):
+        await entitlement_service.set_matrix_cell("free", "cover_letters", False, db_session)
+
+        free = _user(plan="free")
+        pro = _user(plan="pro")
+
+        assert await entitlement_service.has_feature("cover_letters", user=free) is False
+        # Only the free family was disabled → a pro user is unaffected.
+        assert await entitlement_service.has_feature("cover_letters", user=pro) is True
+
+    async def test_default_all_enabled_for_free_user(self):
+        free = _user(plan="free")
+        for key in gateable_keys():
+            assert await entitlement_service.has_feature(key, user=free) is True, key
+
+
+# ── effective_features + get_state shapes ────────────────────────────────────
+
+class TestEffectiveFeaturesAndState:
+
+    async def test_effective_features_all_27_keys(self):
+        free = _user(plan="free")
+        eff = await entitlement_service.effective_features(free)
+        assert set(eff.keys()) == {f.key for f in FEATURE_REGISTRY}
+        assert len(eff) == 27
+        # Non-gateable always True.
+        assert eff["compile"] is True
+
+    async def test_effective_features_reflect_disable(self, db_session: AsyncSession):
+        await entitlement_service.set_matrix_cell("free", "cover_letters", False, db_session)
+        free = _user(plan="free")
+        eff = await entitlement_service.effective_features(free)
+        assert eff["cover_letters"] is False
+        assert eff["compile"] is True  # non-gateable unaffected
+
+    async def test_get_state_shape(self, db_session: AsyncSession):
+        state = await entitlement_service.get_state(db_session)
+        assert set(state.keys()) == {"registry", "kill_switches", "matrix", "plan_families"}
+        assert state["plan_families"] == list(PLAN_FAMILIES)
+
+        gateable = set(gateable_keys())
+        # kill_switches: one entry per gateable feature, all True at baseline.
+        assert set(state["kill_switches"].keys()) == gateable
+        assert all(v is True for v in state["kill_switches"].values())
+
+        # matrix: family → gateable-key → bool.
+        assert set(state["matrix"].keys()) == set(PLAN_FAMILIES)
+        for family in PLAN_FAMILIES:
+            assert set(state["matrix"][family].keys()) == gateable
+
+        # registry entries carry the expected fields.
+        assert len(state["registry"]) == 27
+        sample = state["registry"][0]
+        assert set(sample.keys()) == {"key", "label", "category", "gateable"}
+
+
+# ── sync_has_feature (worker path via Redis blob) ────────────────────────────
+
+class TestSyncHasFeature:
+
+    async def test_sync_reads_blob_disabled_kill(self, db_session: AsyncSession):
+        # set_kill_switch pushes a fresh blob to Redis.
+        await entitlement_service.set_kill_switch("cover_letters", False, db_session)
+        assert entitlement_service.sync_has_feature("cover_letters", "free") is False
+
+    async def test_sync_reads_blob_enabled(self, db_session: AsyncSession):
+        # Any set_* pushes the blob; baseline is all-enabled.
+        await entitlement_service.set_kill_switch("cover_letters", True, db_session)
+        assert entitlement_service.sync_has_feature("cover_letters", "free") is True
+
+    async def test_sync_matrix_family_scoped(self, db_session: AsyncSession):
+        await entitlement_service.set_matrix_cell("free", "cover_letters", False, db_session)
+        assert entitlement_service.sync_has_feature("cover_letters", "free") is False
+        assert entitlement_service.sync_has_feature("cover_letters", "pro") is True
+
+    async def test_sync_non_gateable_always_true(self):
+        assert entitlement_service.sync_has_feature("compile", "free") is True
+
+    async def test_sync_fail_open_when_blob_missing(self):
+        # Delete the Redis blob so there is nothing to read → fail open (True).
+        import redis as _redis
+
+        from app.core.config import settings
+
+        r = _redis.from_url(settings.REDIS_URL, decode_responses=True)
+        r.delete(REDIS_BLOB_KEY)
+        r.close()
+
+        assert entitlement_service.sync_has_feature("cover_letters", "free") is True
+
+
+# ── Regression: has_feature must NOT touch the caller's request session ──────
+
+class TestSessionIsolationRegression:
+
+    async def test_has_feature_does_not_rollback_caller_session(
+        self, db_session: AsyncSession
+    ):
+        """A pending object in the passed session must survive a has_feature call.
+
+        Guards the regression where entitlement reads on the request session
+        rolled back the caller's in-flight transaction.
+        """
+        user_id = str(uuid.uuid4())
+        email = f"test_{user_id.replace('-', '')}@example.com"
+        # Add a pending row on the caller's session (not yet committed).
+        await db_session.execute(
+            text(
+                "INSERT INTO users (id, email, name, email_verified, "
+                "subscription_plan, subscription_status, trial_used) "
+                "VALUES (:id, :email, 'Pending User', true, 'free', 'active', false)"
+            ),
+            {"id": user_id, "email": email},
+        )
+
+        # Call has_feature WITH the caller's session — it must be ignored/untouched.
+        result = await entitlement_service.has_feature(
+            "cover_letters", user=_user(plan="free"), db=db_session
+        )
+        assert result is True
+
+        # The pending object must still be visible in this session (no rollback).
+        row = (
+            await db_session.execute(
+                text("SELECT id FROM users WHERE id = :id"), {"id": user_id}
+            )
+        ).fetchone()
+        assert row is not None
+        assert str(row[0]) == user_id
+        # db_session fixture rolls back on teardown → row never persists globally.

--- a/backend/test/test_entitlement_wiring.py
+++ b/backend/test/test_entitlement_wiring.py
@@ -1,0 +1,47 @@
+"""Regression guard: every gateable feature key must be enforced on a route.
+
+The audit found gateable features in the registry that had NO
+``require_feature`` / ``require_feature_optional`` reference on any API route,
+so admins could disable them and the endpoint would still run (silent
+non-enforcement). This test scans ``app/api/*.py`` for those dependency
+references and asserts that every ``gateable_keys()`` entry appears at least
+once. If a new gateable feature is added to the registry without wiring an
+enforcement dependency, this test FAILS and names the unwired keys.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+
+from app.core.feature_registry import gateable_keys
+
+# Matches require_feature("key") and require_feature_optional("key").
+_REF_RE = re.compile(r'require_feature(?:_optional)?\(\s*["\']([a-z_]+)["\']\s*\)')
+
+_API_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "app",
+    "api",
+)
+
+
+def _wired_keys() -> set[str]:
+    wired: set[str] = set()
+    for path in glob.glob(os.path.join(_API_DIR, "*.py")):
+        with open(path, encoding="utf-8") as fh:
+            for match in _REF_RE.finditer(fh.read()):
+                wired.add(match.group(1))
+    return wired
+
+
+def test_every_gateable_key_is_enforced_on_a_route() -> None:
+    wired = _wired_keys()
+    missing = sorted(k for k in gateable_keys() if k not in wired)
+    assert not missing, (
+        "Gateable feature keys with NO require_feature/"
+        "require_feature_optional enforcement on any app/api route: "
+        f"{missing}. Wire an enforcement dependency on the primary entry "
+        "route, or mark the feature gateable=False in the registry."
+    )

--- a/backend/test/test_feature_registry.py
+++ b/backend/test/test_feature_registry.py
@@ -1,0 +1,75 @@
+"""Feature registry integrity tests (Admin Control Plane).
+
+Pure, synchronous checks on the code-defined catalog — no DB / Redis.
+"""
+
+from __future__ import annotations
+
+from app.core.feature_registry import (
+    FEATURE_REGISTRY,
+    PLAN_FAMILIES,
+    all_feature_keys,
+    gateable_keys,
+    get_feature,
+    is_gateable,
+)
+
+
+def test_registry_has_27_entries():
+    assert len(FEATURE_REGISTRY) == 27
+
+
+def test_registry_has_26_gateable():
+    assert len(gateable_keys()) == 26
+
+
+def test_compile_present_and_non_gateable():
+    compile_feature = get_feature("compile")
+    assert compile_feature is not None
+    assert compile_feature.gateable is False
+    assert is_gateable("compile") is False
+    assert "compile" not in gateable_keys()
+    assert "compile" in all_feature_keys()
+
+
+def test_plan_families_exact():
+    assert PLAN_FAMILIES == ["free", "basic", "pro", "byok", "team"]
+
+
+def test_keys_unique():
+    keys = all_feature_keys()
+    assert len(keys) == len(set(keys))
+
+
+def test_get_feature_known_and_unknown():
+    cover = get_feature("cover_letters")
+    assert cover is not None
+    assert cover.key == "cover_letters"
+    assert cover.gateable is True
+    assert get_feature("does_not_exist") is None
+
+
+def test_is_gateable_correctness():
+    assert is_gateable("cover_letters") is True
+    assert is_gateable("compile") is False  # known but non-gateable
+    assert is_gateable("totally_unknown_key") is False  # unknown → not gateable
+
+
+def test_gateable_keys_are_subset_of_all_keys():
+    all_keys = set(all_feature_keys())
+    for key in gateable_keys():
+        assert key in all_keys
+    # Every gateable key is genuinely gateable.
+    for key in gateable_keys():
+        assert is_gateable(key) is True
+
+
+def test_every_feature_has_required_fields():
+    valid_categories = {
+        "core", "editor", "career", "advanced", "integrations", "analytics",
+    }
+    for f in FEATURE_REGISTRY:
+        assert f.key and isinstance(f.key, str)
+        assert f.label and isinstance(f.label, str)
+        assert f.category in valid_categories
+        assert f.description and isinstance(f.description, str)


### PR DESCRIPTION
Registry/service/enforcement/admin-API tests + a guard test that no gateable feature is left unwired.

Closes #886. Part of #877.