### PR TITLE
fix(api): pass through pre-formed error envelopes (feature_disabled 403)

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -62,6 +62,24 @@ async def _http_handler(request: Request, exc: StarletteHTTPException) -> JSONRe
     # HTTPException.detail is developer-authored (safe to surface). Preserve any
     # headers (e.g. WWW-Authenticate, Retry-After) the raising code attached.
     detail = exc.detail if isinstance(exc.detail, (str, list, dict)) else str(exc.detail)
+
+    # If the raiser already built an error envelope via error_body() — e.g.
+    # require_feature() raising {"error": {"code": "feature_disabled", ...}} —
+    # pass it through as the top-level envelope instead of double-wrapping it
+    # under a generic "http_error". This preserves the specific error code the
+    # client (and frontend gating) keys on.
+    if isinstance(detail, dict) and isinstance(detail.get("error"), dict):
+        body = dict(detail)
+        inner = dict(body["error"])
+        if not inner.get("request_id"):
+            inner["request_id"] = _request_id(request)
+        body["error"] = inner
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=body,
+            headers=getattr(exc, "headers", None),
+        )
+
     message = detail if isinstance(detail, str) else "Request failed."
     return JSONResponse(
         status_code=exc.status_code,

--- a/backend/test/test_error_envelope.py
+++ b/backend/test/test_error_envelope.py
@@ -42,6 +42,12 @@ def _build_app() -> FastAPI:
     async def validate(payload: dict):
         return payload
 
+    @app.get("/gated")
+    async def gated():
+        # Mimics require_feature(): raises an HTTPException whose detail is
+        # already an error envelope built via error_body().
+        raise HTTPException(status_code=403, detail=error_body("feature_disabled", "The 'x' feature is not available on your plan.", None))
+
     return app
 
 
@@ -52,6 +58,23 @@ async def _client(app: FastAPI) -> AsyncClient:
         transport=ASGITransport(app=app, raise_app_exceptions=False),
         base_url="http://test",
     )
+
+
+async def test_preformed_error_envelope_passes_through_without_double_wrap():
+    """An HTTPException whose detail is already an error_body() envelope is
+    surfaced as the top-level envelope (specific code preserved, not wrapped
+    under a generic http_error)."""
+    app = _build_app()
+    async with await _client(app) as ac:
+        resp = await ac.get("/gated")
+    assert resp.status_code == 403
+    body = resp.json()
+    err = body["error"]
+    assert err["code"] == "feature_disabled"
+    assert "not available on your plan" in err["message"]
+    assert "request_id" in err  # present (value depends on request-context middleware)
+    # not double-wrapped under a nested detail.error envelope
+    assert not isinstance(body.get("detail"), dict)
 
 
 async def test_unhandled_exception_returns_generic_500_envelope():


### PR DESCRIPTION
Found via production E2E of the entitlement gate. Fixes the double-wrapped `feature_disabled` 403 so the top-level `error.code` is preserved (frontend gating keys on it). Adds a regression test. Closes #908.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses when an error envelope is already provided.
  * Preserved the original error code, message, request ID, and response headers.
  * Prevented error details from being unnecessarily nested or double-wrapped.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->