### PR TITLE
fix(frontend): remove /api/* rewrite breaking Better Auth; skip vercel.app in middleware

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -26,8 +26,15 @@ export async function middleware(request: NextRequest) {
   // Strip port for local dev
   const hostname = host.replace(/:\d+$/, '')
 
-  // Known Latexy domains → skip
-  if (LATEXY_DOMAINS.has(hostname)) {
+  // Known Latexy domains, the app's own Vercel deployment domains, and the
+  // primary marketing domain → skip (these are NOT custom portfolio domains,
+  // so we must not do a per-request resolve-domain lookup or rewrite them).
+  if (
+    LATEXY_DOMAINS.has(hostname) ||
+    hostname.endsWith('.vercel.app') ||
+    hostname === 'latexy.com' ||
+    hostname === 'www.latexy.com'
+  ) {
     return NextResponse.next()
   }
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,11 +2,5 @@
   "framework": "nextjs",
   "installCommand": "pnpm install --no-frozen-lockfile",
   "buildCommand": "pnpm run build",
-  "outputDirectory": ".next",
-  "rewrites": [
-    {
-      "source": "/api/:path*",
-      "destination": "https://sanskarpandey2004--latexy-backend-fastapi-app.modal.run/:path*"
-    }
-  ]
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
Found via production deploy verification. The vercel.json /api/* rewrite proxied Next-owned /api/auth and /api/byok routes to the backend, 404ing auth. Removes the rewrite (nothing relies on it — apiClient uses NEXT_PUBLIC_API_URL directly). Also skips *.vercel.app/latexy.com in the portfolio-domain middleware. Closes #910.