### PR TITLE
fix(analytics): /analytics/me 500 (Postgres GroupingError)

### DIFF
--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.redis import cache_manager, redis_manager
@@ -157,7 +157,9 @@ class AnalyticsService:
                     UsageAnalytics.user_id == user_id,
                     UsageAnalytics.created_at >= start_date,
                 )
-            ).group_by(func.date_trunc("day", UsageAnalytics.created_at))
+            ).group_by(text("1"))  # GROUP BY the 1st SELECT expr (date_trunc);
+            # avoids SQLAlchemy binding the 'day' literal twice ($1 vs $N), which
+            # Postgres rejects with "must appear in GROUP BY" (GroupingError).
             daily_rows = (await db.execute(daily_agg_query)).all()
             daily_activity = {
                 row.day.strftime("%Y-%m-%d"): row.cnt

--- a/backend/test/test_analytics_visualization.py
+++ b/backend/test/test_analytics_visualization.py
@@ -121,6 +121,45 @@ async def test_me_timeseries_returns_series_data(client: AsyncClient, db_session
     assert any(point['count'] >= 1 for point in body['feature_series'])
 
 
+async def test_me_daily_analytics_groups_by_day(client: AsyncClient, db_session: AsyncSession):
+    """GET /analytics/me must aggregate daily activity without a Postgres
+    GroupingError (regression: date_trunc('day', ...) was bound twice, so PG
+    rejected the GROUP BY). Uses usage rows across multiple days."""
+    user_id = str(uuid4())
+    now = datetime.now(timezone.utc)
+
+    db_session.add(
+        User(
+            id=user_id,
+            email=f'test_{user_id[:8]}@example.com',
+            name='Daily Analytics User',
+            email_verified=True,
+            subscription_plan='free',
+            subscription_status='active',
+            trial_used=False,
+        )
+    )
+    db_session.add_all([
+        UsageAnalytics(
+            user_id=user_id, device_fingerprint=None, action='compile',
+            resource_type='resume', event_metadata={'feature': 'compile'},
+            created_at=now - timedelta(days=d),
+        )
+        for d in (0, 0, 1, 3)
+    ])
+    await db_session.commit()
+
+    token = make_jwt(user_id)
+    response = await client.get('/analytics/me?days=30', headers={'Authorization': f'Bearer {token}'})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body['user_id'] == user_id
+    # daily_activity is a {date: count} map aggregated in SQL by day
+    assert isinstance(body['daily_activity'], dict)
+    assert sum(body['daily_activity'].values()) >= 4
+
+
 @pytest.mark.asyncio
 async def test_admin_analytics_routes_require_admin(client: AsyncClient, db_session: AsyncSession):
     no_auth = await client.get('/analytics/system?days=7')


### PR DESCRIPTION
Dashboard 500 fixed — GROUP BY 1 ordinal avoids the duplicated date_trunc bind. + regression test. Closes #926. Found via prod functional E2E.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily analytics aggregation to correctly group activity by date.
  * Fixed an issue that could cause analytics requests to fail when retrieving daily activity.

* **Tests**
  * Added coverage verifying daily activity results and event counts across multiple days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->