### PR TITLE
fix(jobs): polling fallback so compile→PDF renders without live WS events

### DIFF
--- a/frontend/src/hooks/useJobStream.ts
+++ b/frontend/src/hooks/useJobStream.ts
@@ -4,6 +4,7 @@
 
 import { useEffect, useReducer, useCallback } from 'react'
 import { wsClient } from '@/lib/ws-client'
+import { apiClient } from '@/lib/api-client'
 import type { AnyEvent } from '@/lib/event-types'
 import {
   jobStreamReducer,
@@ -49,6 +50,67 @@ export function useJobStream(jobId: string | null): UseJobStreamResult {
     return () => {
       wsClient.off('event', handleEvent)
       wsClient.unsubscribe(jobId)
+    }
+  }, [jobId])
+
+  // REST polling fallback: real-time job events are delivered via Redis Pub/Sub
+  // from the worker to the API process. When that fanout does not reach this
+  // client (e.g. cross-container Pub/Sub on serverless Redis in production), the
+  // WS subscribes but never receives a terminal event, so the PDF never loads.
+  // Poll the authoritative job state/result and synthesize the terminal event.
+  // The reducer ignores post-terminal transitions, so this never conflicts with
+  // a WS event that arrives first.
+  useEffect(() => {
+    if (!jobId) return
+    let stopped = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const poll = async () => {
+      try {
+        const snap = await apiClient.getJobState(jobId)
+        if (stopped) return
+        if (snap?.status === 'completed') {
+          let result: Record<string, unknown> = {}
+          try {
+            const res = (await apiClient.getJobResult(jobId)) as unknown as Record<string, unknown>
+            result = (res?.result as Record<string, unknown>) ?? res ?? {}
+          } catch {
+            /* result fetch best-effort */
+          }
+          if (stopped) return
+          dispatch({
+            type: 'job.completed',
+            job_id: jobId,
+            pdf_job_id: (result.pdf_job_id as string) ?? jobId,
+            ats_score: result.ats_score,
+            ats_details: result.ats_details,
+            changes_made: result.changes_made,
+            compilation_time: result.compilation_time,
+            optimization_time: result.optimization_time,
+            tokens_used: result.tokens_used,
+            page_count: result.page_count,
+          } as unknown as AnyEvent)
+          return // terminal → stop polling
+        }
+        if (snap?.status === 'failed') {
+          dispatch({
+            type: 'job.failed',
+            job_id: jobId,
+            error: (snap as unknown as Record<string, unknown>)?.error ?? 'Job failed',
+          } as unknown as AnyEvent)
+          return
+        }
+      } catch {
+        /* transient — keep polling */
+      }
+      if (!stopped) timer = setTimeout(poll, 4000)
+    }
+
+    // Delay the first poll so a healthy WS stream gets the first chance.
+    timer = setTimeout(poll, 4000)
+    return () => {
+      stopped = true
+      if (timer) clearTimeout(timer)
     }
   }, [jobId])
 


### PR DESCRIPTION
Core compile feature: PDF never rendered on prod because useJobStream had no polling fallback and WS terminal events don't fan out cross-container on Upstash. Adds a state/result poll that synthesizes the terminal event. Closes #930.