### PR TITLE
fix: optimize+compile (combined job) on Modal — texlive + PDF caching

### DIFF
--- a/backend/app/workers/orchestrator.py
+++ b/backend/app/workers/orchestrator.py
@@ -625,6 +625,21 @@ def _run_latex_stage(
                 _pdf_bytes = pdf_file.stat().st_size
             except OSError:
                 _pdf_bytes = None
+            # Cache the PDF bytes in Redis so GET /download/{job_id} can serve
+            # them from the API container. On Modal the orchestrator worker's
+            # filesystem is NOT shared with the API, and job_dir is rmtree'd in
+            # the finally below — without this the combined-job PDF is lost.
+            try:
+                import base64 as _b64
+
+                from ..workers.event_publisher import get_worker_redis
+                get_worker_redis().setex(
+                    f"latexy:job:{job_id}:pdf",
+                    settings.JOB_RESULT_TTL,
+                    _b64.b64encode(pdf_file.read_bytes()).decode(),
+                )
+            except Exception as _redis_exc:
+                logger.warning(f"Failed to cache orchestrator PDF in Redis for job {job_id}: {_redis_exc}")
             record_compile(
                 "success",
                 duration_seconds=_compile_duration,

--- a/backend/modal_app.py
+++ b/backend/modal_app.py
@@ -112,7 +112,10 @@ def run_latex_task(payload: dict) -> None:
 
 
 @app.function(
-    image=worker_image,
+    # latex_image (not worker_image): the orchestrator compiles LaTeX in-process
+    # during its pipeline, so it needs the full texlive toolchain — otherwise the
+    # compile stage fails (no pdflatex) and the combined job retries/stalls.
+    image=latex_image,
     secrets=_secrets,
     timeout=600,
     scaledown_window=60,


### PR DESCRIPTION
Combined job stalled (orchestrator image lacked texlive) and PDF 404'd (not cached to Redis). Fixed both; verified on prod (job completes, PDF 80KB downloads). Closes #934.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resume PDFs can now be downloaded reliably in deployed environments, even when processing and API services use separate filesystems.
  * Improved LaTeX compilation compatibility by ensuring the required compilation tools are available during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->