### PR TITLE
feat: custom domain cutover — latexy.xyz

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -72,10 +72,13 @@ class Settings(BaseSettings):
             "http://localhost:5183",
             "http://127.0.0.1:5183",
             # Production
+            "https://latexy.xyz",
+            "https://www.latexy.xyz",
             "https://latexy.com",
             "https://www.latexy.com",
             "https://app.latexy.com",
             "https://latexy.vercel.app",
+            "https://latexy-frontend-tau.vercel.app",
         ]
     )
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -127,10 +127,15 @@ export const auth = betterAuth({
   secret: getAuthSecret(),
   baseURL: process.env.BETTER_AUTH_URL || 'http://localhost:5180',
 
-  // Trust requests from both the frontend and the FastAPI backend
+  // Trust requests from both the frontend and the FastAPI backend.
+  // Includes the custom domain + the Vercel deployment URL so auth keeps
+  // working during/after the domain cutover regardless of BETTER_AUTH_URL.
   trustedOrigins: [
     process.env.BETTER_AUTH_URL || 'http://localhost:5180',
     process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8030',
+    'https://latexy.xyz',
+    'https://www.latexy.xyz',
+    'https://latexy-frontend-tau.vercel.app',
   ],
 
   // Session configuration

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 const LATEXY_DOMAINS = new Set([
+  'latexy.xyz',
+  'www.latexy.xyz',
   'latexy.io',
   'www.latexy.io',
   'localhost',


### PR DESCRIPTION
Wires the app to serve on the primary domain `latexy.xyz`.

- middleware: treat `latexy.xyz`/`www` as first-party (skip portfolio routing) — closes #937
- auth: add `latexy.xyz` (+ www + Vercel URL) to Better Auth trustedOrigins — closes #938
- config: add `latexy.xyz` to default backend CORS_ORIGINS — closes #939

Server-side already live: domain attached to Vercel `latexy-frontend`, GoDaddy DNS pointed (A `@`→76.76.21.21, CNAME `www`→apex; Vercel `misconfigured: false`), Modal secret CORS_ORIGINS + BETTER_AUTH_URL updated and backend redeployed (verified 200 + allow-origin echo), Vercel env BETTER_AUTH_URL/NEXT_PUBLIC_APP_URL → https://latexy.xyz. Merging this bakes the code changes into the frontend build so auth works on latexy.xyz (and the Vercel URL keeps working).

Epic #936.