### PR TITLE
perf + visual/functional hardening: warm compile, 500 guards, CORS-on-error, dropdown clipping, mobile overflow

### DIFF
--- a/backend/app/api/interview_routes.py
+++ b/backend/app/api/interview_routes.py
@@ -156,6 +156,12 @@ async def get_interview_prep(
     db: AsyncSession = Depends(get_db),
 ):
     """Get a specific interview prep session."""
+    # prep_id is UUID-typed; a non-UUID literal (e.g. "my") falling through to
+    # this catch-all route would raise asyncpg DataError -> 500. Return 404.
+    try:
+        uuid.UUID(str(prep_id))
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(status_code=404, detail="Interview prep not found")
     result = await db.execute(
         select(InterviewPrep).where(
             InterviewPrep.id == prep_id,

--- a/backend/app/api/resume_routes.py
+++ b/backend/app/api/resume_routes.py
@@ -5,7 +5,7 @@ import secrets
 import zipfile
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import StreamingResponse
@@ -778,6 +778,13 @@ async def get_resume(
     user_id: str = Depends(get_current_user_required)
 ):
     """Get a specific resume by ID."""
+    # resume_id is UUID-typed in the DB; a non-UUID path segment (e.g. an
+    # unmatched literal like "dashboard" falling through to this catch-all route)
+    # would otherwise raise asyncpg DataError -> 500. Treat it as 404.
+    try:
+        UUID(str(resume_id))
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(status_code=404, detail="Resume not found")
     variant_count_sq = _variant_count_subquery()
     result = await db.execute(
         select(Resume, variant_count_sq)

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -25,6 +25,10 @@ instrument_celery()
 logger = get_logger(__name__)
 _task_start_times: dict[str, float] = {}
 
+# On Modal, worker tasks execute in-process (`.apply()`) and results are never
+# read from the Celery backend, so we disable eager-result storage there.
+_IS_MODAL = (settings.DEPLOY_TARGET or "").lower() == "modal"
+
 # Create Celery instance
 celery_app = Celery(
     "latexy",
@@ -69,8 +73,14 @@ celery_app.conf.update(
     # Task configuration
     task_always_eager=False,
     task_eager_propagates=True,
-    task_ignore_result=False,
-    task_store_eager_result=True,
+    # On Modal, tasks run in-process via `.apply()` and job state/results are
+    # published to Redis directly by the event_publisher — we never read the
+    # Celery result backend. Storing eager results there makes Celery connect to
+    # CELERY_RESULT_BACKEND (localhost by default on Modal), which raises
+    # ConnectionError on every task and *fails* cold-start compiles. Disable
+    # result storage on Modal to avoid the wasted round-trip and the failures.
+    task_ignore_result=_IS_MODAL,
+    task_store_eager_result=not _IS_MODAL,
 
     # Result backend configuration
     result_expires=settings.JOB_RESULT_TTL,

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -17,6 +17,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from .config import settings
 from .logging import get_logger
 from .observability import get_log_context
 
@@ -28,6 +29,38 @@ def _request_id(request: Request) -> str | None:
     if rid:
         return rid
     return get_log_context().get("request_id")
+
+
+def _cors_headers(request: Request) -> dict[str, str]:
+    """CORS headers for error responses.
+
+    Exception handlers return a JSONResponse directly, which bypasses
+    CORSMiddleware (a Starlette ASGI-ordering limitation). Without this, every
+    5xx / cold-start error reaches the browser WITHOUT an
+    Access-Control-Allow-Origin header, so the browser reports a misleading
+    "blocked by CORS policy" / net::ERR_FAILED instead of the real error. Echo
+    the request Origin when it is allowed so errors surface truthfully.
+    """
+    origin = request.headers.get("origin")
+    if not origin:
+        return {}
+    try:
+        allowed = settings.effective_cors_origins()
+    except Exception:
+        allowed = settings.CORS_ORIGINS or []
+    if origin in allowed or "*" in allowed:
+        return {
+            "access-control-allow-origin": origin,
+            "access-control-allow-credentials": "true",
+            "vary": "Origin",
+        }
+    return {}
+
+
+def _merge_headers(request: Request, headers: dict | None) -> dict:
+    merged = dict(headers or {})
+    merged.update(_cors_headers(request))
+    return merged
 
 
 def error_body(code: str, message: str, request_id: str | None, details: Any = None, *, detail_compat: Any = None) -> dict:
@@ -55,6 +88,7 @@ async def _validation_handler(request: Request, exc: RequestValidationError) -> 
             "validation_error", "Request validation failed.", _request_id(request),
             details=details, detail_compat=details,
         ),
+        headers=_merge_headers(request, None),
     )
 
 
@@ -77,14 +111,14 @@ async def _http_handler(request: Request, exc: StarletteHTTPException) -> JSONRe
         return JSONResponse(
             status_code=exc.status_code,
             content=body,
-            headers=getattr(exc, "headers", None),
+            headers=_merge_headers(request, getattr(exc, "headers", None)),
         )
 
     message = detail if isinstance(detail, str) else "Request failed."
     return JSONResponse(
         status_code=exc.status_code,
         content=error_body("http_error", message, _request_id(request), detail_compat=detail),
-        headers=getattr(exc, "headers", None),
+        headers=_merge_headers(request, getattr(exc, "headers", None)),
     )
 
 
@@ -99,6 +133,7 @@ async def _unhandled_handler(request: Request, exc: Exception) -> JSONResponse:
     return JSONResponse(
         status_code=500,
         content=error_body("internal_error", "An internal error occurred.", rid, detail_compat="Internal Server Error"),
+        headers=_merge_headers(request, None),
     )
 
 

--- a/backend/modal_app.py
+++ b/backend/modal_app.py
@@ -99,7 +99,12 @@ def _init_worker_redis() -> None:
     image=latex_image,
     secrets=_secrets,
     timeout=300,
-    scaledown_window=60,
+    # Keep one worker warm at all times. The texlive image cold-starts in ~40-45s,
+    # which dominated compile latency (warm compile work is only ~3.5s). min_containers=1
+    # eliminates the cold start for the common single-compile path. scaledown_window keeps
+    # extra burst containers around briefly so bursts stay warm too.
+    min_containers=1,
+    scaledown_window=120,
 )
 def run_latex_task(payload: dict) -> None:
     """Compile LaTeX to PDF (texlive installed in image; no Docker needed)."""
@@ -118,7 +123,10 @@ def run_latex_task(payload: dict) -> None:
     image=latex_image,
     secrets=_secrets,
     timeout=600,
-    scaledown_window=60,
+    # No min_containers here (cost): combined jobs are LLM-dominated (~40s), so a cold
+    # start is proportionally smaller. A longer scaledown_window keeps back-to-back
+    # optimize runs on a warm container. Bump to min_containers=1 if optimize latency matters.
+    scaledown_window=180,
 )
 def run_orchestrator_task(payload: dict) -> None:
     """Combined LLM optimisation → LaTeX compilation → ATS scoring pipeline."""

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -539,7 +539,7 @@ function UsersTab() {
             <table className="w-full min-w-[560px] border-collapse text-sm">
               <thead>
                 <tr className="border-b border-white/[0.07] text-[11px] uppercase tracking-wider text-zinc-500">
-                  <th className="min-w-[220px] px-4 py-3 text-left font-semibold">User</th>
+                  <th className="sticky left-0 z-10 min-w-[220px] bg-zinc-950 px-4 py-3 text-left font-semibold">User</th>
                   <th className="min-w-[90px] px-4 py-3 text-left font-semibold">Plan</th>
                   <th className="min-w-[130px] px-4 py-3 text-left font-semibold">Role</th>
                 </tr>
@@ -548,9 +548,9 @@ function UsersTab() {
                 {users.map((u, idx) => (
                   <tr
                     key={u.id}
-                    className={`border-t border-white/[0.04] ${idx % 2 === 1 ? 'bg-white/[0.012]' : ''}`}
+                    className={`group border-t border-white/[0.04] ${idx % 2 === 1 ? 'bg-white/[0.012]' : ''}`}
                   >
-                    <td className="px-4 py-3">
+                    <td className="sticky left-0 z-10 min-w-[220px] bg-zinc-950 px-4 py-3">
                       <div className="flex items-center gap-2">
                         <span className="truncate text-sm font-medium text-zinc-100">{u.email}</span>
                         {u.email_verified && (

--- a/frontend/src/app/tracker/page.tsx
+++ b/frontend/src/app/tracker/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Plus, MoreHorizontal, ExternalLink, Trash2, Pencil, X } from 'lucide-react'
@@ -96,6 +97,28 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
   const { attributes, listeners, setNodeRef, transform, transition, isDragging: sortableDragging } =
     useSortable({ id: app.id })
   const [menuOpen, setMenuOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const menuTriggerRef = useRef<HTMLButtonElement>(null)
+  const [menuPos, setMenuPos] = useState<{ top?: number; bottom?: number; right: number } | null>(null)
+
+  useEffect(() => { setMounted(true) }, [])
+
+  function openMenu() {
+    if (menuTriggerRef.current) {
+      const rect = menuTriggerRef.current.getBoundingClientRect()
+      const margin = 8
+      const menuHeight = 88 // approx height of 2-item menu
+      const right = Math.max(margin, window.innerWidth - rect.right)
+      const spaceBelow = window.innerHeight - rect.bottom - margin
+      // Flip upward when there isn't enough room below the trigger.
+      if (spaceBelow < menuHeight) {
+        setMenuPos({ bottom: window.innerHeight - rect.top + 4, right })
+      } else {
+        setMenuPos({ top: rect.bottom + 4, right })
+      }
+    }
+    setMenuOpen(true)
+  }
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -146,22 +169,34 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
       {/* Overflow menu */}
       <div className="absolute right-2 top-2 opacity-0 group-hover:opacity-100 transition">
         <button
+          ref={menuTriggerRef}
           type="button"
-          onClick={(e) => { e.stopPropagation(); setMenuOpen((v) => !v) }}
+          onClick={(e) => { e.stopPropagation(); menuOpen ? setMenuOpen(false) : openMenu() }}
           className="rounded p-1 text-zinc-600 transition hover:bg-white/5 hover:text-zinc-300"
         >
           <MoreHorizontal size={14} />
         </button>
-        {menuOpen && (
+        {/* Rendered via portal to document.body with fixed positioning so the
+            menu escapes the column's overflow-y-auto and the board's
+            overflow-x-auto clipping. */}
+        {mounted && menuOpen && menuPos && createPortal(
           <>
             <button
               type="button"
-              className="fixed inset-0 z-10"
+              className="fixed inset-0 z-[200]"
               onClick={() => setMenuOpen(false)}
               aria-label="Close menu"
               tabIndex={-1}
             />
-            <div className="absolute right-0 top-6 z-20 w-36 rounded-xl border border-white/10 bg-zinc-900 p-1 shadow-xl">
+            <div
+              className="z-[201] w-36 rounded-xl border border-white/10 bg-zinc-900 p-1 shadow-xl"
+              style={{
+                position: 'fixed',
+                top: menuPos.top,
+                bottom: menuPos.bottom,
+                right: menuPos.right,
+              }}
+            >
               <button
                 type="button"
                 onClick={() => { setMenuOpen(false); onEdit(app) }}
@@ -177,7 +212,8 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
                 <Trash2 size={12} /> Delete
               </button>
             </div>
-          </>
+          </>,
+          document.body
         )}
       </div>
     </div>

--- a/frontend/src/app/workspace/[resumeId]/career/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/career/page.tsx
@@ -203,7 +203,7 @@ export default function CareerPathPage() {
                 />
                 {/* Autocomplete dropdown */}
                 {showSuggestions && suggestions.length > 0 && (
-                  <div className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-lg border border-white/[0.06] bg-[#111] shadow-xl">
+                  <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-y-auto rounded-lg border border-white/[0.06] bg-[#111] shadow-xl">
                     {suggestions.map((role) => (
                       <button
                         key={role.id}

--- a/frontend/src/app/workspace/[resumeId]/edit/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/edit/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
@@ -748,6 +749,12 @@ export default function ResumeEditPage() {
 
   // Layout
   const [rightTab, setRightTab] = useState<RightTab>('preview')
+  const rightTabBarRef = useRef<HTMLDivElement>(null)
+  const activeRightTabRef = useRef<HTMLButtonElement>(null)
+  // Keep the active right-panel tab scrolled into view within the horizontal scroller
+  useEffect(() => {
+    activeRightTabRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  }, [rightTab])
   const [rightWidth, setRightWidth] = useState<number | null>(null)
   const [showOutline, setShowOutline] = useState(false)
   const [isDraggingResize, setIsDraggingResize] = useState(false)
@@ -823,6 +830,19 @@ export default function ResumeEditPage() {
   const [forkPopoverOpen, setForkPopoverOpen] = useState(false)
   const [forkTitleInput, setForkTitleInput] = useState('')
   const [isForkingResume, setIsForkingResume] = useState(false)
+  const forkTriggerRef = useRef<HTMLButtonElement>(null)
+  const [forkPopoverPos, setForkPopoverPos] = useState<{ top: number; right: number } | null>(null)
+  const openForkPopover = useCallback(() => {
+    const rect = forkTriggerRef.current?.getBoundingClientRect()
+    if (rect) {
+      setForkPopoverPos({
+        top: rect.bottom + 6,
+        right: Math.max(12, window.innerWidth - rect.right),
+      })
+    }
+    setForkTitleInput(`${title} — Variant`)
+    setForkPopoverOpen(true)
+  }, [title])
   const [academicReport, setAcademicReport] = useState<AcademicCVReport | null>(null)
   const [academicConvertOpen, setAcademicConvertOpen] = useState(false)
   const [academicTargetIndustry, setAcademicTargetIndustry] = useState<'tech' | 'data_science' | 'finance' | 'consulting' | 'product' | 'other'>('tech')
@@ -1915,30 +1935,40 @@ export default function ResumeEditPage() {
           {/* Create Variant button */}
           <div className="relative">
             <button
-              onClick={() => { setForkPopoverOpen(v => !v); setForkTitleInput(`${title} — Variant`) }}
+              ref={forkTriggerRef}
+              onClick={() => { if (forkPopoverOpen) { setForkPopoverOpen(false) } else { openForkPopover() } }}
               className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
             >
               <GitFork size={12} />
               Variant
             </button>
-            {forkPopoverOpen && (
-              <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-white/10 bg-zinc-950 p-3 shadow-xl">
-                <input
-                  type="text"
-                  value={forkTitleInput}
-                  onChange={e => setForkTitleInput(e.target.value)}
-                  onKeyDown={e => { if (e.key === 'Enter') handleCreateVariant(); if (e.key === 'Escape') setForkPopoverOpen(false) }}
-                  placeholder="Variant title"
-                  autoFocus
-                  className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-xs text-zinc-100 outline-none focus:border-orange-300/40 mb-2"
-                />
-                <div className="flex gap-2 justify-end">
-                  <button onClick={() => setForkPopoverOpen(false)} className="px-2 py-1 text-[10px] text-zinc-500 hover:text-zinc-300">Cancel</button>
-                  <button onClick={handleCreateVariant} disabled={isForkingResume} className="rounded-md bg-orange-500/20 px-3 py-1 text-[10px] font-semibold text-orange-200 ring-1 ring-orange-400/20 hover:bg-orange-500/30 disabled:opacity-50">
-                    {isForkingResume ? 'Creating...' : 'Create'}
-                  </button>
+            {forkPopoverOpen && forkPopoverPos && createPortal(
+              <>
+                {/* Backdrop */}
+                <div className="fixed inset-0 z-[200]" onClick={() => setForkPopoverOpen(false)} />
+                {/* Popover — fixed positioning from trigger rect so the scrolling toolbar can't clip it */}
+                <div
+                  className="z-[201] w-64 rounded-lg border border-white/10 bg-zinc-950 p-3 shadow-xl"
+                  style={{ position: 'fixed', top: forkPopoverPos.top, right: forkPopoverPos.right }}
+                >
+                  <input
+                    type="text"
+                    value={forkTitleInput}
+                    onChange={e => setForkTitleInput(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') handleCreateVariant(); if (e.key === 'Escape') setForkPopoverOpen(false) }}
+                    placeholder="Variant title"
+                    autoFocus
+                    className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-xs text-zinc-100 outline-none focus:border-orange-300/40 mb-2"
+                  />
+                  <div className="flex gap-2 justify-end">
+                    <button onClick={() => setForkPopoverOpen(false)} className="px-2 py-1 text-[10px] text-zinc-500 hover:text-zinc-300">Cancel</button>
+                    <button onClick={handleCreateVariant} disabled={isForkingResume} className="rounded-md bg-orange-500/20 px-3 py-1 text-[10px] font-semibold text-orange-200 ring-1 ring-orange-400/20 hover:bg-orange-500/30 disabled:opacity-50">
+                      {isForkingResume ? 'Creating...' : 'Create'}
+                    </button>
+                  </div>
                 </div>
-              </div>
+              </>,
+              document.body
             )}
           </div>
 
@@ -2407,7 +2437,11 @@ export default function ResumeEditPage() {
           }
         >
           {/* Tab bar */}
-          <div className="flex h-9 shrink-0 items-center overflow-x-auto whitespace-nowrap border-b border-white/[0.05] bg-black/20 px-1 scrollbar-none">
+          <div
+            ref={rightTabBarRef}
+            className="flex h-9 shrink-0 snap-x items-center overflow-x-auto whitespace-nowrap border-b border-white/[0.05] bg-black/20 px-1 pr-3 scrollbar-none"
+            style={{ WebkitOverflowScrolling: 'touch' }}
+          >
             {(
               [
                 { id: 'preview', label: 'Preview', icon: Eye },
@@ -2431,8 +2465,9 @@ export default function ResumeEditPage() {
             ).map(({ id, label, icon: Icon }) => (
               <button
                 key={id}
+                ref={rightTab === id ? activeRightTabRef : undefined}
                 onClick={() => setRightTab(id)}
-                className={`relative flex shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium transition ${
+                className={`relative flex shrink-0 snap-start items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium transition ${
                   rightTab === id ? 'text-zinc-100' : 'text-zinc-600 hover:text-zinc-300'
                 }`}
               >

--- a/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
@@ -387,13 +387,13 @@ export default function OptimizationSuitePage() {
 
   return (
     <div className="content-shell min-h-screen space-y-6 pb-12">
-      <header className="flex items-end justify-between gap-4">
-        <div>
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0">
           <p className="overline">Optimization</p>
           <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">Targeted Optimization</h1>
           <p className="mt-1 text-sm text-zinc-400">Optimize "{resume?.title}" — add a job description to tailor it to a specific role, or leave blank for general improvements.</p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2 sm:flex-nowrap sm:shrink-0">
           <div className="relative">
             <button
               onClick={() => { setForkPopoverOpen(v => !v); setForkTitleInput(`${resume?.title ?? ''} — Variant`) }}
@@ -452,8 +452,8 @@ export default function OptimizationSuitePage() {
         </div>
       )}
 
-      <div className="grid gap-6 lg:grid-cols-[380px_1fr]">
-        <aside className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-[380px_minmax(0,1fr)]">
+        <aside className="min-w-0 space-y-6">
           {/* ── Persona selector (Feature 56) ── */}
           <section className="surface-panel edge-highlight p-5">
             <div className="flex items-center justify-between">
@@ -616,12 +616,12 @@ export default function OptimizationSuitePage() {
           </section>
         </aside>
 
-        <main className="space-y-6">
+        <main className="min-w-0 space-y-6">
           <div className="grid gap-6 xl:grid-cols-2">
-            <section className="surface-panel edge-highlight flex h-[620px] flex-col overflow-hidden">
-              <div className="flex h-11 items-center justify-between border-b border-white/10 bg-white/[0.03] px-4">
-                <div className="flex items-center gap-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">LaTeX Source</p>
+            <section className="surface-panel edge-highlight flex h-[620px] min-w-0 flex-col overflow-hidden">
+              <div className="flex h-11 items-center justify-between gap-2 border-b border-white/10 bg-white/[0.03] px-4">
+                <div className="flex min-w-0 items-center gap-3 overflow-x-auto">
+                  <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">LaTeX Source</p>
                   <button
                     onClick={toggleAutoCompile}
                     title="Auto-compile on change (2s debounce)"
@@ -642,7 +642,7 @@ export default function OptimizationSuitePage() {
                     disabled={isProcessing || isSubmitting}
                   />
                 </div>
-                <button onClick={restoreOriginal} className="text-xs font-semibold text-zinc-300 transition hover:text-white">
+                <button onClick={restoreOriginal} className="shrink-0 text-xs font-semibold text-zinc-300 transition hover:text-white">
                   Restore Original
                 </button>
               </div>
@@ -660,7 +660,7 @@ export default function OptimizationSuitePage() {
                   </button>
                 </div>
               )}
-              <div className="relative min-h-0 flex-1 bg-black/20">
+              <div className="relative min-h-0 min-w-0 flex-1 overflow-x-auto bg-black/20">
                 <LaTeXEditor
                   ref={editorRef}
                   value={resume?.latex_content || ''}
@@ -686,9 +686,9 @@ export default function OptimizationSuitePage() {
               </div>
             </section>
 
-            <section className="surface-panel edge-highlight flex h-[620px] flex-col overflow-hidden">
-              <div className="flex h-11 items-center justify-between border-b border-white/10 bg-white/[0.03] px-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Output Preview</p>
+            <section className="surface-panel edge-highlight flex h-[620px] min-w-0 flex-col overflow-hidden">
+              <div className="flex h-11 items-center justify-between gap-2 border-b border-white/10 bg-white/[0.03] px-4">
+                <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Output Preview</p>
                 <div className="flex items-center gap-3">
                   {compareAfterLatex !== null && compareOriginalLatex !== null && (
                     <button
@@ -713,12 +713,12 @@ export default function OptimizationSuitePage() {
 
           <section className="surface-panel edge-highlight overflow-hidden">
             {/* Tab bar */}
-            <div className="flex border-b border-white/10">
+            <div className="flex overflow-x-auto border-b border-white/10">
               {(['ATS Simulator', 'Keywords', 'Publications'] as const).map(tab => (
                 <button
                   key={tab}
                   onClick={() => setActiveToolTab(tab)}
-                  className={`px-5 py-3 text-xs font-semibold uppercase tracking-[0.14em] transition ${
+                  className={`shrink-0 px-5 py-3 text-xs font-semibold uppercase tracking-[0.14em] transition ${
                     activeToolTab === tab
                       ? 'border-b-2 border-orange-400 text-orange-300'
                       : 'text-zinc-500 hover:text-zinc-300'

--- a/frontend/src/app/workspace/page.tsx
+++ b/frontend/src/app/workspace/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { BookUser, GitFork, GitMerge, ChevronDown, ChevronRight, Share2, X, Search, Zap, AlertTriangle, BarChart2, Download, Loader2, Tag, Pin, PinOff, Archive, ArchiveRestore, LayoutTemplate, Globe, Send } from 'lucide-react'
@@ -63,6 +63,8 @@ export default function WorkspacePage() {
   const [atsStats, setAtsStats] = useState<ResumeStats | null>(null)
   const [staleBannerDismissed, setStaleBannerDismissed] = useState(false)
   const [exportMenuOpen, setExportMenuOpen] = useState(false)
+  const [exportMenuFlipUp, setExportMenuFlipUp] = useState(false)
+  const exportMenuTriggerRef = useRef<HTMLButtonElement>(null)
   const [exportLoading, setExportLoading] = useState(false)
 
   // Onboarding for new users
@@ -679,7 +681,16 @@ export default function WorkspacePage() {
           {/* Export All dropdown (Feature 49) */}
           <div className="relative">
             <button
-              onClick={() => setExportMenuOpen(o => !o)}
+              ref={exportMenuTriggerRef}
+              onClick={() => {
+                if (!exportMenuOpen && exportMenuTriggerRef.current) {
+                  const rect = exportMenuTriggerRef.current.getBoundingClientRect()
+                  const spaceBelow = window.innerHeight - rect.bottom
+                  const spaceAbove = rect.top
+                  setExportMenuFlipUp(spaceBelow < 220 && spaceAbove > spaceBelow)
+                }
+                setExportMenuOpen(o => !o)
+              }}
               disabled={exportLoading}
               className="btn-ghost flex items-center gap-1.5 px-3 py-2 text-xs"
             >
@@ -692,7 +703,9 @@ export default function WorkspacePage() {
               <ChevronDown size={11} />
             </button>
             {exportMenuOpen && (
-              <div className="absolute right-0 top-full z-20 mt-1 w-44 rounded-lg border border-white/[0.08] bg-[#111] py-1 shadow-xl">
+              <div className={`absolute right-0 z-50 max-h-[min(20rem,calc(100vh-6rem))] w-44 overflow-y-auto rounded-lg border border-white/[0.08] bg-[#111] py-1 shadow-xl ${
+                exportMenuFlipUp ? 'bottom-full mb-1' : 'top-full mt-1'
+              }`}>
                 {([
                   { format: 'tex', label: 'LaTeX Source (.zip)' },
                   { format: 'pdf', label: 'PDF Files (.zip)' },

--- a/frontend/src/components/BulletGeneratorWidget.tsx
+++ b/frontend/src/components/BulletGeneratorWidget.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Check, Loader2, RefreshCw, Sparkles, X } from 'lucide-react'
 import { apiClient, type GenerateBulletsRequest } from '@/lib/api-client'
 
@@ -36,6 +36,12 @@ export default function BulletGeneratorWidget({
   const [insertedIdx, setInsertedIdx]     = useState<number | null>(null)
   const [generationAttempted, setAttempted] = useState(false)
   const containerRef                      = useRef<HTMLDivElement>(null)
+  // Flip/clamp so the panel is never clipped when opened low in the editor.
+  const [placement, setPlacement] = useState<{
+    top?: number
+    bottom?: number
+    maxHeight: number
+  } | null>(null)
 
   // Close on Escape
   useEffect(() => {
@@ -76,10 +82,39 @@ export default function BulletGeneratorWidget({
     setTimeout(onClose, 300)
   }
 
-  if (!isOpen) return null
+  // Anchor position within the positioned editor container.
+  const anchorTop = Math.max(8, top - 4)
 
-  // Clamp to keep widget visible (approximate widget height 380px)
-  const clampedTop = Math.max(8, top - 4)
+  // Measure the panel against the viewport and decide direction + maxHeight.
+  // Runs after the panel mounts at `anchorTop`, then flips upward if there's
+  // more room above, and always caps height so content scrolls inside.
+  useLayoutEffect(() => {
+    if (!isOpen) return
+    const el = containerRef.current
+    if (!el) return
+    const margin = 12
+    // Derive the anchor's viewport position from the positioned parent so the
+    // measurement is stable across re-measures (independent of any flip already
+    // applied to the panel itself).
+    const parent = el.offsetParent as HTMLElement | null
+    const parentRect = parent?.getBoundingClientRect()
+    const parentTop = parentRect?.top ?? 0
+    const parentBottom = parentRect?.bottom ?? window.innerHeight
+    const anchorViewportTop = parentTop + anchorTop
+    const spaceBelow = window.innerHeight - anchorViewportTop - margin
+    const spaceAbove = anchorViewportTop - margin
+    if (spaceBelow < 320 && spaceAbove > spaceBelow) {
+      // Open upward: pin the panel's bottom to the anchor line.
+      setPlacement({
+        bottom: parentBottom - anchorViewportTop,
+        maxHeight: spaceAbove,
+      })
+    } else {
+      setPlacement({ top: anchorTop, maxHeight: Math.max(120, spaceBelow) })
+    }
+  }, [isOpen, top, anchorTop, bullets])
+
+  if (!isOpen) return null
 
   return (
     <>
@@ -93,8 +128,12 @@ export default function BulletGeneratorWidget({
       {/* Widget panel */}
       <div
         ref={containerRef}
-        className="absolute left-4 z-50 w-80 rounded-xl border border-white/[0.1] bg-zinc-950 shadow-2xl shadow-black/60 ring-1 ring-white/[0.06]"
-        style={{ top: clampedTop }}
+        className="absolute left-4 z-50 w-80 overflow-y-auto overscroll-contain rounded-xl border border-white/[0.1] bg-zinc-950 shadow-2xl shadow-black/60 ring-1 ring-white/[0.06]"
+        style={{
+          top: placement?.top ?? (placement?.bottom !== undefined ? undefined : anchorTop),
+          bottom: placement?.bottom,
+          maxHeight: placement?.maxHeight,
+        }}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}

--- a/frontend/src/components/CompilerSelector.tsx
+++ b/frontend/src/components/CompilerSelector.tsx
@@ -44,7 +44,9 @@ export default function CompilerSelector({
 }: CompilerSelectorProps) {
   const [open, setOpen] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [flipUp, setFlipUp] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
 
   const currentOption = COMPILER_OPTIONS.find((o) => o.id === current) ?? COMPILER_OPTIONS[0]
 
@@ -75,10 +77,23 @@ export default function CompilerSelector({
     }
   }
 
+  const toggleOpen = () => {
+    if (disabled || saving) return
+    if (!open && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect()
+      const spaceBelow = window.innerHeight - rect.bottom
+      const spaceAbove = rect.top
+      // Flip up when there isn't enough room below and there's more room above.
+      setFlipUp(spaceBelow < 260 && spaceAbove > spaceBelow)
+    }
+    setOpen((v) => !v)
+  }
+
   return (
     <div ref={ref} className="relative">
       <button
-        onClick={() => !disabled && !saving && setOpen((v) => !v)}
+        ref={triggerRef}
+        onClick={toggleOpen}
         disabled={disabled || saving}
         title="LaTeX compiler engine"
         className={`flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium transition ${
@@ -95,7 +110,9 @@ export default function CompilerSelector({
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-1 w-56 rounded-lg border border-white/10 bg-zinc-950 py-1 shadow-xl">
+        <div className={`absolute right-0 z-50 max-h-[min(20rem,calc(100vh-6rem))] w-56 overflow-y-auto rounded-lg border border-white/10 bg-zinc-950 py-1 shadow-xl ${
+          flipUp ? 'bottom-full mb-1' : 'top-full mt-1'
+        }`}>
           {COMPILER_OPTIONS.map((option) => (
             <button
               key={option.id}

--- a/frontend/src/components/ExportDropdown.tsx
+++ b/frontend/src/components/ExportDropdown.tsx
@@ -63,7 +63,12 @@ export default function ExportDropdown({
   const [isOpen, setIsOpen] = useState(false)
   const [loading, setLoading] = useState<ExportFormatKey | null>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
-  const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null)
+  const [dropdownPos, setDropdownPos] = useState<{
+    top?: number
+    bottom?: number
+    right: number
+    maxHeight: number
+  } | null>(null)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => { setMounted(true) }, [])
@@ -74,10 +79,26 @@ export default function ExportDropdown({
     if (isExporting) return
     if (triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect()
-      setDropdownPos({
-        top: rect.bottom + 6,
-        right: window.innerWidth - rect.right,
-      })
+      const margin = 12
+      const right = Math.max(margin, window.innerWidth - rect.right)
+      const spaceBelow = window.innerHeight - rect.bottom - margin
+      const spaceAbove = rect.top - margin
+      // Open upward when there isn't enough room below and there's more room above.
+      // Always cap max-height to the available space + scroll, so the menu can never
+      // be clipped off-screen regardless of where the trigger sits.
+      if (spaceBelow < 320 && spaceAbove > spaceBelow) {
+        setDropdownPos({
+          bottom: window.innerHeight - rect.top + 6,
+          right,
+          maxHeight: spaceAbove,
+        })
+      } else {
+        setDropdownPos({
+          top: rect.bottom + 6,
+          right,
+          maxHeight: spaceBelow,
+        })
+      }
     }
     setIsOpen(true)
   }
@@ -200,10 +221,16 @@ export default function ExportDropdown({
             className="fixed inset-0 z-[200]"
             onClick={() => setIsOpen(false)}
           />
-          {/* Dropdown panel — fixed positioning so it's never clipped */}
+          {/* Dropdown panel — fixed positioning + capped height so it's never clipped */}
           <div
-            className="z-[201] w-56 overflow-hidden rounded-xl border border-white/10 bg-zinc-900 shadow-2xl shadow-black/60"
-            style={{ position: 'fixed', top: dropdownPos.top, right: dropdownPos.right }}
+            className="z-[201] w-56 overflow-y-auto overscroll-contain rounded-xl border border-white/10 bg-zinc-900 shadow-2xl shadow-black/60"
+            style={{
+              position: 'fixed',
+              top: dropdownPos.top,
+              bottom: dropdownPos.bottom,
+              right: dropdownPos.right,
+              maxHeight: dropdownPos.maxHeight,
+            }}
           >
             <div className="px-3 pt-2.5 pb-1.5">
               <p className="text-[10px] uppercase tracking-[0.16em] text-zinc-500 font-medium">

--- a/frontend/src/components/GlobalHeader.tsx
+++ b/frontend/src/components/GlobalHeader.tsx
@@ -160,7 +160,7 @@ export default function GlobalHeader() {
                       exit={{ opacity: 0, y: 8, scale: 0.98 }}
                       role="menu"
                       aria-label="Account menu"
-                      className="absolute right-0 z-20 mt-2 w-56 rounded-xl border border-white/10 bg-zinc-900 p-2 shadow-2xl"
+                      className="absolute right-0 z-50 mt-2 w-56 rounded-xl border border-white/10 bg-zinc-900 p-2 shadow-2xl"
                     >
                       <div className="px-3 py-2">
                         <p className="text-[10px] uppercase tracking-[0.2em] text-zinc-500">Account</p>

--- a/frontend/src/components/LaTeXSearchPanel.tsx
+++ b/frontend/src/components/LaTeXSearchPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ChevronDown, Search, X } from 'lucide-react'
 import type { LatexSearchPreset } from '@/data/latex-search-presets'
 
@@ -14,6 +14,17 @@ interface Props {
 
 export default function LaTeXSearchPanel({ presets, onPresetSelect, isOpen, onToggle, onClose }: Props) {
   const panelRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const [flipUp, setFlipUp] = useState(false)
+
+  // Decide flip direction whenever the panel opens
+  useEffect(() => {
+    if (!isOpen || !triggerRef.current) return
+    const rect = triggerRef.current.getBoundingClientRect()
+    const spaceBelow = window.innerHeight - rect.bottom
+    const spaceAbove = rect.top
+    setFlipUp(spaceBelow < 360 && spaceAbove > spaceBelow)
+  }, [isOpen])
 
   // Close on click outside
   useEffect(() => {
@@ -38,8 +49,9 @@ export default function LaTeXSearchPanel({ presets, onPresetSelect, isOpen, onTo
   }, [isOpen, onClose])
 
   return (
-    <div ref={panelRef} className="absolute right-3 top-2 z-30">
+    <div ref={panelRef} className="absolute right-3 top-2 z-50">
       <button
+        ref={triggerRef}
         onClick={onToggle}
         title="LaTeX search presets (⌘⇧H)"
         className={`flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] font-medium transition ${
@@ -54,8 +66,10 @@ export default function LaTeXSearchPanel({ presets, onPresetSelect, isOpen, onTo
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 top-full mt-1 w-[min(18rem,calc(100vw-2rem))] overflow-hidden rounded-lg border border-white/10 bg-zinc-900 shadow-2xl">
-          <div className="flex items-center justify-between border-b border-white/5 px-3 py-2">
+        <div className={`absolute right-0 flex max-h-[min(24rem,calc(100vh-6rem))] w-[min(18rem,calc(100vw-2rem))] flex-col overflow-hidden rounded-lg border border-white/10 bg-zinc-900 shadow-2xl ${
+          flipUp ? 'bottom-full mb-1' : 'top-full mt-1'
+        }`}>
+          <div className="flex shrink-0 items-center justify-between border-b border-white/5 px-3 py-2">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
               LaTeX Patterns
             </span>
@@ -63,7 +77,7 @@ export default function LaTeXSearchPanel({ presets, onPresetSelect, isOpen, onTo
               <X size={12} />
             </button>
           </div>
-          <div className="py-1">
+          <div className="overflow-y-auto py-1">
             {presets.map((preset) => (
               <button
                 key={preset.label}
@@ -80,7 +94,7 @@ export default function LaTeXSearchPanel({ presets, onPresetSelect, isOpen, onTo
               </button>
             ))}
           </div>
-          <div className="border-t border-white/5 px-3 py-1.5">
+          <div className="shrink-0 border-t border-white/5 px-3 py-1.5">
             <p className="text-[9px] text-zinc-700">Tip: use capture groups (…) for replace-all</p>
           </div>
         </div>

--- a/frontend/src/components/PDFPreview.tsx
+++ b/frontend/src/components/PDFPreview.tsx
@@ -439,7 +439,7 @@ export default function PDFPreview({
                 <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/10 border-t-orange-400" />
               </div>
             }
-            className="flex flex-col items-center gap-5 py-6"
+            className="flex min-w-max flex-col items-center gap-5 px-4 py-6"
           >
             {Array.from({ length: numPages }, (_, i) => i + 1).map((pageNum) => (
               <div

--- a/frontend/src/components/SaveCheckpointPopover.tsx
+++ b/frontend/src/components/SaveCheckpointPopover.tsx
@@ -78,7 +78,7 @@ export default function SaveCheckpointPopover({
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full z-30 mt-1.5 w-64 rounded-xl border border-white/10 bg-zinc-900 p-3 shadow-xl">
+        <div className="absolute right-0 top-full z-50 mt-1.5 w-64 rounded-xl border border-white/10 bg-zinc-900 p-3 shadow-xl">
           <p className="mb-2 text-[11px] font-medium text-zinc-400">
             Name this checkpoint
           </p>

--- a/frontend/src/components/SummaryGeneratorWidget.tsx
+++ b/frontend/src/components/SummaryGeneratorWidget.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Check, ChevronDown, ChevronUp, Loader2, RefreshCw, Sparkles, X } from 'lucide-react'
 import { apiClient, type SummaryVariant } from '@/lib/api-client'
 
@@ -29,6 +29,13 @@ export default function SummaryGeneratorWidget({
   const [isLoading, setIsLoading] = useState(false)
   const [insertedIdx, setInsertedIdx] = useState<number | null>(null)
   const [attempted, setAttempted] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  // Flip/clamp so the panel is never clipped when opened low in the editor.
+  const [placement, setPlacement] = useState<{
+    top?: number
+    bottom?: number
+    maxHeight: number
+  } | null>(null)
 
   // Close on Escape
   useEffect(() => {
@@ -68,9 +75,38 @@ export default function SummaryGeneratorWidget({
     setTimeout(onClose, 300)
   }
 
-  if (!isOpen) return null
+  // Anchor position within the positioned editor container.
+  const anchorTop = Math.max(8, top - 4)
 
-  const clampedTop = Math.max(8, top - 4)
+  // Measure against the viewport, flip upward when there's more room above,
+  // and always cap height so long content scrolls inside the panel.
+  useLayoutEffect(() => {
+    if (!isOpen) return
+    const el = containerRef.current
+    if (!el) return
+    const margin = 12
+    // Derive the anchor's viewport position from the positioned parent so the
+    // measurement is stable across re-measures (independent of any flip already
+    // applied to the panel itself).
+    const parent = el.offsetParent as HTMLElement | null
+    const parentRect = parent?.getBoundingClientRect()
+    const parentTop = parentRect?.top ?? 0
+    const parentBottom = parentRect?.bottom ?? window.innerHeight
+    const anchorViewportTop = parentTop + anchorTop
+    const spaceBelow = window.innerHeight - anchorViewportTop - margin
+    const spaceAbove = anchorViewportTop - margin
+    if (spaceBelow < 320 && spaceAbove > spaceBelow) {
+      // Open upward: pin the panel's bottom to the anchor line.
+      setPlacement({
+        bottom: parentBottom - anchorViewportTop,
+        maxHeight: spaceAbove,
+      })
+    } else {
+      setPlacement({ top: anchorTop, maxHeight: Math.max(120, spaceBelow) })
+    }
+  }, [isOpen, top, anchorTop, summaries, jobDescOpen])
+
+  if (!isOpen) return null
 
   return (
     <>
@@ -83,8 +119,14 @@ export default function SummaryGeneratorWidget({
 
       {/* Widget panel */}
       <div
-        className="absolute left-4 z-50 w-84 rounded-xl border border-white/[0.1] bg-zinc-950 shadow-2xl shadow-black/60 ring-1 ring-white/[0.06]"
-        style={{ top: clampedTop, width: '22rem' }}
+        ref={containerRef}
+        className="absolute left-4 z-50 w-84 overflow-y-auto overscroll-contain rounded-xl border border-white/[0.1] bg-zinc-950 shadow-2xl shadow-black/60 ring-1 ring-white/[0.06]"
+        style={{
+          top: placement?.top ?? (placement?.bottom !== undefined ? undefined : anchorTop),
+          bottom: placement?.bottom,
+          maxHeight: placement?.maxHeight,
+          width: '22rem',
+        }}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}

--- a/frontend/src/components/WritingAssistantWidget.tsx
+++ b/frontend/src/components/WritingAssistantWidget.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Check, Loader2, MessageSquare, RefreshCw, Scissors, Sparkles, TrendingUp, X, ZoomIn } from 'lucide-react'
 import { apiClient, type RewriteAction } from '@/lib/api-client'
 
@@ -49,6 +49,13 @@ export default function WritingAssistantWidget({
   const [activeTone, setActiveTone]     = useState<string | null>(null)
   const [rewritten, setRewritten]       = useState<string | null>(null)
   const [error, setError]               = useState<string | null>(null)
+  const containerRef                    = useRef<HTMLDivElement>(null)
+  // Flip/clamp so the panel is never clipped when opened low in the editor.
+  const [placement, setPlacement] = useState<{
+    top?: number
+    bottom?: number
+    maxHeight: number
+  } | null>(null)
 
   // Reset when widget opens/closes or selectedText changes
   useEffect(() => {
@@ -103,9 +110,39 @@ export default function WritingAssistantWidget({
     if (activeAction) callApi(activeAction, activeTone ?? undefined)
   }
 
-  if (!isOpen) return null
+  // Anchor position within the positioned editor container.
+  const anchorTop = Math.max(8, top - 4)
 
-  const clampedTop = Math.max(8, top - 4)
+  // Measure against the viewport, flip upward when there's more room above,
+  // and always cap height so long content scrolls inside the panel.
+  // Recomputes on phase change since the panel grows with the diff/result view.
+  useLayoutEffect(() => {
+    if (!isOpen) return
+    const el = containerRef.current
+    if (!el) return
+    const margin = 12
+    // Derive the anchor's viewport position from the positioned parent so the
+    // measurement is stable across re-measures (independent of any flip already
+    // applied to the panel itself).
+    const parent = el.offsetParent as HTMLElement | null
+    const parentRect = parent?.getBoundingClientRect()
+    const parentTop = parentRect?.top ?? 0
+    const parentBottom = parentRect?.bottom ?? window.innerHeight
+    const anchorViewportTop = parentTop + anchorTop
+    const spaceBelow = window.innerHeight - anchorViewportTop - margin
+    const spaceAbove = anchorViewportTop - margin
+    if (spaceBelow < 320 && spaceAbove > spaceBelow) {
+      // Open upward: pin the panel's bottom to the anchor line.
+      setPlacement({
+        bottom: parentBottom - anchorViewportTop,
+        maxHeight: spaceAbove,
+      })
+    } else {
+      setPlacement({ top: anchorTop, maxHeight: Math.max(120, spaceBelow) })
+    }
+  }, [isOpen, top, anchorTop, phase])
+
+  if (!isOpen) return null
 
   return (
     <>
@@ -114,8 +151,13 @@ export default function WritingAssistantWidget({
 
       {/* Widget panel */}
       <div
-        className="absolute left-4 z-50 w-80 rounded-xl border border-white/[0.1] bg-zinc-950 shadow-2xl shadow-black/60 ring-1 ring-white/[0.06]"
-        style={{ top: clampedTop }}
+        ref={containerRef}
+        className="absolute left-4 z-50 w-80 overflow-y-auto overscroll-contain rounded-xl border border-white/[0.1] bg-zinc-950 shadow-2xl shadow-black/60 ring-1 ring-white/[0.06]"
+        style={{
+          top: placement?.top ?? (placement?.bottom !== undefined ? undefined : anchorTop),
+          bottom: placement?.bottom,
+          maxHeight: placement?.maxHeight,
+        }}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}

--- a/frontend/src/components/ats/DeepAnalysisPanel.tsx
+++ b/frontend/src/components/ats/DeepAnalysisPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Brain, X, AlertCircle, Zap, ChevronDown, TrendingUp, Tag } from 'lucide-react'
 import type { ATSDeepAnalysis, ATSDeepSection } from '@/lib/event-types'
 import ATSRadarChart from './ATSRadarChart'
@@ -133,18 +134,45 @@ export default function DeepAnalysisPanel({
   const [historyOpen, setHistoryOpen] = useState(false)
   const [industryOverride, setIndustryOverride] = useState<string>('generic')
   const [industryDropdownOpen, setIndustryDropdownOpen] = useState(false)
-  const dropdownRef = useRef<HTMLDivElement>(null)
+  const industryTriggerRef = useRef<HTMLButtonElement>(null)
+  const [mounted, setMounted] = useState(false)
+  const [industryDropdownPos, setIndustryDropdownPos] = useState<{
+    top?: number
+    bottom?: number
+    left: number
+    width: number
+    maxHeight: number
+  } | null>(null)
 
-  // Close dropdown on outside click
-  useEffect(() => {
-    const onOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setIndustryDropdownOpen(false)
+  useEffect(() => { setMounted(true) }, [])
+
+  // The industry dropdown is portaled to document.body to escape the panel's
+  // overflow-y-auto scroll ancestor. Compute edge-aware fixed positioning from
+  // the trigger rect (mirrors ExportDropdown).
+  function openIndustryDropdown() {
+    if (industryTriggerRef.current) {
+      const rect = industryTriggerRef.current.getBoundingClientRect()
+      const margin = 12
+      const spaceBelow = window.innerHeight - rect.bottom - margin
+      const spaceAbove = rect.top - margin
+      if (spaceBelow < 240 && spaceAbove > spaceBelow) {
+        setIndustryDropdownPos({
+          bottom: window.innerHeight - rect.top + 6,
+          left: rect.left,
+          width: rect.width,
+          maxHeight: Math.min(spaceAbove, 240),
+        })
+      } else {
+        setIndustryDropdownPos({
+          top: rect.bottom + 6,
+          left: rect.left,
+          width: rect.width,
+          maxHeight: Math.min(spaceBelow, 240),
+        })
       }
     }
-    document.addEventListener('mousedown', onOutside)
-    return () => document.removeEventListener('mousedown', onOutside)
-  }, [])
+    setIndustryDropdownOpen(true)
+  }
 
   // Displayed industry label: from result or from override selection
   const displayedIndustryLabel =
@@ -219,10 +247,11 @@ export default function DeepAnalysisPanel({
               </div>
 
               {/* Industry override selector */}
-              <div ref={dropdownRef} className="relative">
+              <div className="relative">
                 <button
+                  ref={industryTriggerRef}
                   type="button"
-                  onClick={() => setIndustryDropdownOpen((v) => !v)}
+                  onClick={() => (industryDropdownOpen ? setIndustryDropdownOpen(false) : openIndustryDropdown())}
                   className="flex w-full items-center justify-between rounded-lg border border-white/[0.07] bg-white/[0.03] px-3 py-2 text-left text-[11px] text-zinc-400 transition hover:border-white/[0.12] hover:bg-white/[0.05]"
                 >
                   <span className="flex items-center gap-1.5">
@@ -233,21 +262,40 @@ export default function DeepAnalysisPanel({
                   </span>
                   <ChevronDown size={11} className={`text-zinc-600 transition-transform ${industryDropdownOpen ? 'rotate-180' : ''}`} />
                 </button>
-                {industryDropdownOpen && (
-                  <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-white/[0.08] bg-[#111] py-1 shadow-xl">
-                    {INDUSTRY_OPTIONS.map((opt) => (
-                      <button
-                        key={opt.key}
-                        type="button"
-                        onClick={() => { setIndustryOverride(opt.key); setIndustryDropdownOpen(false) }}
-                        className={`flex w-full items-center px-3 py-2 text-left text-[11px] transition hover:bg-white/[0.05] ${
-                          industryOverride === opt.key ? 'text-violet-300' : 'text-zinc-400'
-                        }`}
-                      >
-                        {opt.label}
-                      </button>
-                    ))}
-                  </div>
+                {mounted && industryDropdownOpen && industryDropdownPos && createPortal(
+                  <>
+                    {/* Backdrop */}
+                    <div
+                      className="fixed inset-0 z-[200]"
+                      onClick={() => setIndustryDropdownOpen(false)}
+                    />
+                    {/* Dropdown — fixed positioning so it escapes the panel's overflow-y-auto */}
+                    <div
+                      className="z-[201] overflow-y-auto overscroll-contain rounded-lg border border-white/[0.08] bg-[#111] py-1 shadow-2xl shadow-black/60"
+                      style={{
+                        position: 'fixed',
+                        top: industryDropdownPos.top,
+                        bottom: industryDropdownPos.bottom,
+                        left: industryDropdownPos.left,
+                        width: industryDropdownPos.width,
+                        maxHeight: industryDropdownPos.maxHeight,
+                      }}
+                    >
+                      {INDUSTRY_OPTIONS.map((opt) => (
+                        <button
+                          key={opt.key}
+                          type="button"
+                          onClick={() => { setIndustryOverride(opt.key); setIndustryDropdownOpen(false) }}
+                          className={`flex w-full items-center px-3 py-2 text-left text-[11px] transition hover:bg-white/[0.05] ${
+                            industryOverride === opt.key ? 'text-violet-300' : 'text-zinc-400'
+                          }`}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </>,
+                  document.body
                 )}
               </div>
 


### PR DESCRIPTION
Closes #942 #943 #944 #945 #946 #947. Epic #941.

## Performance (verified on prod)
- **Compile cold-start 50.6s (failing) → 4.4s (completed)**; warm compile work ~2.9s. Warm LaTeX worker (min_containers=1) + disable Celery eager-result storage on Modal (was hitting localhost:6379 and failing cold compiles).
- Submit latency 2.0s → 0.8s.

## Backend correctness
- Non-UUID path segments (/resumes/dashboard, /interview-prep/my) returned 500 (asyncpg DataError) → now 404.
- Error responses bypassed CORSMiddleware → every 5xx/cold-start looked like a browser 'CORS blocked' error. Now echo the allowed Origin on error responses. Verified live: 404 + ACAO header.

## Frontend visual/layout (interactive audit on prod)
- **Export dropdown clipped off-viewport** (9/11 items unreachable at laptop heights) → flip-up + capped height + scroll.
- AI generator widgets (bullet/summary/writing), compiler selector, deep-analysis dropdown, latex-search presets, career autocomplete, workspace Export All → capped height / flip / portal / z-index.
- **/optimize ~138px mobile horizontal overflow** (non-wrapping header row) → responsive wrap + min-w-0; edit tab strip scroll affordance; PDF preview left-clip on mobile.
- Tracker card menu portaled out of column/board overflow; admin Users table sticky first column.

Backend already deployed to Modal + verified; this PR carries the code + triggers the frontend (Vercel) deploy.