### PR TITLE
P0 fix: prod auth 500 — email boot-assert must not throw

### DIFF
--- a/frontend/src/__tests__/auth-email-sender.test.ts
+++ b/frontend/src/__tests__/auth-email-sender.test.ts
@@ -42,23 +42,29 @@ describe('sendEmail without RESEND_API_KEY', () => {
     expect(logged).not.toContain('<html>')
   })
 
-  test('throws in production instead of falling back to the console', async () => {
+  test('warns loudly but still completes in production without a provider', async () => {
     vi.stubEnv('NODE_ENV', 'production')
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    await expect(sendEmail(RESET_EMAIL)).rejects.toThrow(/RESEND_API_KEY is not set/)
-    expect(info).not.toHaveBeenCalled()
+    // Email must not throw here: Better Auth awaits some senders (sign-up
+    // verification), and a throw would 500 the auth request. Degrade to a
+    // console log + a loud warning instead.
+    await expect(sendEmail(RESET_EMAIL)).resolves.toBeUndefined()
+    expect(err).toHaveBeenCalledWith(expect.stringContaining('RESEND_API_KEY is not set'))
+    expect(info).toHaveBeenCalled()
   })
 
   /**
-   * Better Auth invokes every sender inside `runInBackgroundOrAwait`, which
-   * try/catches and only logs — so the per-send throw above never reaches the
-   * user. The boot preflight is what actually stops a keyless production
-   * deploy, by refusing to construct `auth` at all (see lib/auth.ts).
+   * Email verification is a soft, product-level decision, so a missing mail
+   * provider must degrade email delivery only — it must NEVER take the auth
+   * module down. The boot preflight therefore warns instead of throwing.
    */
-  test('the boot preflight fails a keyless production process', () => {
+  test('the boot preflight warns, never throws, on a keyless production process', () => {
     vi.stubEnv('NODE_ENV', 'production')
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    expect(() => assertEmailTransportConfigured()).toThrow(/RESEND_API_KEY is not set/)
+    expect(() => assertEmailTransportConfigured()).not.toThrow()
+    expect(err).toHaveBeenCalledWith(expect.stringContaining('RESEND_API_KEY is not set'))
   })
 
   test('the boot preflight stays quiet in development and during `next build`', () => {

--- a/frontend/src/lib/email.ts
+++ b/frontend/src/lib/email.ts
@@ -56,21 +56,22 @@ function isProductionRuntime(): boolean {
 }
 
 const MISSING_KEY_MESSAGE =
-  'RESEND_API_KEY is not set — refusing to fall back to console logging in production. ' +
-  'Configure a transactional email provider before serving traffic.'
+  'RESEND_API_KEY is not set — transactional email (verification, password reset) ' +
+  'will be console-logged, not delivered. Configure a provider before relying on email.'
 
 /**
- * Boot-time preflight: fail the process when production has no mail transport.
+ * Boot-time preflight: warn (loudly) when production has no mail transport.
  *
- * Throwing from `sendEmail` alone is not enough — Better Auth runs every sender
- * inside `runInBackgroundOrAwait`, which swallows the error — so a container
- * missing `RESEND_API_KEY` would otherwise happily serve sign-ups whose
- * verification mail can never be delivered. Called from `lib/auth.ts` at module
- * load, alongside the `BETTER_AUTH_SECRET` check.
+ * This is called from `lib/auth.ts` at module load. It must NEVER throw:
+ * email verification is soft (a product decision), so a missing mail provider
+ * degrades email delivery only — it must not crash the auth module and 500
+ * every sign-in / sign-up / get-session. `sendEmail` already falls back to a
+ * console log when the key is absent, so flows still complete. Surface the
+ * misconfiguration in the logs rather than taking authentication down with it.
  */
 export function assertEmailTransportConfigured(): void {
   if (!process.env.RESEND_API_KEY && isProductionRuntime()) {
-    throw new Error(MISSING_KEY_MESSAGE)
+    console.error(`[email] ${MISSING_KEY_MESSAGE}`)
   }
 }
 


### PR DESCRIPTION
Closes #953. **Production auth was fully down** (every sign-in/sign-up/get-session 500) after #951: `assertEmailTransportConfigured()` runs at auth-module load and threw when RESEND_API_KEY is unset (Resend isn't provisioned; email verification is soft). Auth must not depend on email config — now it warns loudly and `sendEmail` falls back to console-log, so flows still complete. Tests updated + green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication no longer fails when email delivery is not configured in production.
  * Missing email provider configuration now triggers a clear warning while allowing the application to continue operating.
  * Email sending gracefully degrades instead of causing requests or startup checks to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->