### PR TITLE
P0 fix: PR #951 broke all prod compiles (Modal engine gate + paranoid openin_any)

### DIFF
--- a/backend/app/services/latex_service.py
+++ b/backend/app/services/latex_service.py
@@ -139,6 +139,13 @@ def local_engine_allowed() -> bool:
     raw = os.environ.get("ALLOW_LOCAL_LATEX_ENGINE")
     if raw is not None:
         return raw.strip().lower() in _TRUTHY
+    # Modal runs each worker in an isolated gVisor container with texlive baked
+    # into the image, but its /proc/self/cgroup does not carry the
+    # docker/kubepods/containerd markers running_in_container() looks for, so
+    # detect the Modal target explicitly — the in-image engine is exactly the
+    # intended, sandboxed production path there.
+    if (settings.DEPLOY_TARGET or "").lower() == "modal":
+        return True
     if running_in_container():
         return True
     return settings.normalized_environment != "production"

--- a/backend/app/workers/latex_worker.py
+++ b/backend/app/workers/latex_worker.py
@@ -513,6 +513,11 @@ def compile_latex_task(
             workspace = "/workspace"
         else:
             assert_local_engine_allowed(job_id)
+            # Run WITH cwd=job_dir and pass RELATIVE paths. The sandbox sets
+            # openin_any/openout_any=p (paranoid), under which kpathsea refuses to
+            # read/write ABSOLUTE paths (e.g. /tmp/.../resume.tex) — pdflatex would
+            # fail with "Not reading from … (openin_any = p)". Relative names
+            # resolve against cwd, which paranoid mode permits.
             cmd = [
                 compiler,
                 *LATEX_SANDBOX_FLAGS,
@@ -520,9 +525,9 @@ def compile_latex_task(
                 "-halt-on-error",
                 "-synctex=1",
                 "-jobname", "resume",
-                "-output-directory", str(job_dir),
+                "-output-directory", ".",
                 *custom_flags,
-                str(tex_file),
+                main_file,
             ]
             compile_cwd = str(job_dir)
             workspace = str(job_dir)

--- a/backend/app/workers/orchestrator.py
+++ b/backend/app/workers/orchestrator.py
@@ -624,14 +624,17 @@ def _run_latex_stage(
             workspace = "/workdir"
         else:
             assert_local_engine_allowed(job_id)
+            # Relative paths + cwd=job_dir: the sandbox sets openin_any/openout_any=p
+            # (paranoid), under which kpathsea refuses ABSOLUTE read/write paths, so
+            # an absolute /tmp/.../resume.tex fails with "Not reading … (openin_any=p)".
             cmd = [
                 compiler,
                 *LATEX_SANDBOX_FLAGS,
                 "-interaction=nonstopmode",
                 "-halt-on-error",
                 "-synctex=1",
-                "-output-directory", str(job_dir),
-                str(tex_file),
+                "-output-directory", ".",
+                "resume.tex",
             ]
             cwd = str(job_dir)
             workspace = str(job_dir)

--- a/backend/modal_app.py
+++ b/backend/modal_app.py
@@ -123,9 +123,11 @@ def run_latex_task(payload: dict) -> None:
     image=latex_image,
     secrets=_secrets,
     timeout=600,
-    # No min_containers here (cost): combined jobs are LLM-dominated (~40s), so a cold
-    # start is proportionally smaller. A longer scaledown_window keeps back-to-back
-    # optimize runs on a warm container. Bump to min_containers=1 if optimize latency matters.
+    # Keep one orchestrator warm: the texlive image cold-starts in ~2min, which
+    # made the flagship "Optimize + Compile" flow take ~230s. Warm it so combined
+    # jobs are ~40-50s (LLM-bound) instead. scaledown_window keeps burst
+    # containers around for back-to-back runs.
+    min_containers=1,
     scaledown_window=180,
 )
 def run_orchestrator_task(payload: dict) -> None:


### PR DESCRIPTION
Closes #955. Found during #951 prod E2E — **every compile failed on Modal**:
1. `assert_local_engine_allowed()` refused the in-process engine (Modal's gVisor cgroup lacks docker/kubepods markers + ENVIRONMENT=production). → treat DEPLOY_TARGET=modal as containerized.
2. Paranoid `openin_any=p` rejected the **absolute** input path the workers passed (`pdflatex: Not reading … (openin_any=p)`). → invoke with a **relative** filename + `-output-directory .` and cwd=job_dir, in both latex_worker and orchestrator.
3. Warmed the orchestrator (min_containers=1) so the flagship optimize+compile isn't a ~2min cold start.

**Verified live:** compile → valid PDF (27KB); combined → valid PDF (75KB) + ATS 85; quota still enforces (402).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LaTeX compilation reliability in sandboxed environments by using relative file paths.
  * Enabled the local LaTeX engine for Modal deployments.

* **Performance**
  * Reduced compilation startup times by keeping one deployment container warm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->