### PR TITLE
chore(deps): bump OpenTelemetry family to 1.43.0 (supersedes #760)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -57,13 +57,13 @@ redis==8.0.0
 celery==5.3.4
 flower==2.0.1
 prometheus-client==0.23.1
-opentelemetry-api==1.38.0
-opentelemetry-sdk==1.38.0
-opentelemetry-exporter-otlp-proto-http==1.38.0
-opentelemetry-instrumentation-fastapi==0.59b0
-opentelemetry-instrumentation-sqlalchemy==0.59b0
-opentelemetry-instrumentation-redis==0.59b0
-opentelemetry-instrumentation-celery==0.59b0
+opentelemetry-api==1.43.0
+opentelemetry-sdk==1.43.0
+opentelemetry-exporter-otlp-proto-http==1.43.0
+opentelemetry-instrumentation-fastapi==0.64b0
+opentelemetry-instrumentation-sqlalchemy==0.64b0
+opentelemetry-instrumentation-redis==0.64b0
+opentelemetry-instrumentation-celery==0.64b0
 
 # Additional dependencies for Phase 8
 aioredis==2.0.1


### PR DESCRIPTION
Dependabot #760 bumped **only** `opentelemetry-exporter-otlp-proto-http` 1.38→1.43, leaving api/sdk at 1.38 — OTEL is version-locked, so the mismatch broke Backend Tests. This bumps the whole family coherently (api/sdk/exporter 1.43.0, instrumentation 0.64b0).

Verified locally: full-family install resolves clean, observability + metrics + tracing tests pass, app+OTEL init imports OK.

Closes #760.