### PR TITLE
chore(deps): backend pip batch (alembic/bs4/idna/setuptools) + docker/login-action pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.5.2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.5.2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,7 @@ fastapi==0.136.3
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.8.0
-idna==3.10
+idna==3.18
 iniconfig==2.3.0
 packaging==26.2
 pluggy==1.6.0
@@ -42,12 +42,12 @@ tiktoken==0.13.0
 
 # Database
 SQLAlchemy==2.0.48
-alembic==1.16.1
+alembic==1.18.5
 asyncpg==0.31.0
 psycopg2-binary==2.9.12
 greenlet==3.3.2
 
-setuptools==82.0.1
+setuptools==83.0.0
 watchdog==6.0.0
 PyJWT==2.11.0
 razorpay==2.0.1
@@ -76,7 +76,7 @@ pdfminer.six==20231228
 pdfplumber==0.11.4
 python-docx==1.2.0
 mammoth==1.12.0
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
 lxml==6.1.1
 defusedxml==0.7.1
 mistune==3.3.1


### PR DESCRIPTION
Batches Dependabot #988 #989 #990 #992 (backend pip) + #987 (CI action). Verified: full backend suite passes (exit 0).

**Held: #991 pdfplumber** — 0.11.10 pins `pdfminer.six==20260107` (a 2-year jump on a core PDF-parsing lib); disproportionate risk for a patch, deferred.

Closes #987, #988, #989, #990, #992.