### PR TITLE
chore(deps): backend batch — PyJWT/greenlet/OTEL-1.44 + docker-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -45,11 +45,11 @@ SQLAlchemy==2.0.48
 alembic==1.18.5
 asyncpg==0.31.0
 psycopg2-binary==2.9.12
-greenlet==3.3.2
+greenlet==3.5.4
 
 setuptools==83.0.0
 watchdog==6.0.0
-PyJWT==2.11.0
+PyJWT==2.13.0
 razorpay==2.0.1
 
 # Redis and Celery for Phase 8 - Workers & Queue System
@@ -57,13 +57,13 @@ redis==8.0.0
 celery==5.3.4
 flower==2.0.1
 prometheus-client==0.23.1
-opentelemetry-api==1.43.0
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-otlp-proto-http==1.43.0
-opentelemetry-instrumentation-fastapi==0.64b0
-opentelemetry-instrumentation-sqlalchemy==0.64b0
-opentelemetry-instrumentation-redis==0.64b0
-opentelemetry-instrumentation-celery==0.64b0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-http==1.44.0
+opentelemetry-instrumentation-fastapi==0.65b0
+opentelemetry-instrumentation-sqlalchemy==0.65b0
+opentelemetry-instrumentation-redis==0.65b0
+opentelemetry-instrumentation-celery==0.65b0
 
 # Additional dependencies for Phase 8
 aioredis==2.0.1


### PR DESCRIPTION
Batches #1005 #1007 + coordinated OTEL family (supersedes #1008/#1009) + #1006 CI action. Full backend suite passes (exit 0).

**Held: #1010 pydantic-core** — pinned by pydantic==2.11.7 (needs pydantic-core==2.33.2); can't bump standalone.

Closes #1005, #1006, #1007, #1008, #1009.