### PR TITLE
chore(deps): pdfplumber 0.11.10 + coordinated pdfminer.six

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -72,8 +72,8 @@ kombu==5.6.2
 pgvector==0.4.2
 
 # Document parsing
-pdfminer.six==20231228
-pdfplumber==0.11.4
+pdfminer.six==20260107
+pdfplumber==0.11.10
 python-docx==1.2.0
 mammoth==1.12.0
 beautifulsoup4==4.15.0


### PR DESCRIPTION
Governance review verdict: MIGRATE NOW. pdfplumber 0.11.4→0.11.10 (patch) + the pdfminer.six==20260107 it pins. Verified: targeted PDF/ATS/format tests + full backend suite pass (exit 0). Closes #991.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated document-parsing components to newer dependency versions, improving compatibility and reliability when processing PDF files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->