### PR TITLE
chore(deps): backend batch — fastapi/cryptography/pgvector/types

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,14 +1,14 @@
 annotated-doc==0.0.4
-annotated-types==0.7.0
+annotated-types==0.8.0
 anyio==4.14.1
 attrs==26.1.0
 certifi==2026.5.20
 httpx==0.28.1
 cffi==2.0.0
 click==8.3.3
-cryptography==47.0.0
+cryptography==49.0.0
 ecdsa==0.19.2
-fastapi==0.136.3
+fastapi==0.140.13
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.8.0
@@ -32,7 +32,7 @@ sniffio==1.3.1
 starlette==1.2.1
 typing-inspection==0.4.2
 
-typing_extensions==4.15.0
+typing_extensions==4.16.0
 uvicorn==0.49.0
 uvloop==0.22.1
 watchfiles==1.2.0
@@ -69,7 +69,7 @@ opentelemetry-instrumentation-celery==0.65b0
 aioredis==2.0.1
 kombu==5.6.2
 
-pgvector==0.4.2
+pgvector==0.5.0
 
 # Document parsing
 pdfminer.six==20260107


### PR DESCRIPTION
Batches #1018–#1022. cryptography 49 (Fernet) + fastapi 0.140 are the risk; full backend suite passes (exit 0). Closes #1018, #1019, #1020, #1021, #1022.