### PR TITLE
feat(optimize): guided-intake direction fields → prompt (F2-P1 backend) + PRDs

### DIFF
--- a/backend/app/api/job_routes.py
+++ b/backend/app/api/job_routes.py
@@ -171,6 +171,13 @@ class JobSubmissionRequest(BaseModel):
     model: Optional[str] = None
     compiler: Optional[str] = None  # "pdflatex" | "xelatex" | "lualatex"
     persona: Optional[str] = None
+    # Guided-intake direction (input-driven optimization, PRD 2026-08-02): the
+    # user's explicit answers, threaded into the LLM prompt so the output honours
+    # their intent over generic ATS heuristics.
+    seniority: Optional[str] = None
+    tone: Optional[str] = None
+    emphasize: Optional[List[str]] = None
+    downplay: Optional[List[str]] = None
 
 
 class JobSubmissionResponse(BaseModel):
@@ -476,6 +483,11 @@ async def submit_job(
                 metadata=extra_meta,
                 compiler=compiler,
                 persona=request.persona,
+                industry=request.industry,
+                seniority=request.seniority,
+                tone=request.tone,
+                emphasize=request.emphasize,
+                downplay=request.downplay,
             )
 
         elif request.job_type == "ats_scoring":

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -295,8 +295,19 @@ class LLMService:
         optimization_level: str,
         target_sections: Optional[List[str]] = None,
         custom_instructions: Optional[str] = None,
+        industry: Optional[str] = None,
+        seniority: Optional[str] = None,
+        tone: Optional[str] = None,
+        emphasize: Optional[List[str]] = None,
+        downplay: Optional[List[str]] = None,
     ) -> str:
-        """Create optimization prompt for LLM using delimiter output format."""
+        """Create optimization prompt for LLM using delimiter output format.
+
+        The guided-intake fields (industry/seniority/tone/emphasize/downplay)
+        are the user's explicit direction — they are injected verbatim so the
+        model tailors to what the user actually asked for, not just the ATS
+        heuristics. See docs/prd/2026-08-02-input-driven-optimization.md.
+        """
 
         level_instructions = {
             "conservative": "Make minimal changes, only fixing obvious issues and improving clarity where clearly beneficial.",
@@ -336,12 +347,42 @@ KEY REQUIREMENTS:
         if custom_instructions:
             user_constraint = f"\n\nUser instructions: {custom_instructions}"
 
+        # Guided-intake direction: the user's explicit answers, honoured over the
+        # generic ATS defaults. Each line is only added when the user provided it.
+        direction_lines = []
+        if industry:
+            direction_lines.append(
+                f"- Target industry: {industry}. Use its conventions, terminology, and expected emphasis."
+            )
+        if seniority:
+            direction_lines.append(
+                f"- Seniority level: {seniority}. Calibrate scope, ownership, and leadership language accordingly."
+            )
+        if tone:
+            direction_lines.append(
+                f"- Voice/tone: {tone}. Match this consistently across bullets."
+            )
+        if emphasize:
+            direction_lines.append(
+                f"- Emphasize these (make them prominent and impactful): {', '.join(emphasize)}."
+            )
+        if downplay:
+            direction_lines.append(
+                f"- De-emphasize / keep brief (do NOT remove, just reduce prominence): {', '.join(downplay)}."
+            )
+        direction_block = ""
+        if direction_lines:
+            direction_block = (
+                "\n\nUSER DIRECTION (respect these explicit choices above generic heuristics):\n"
+                + "\n".join(direction_lines)
+            )
+
         return f"""Please optimize the following LaTeX resume.
 
 OPTIMIZATION LEVEL: {optimization_level}
 INSTRUCTIONS: {level_instructions.get(optimization_level, level_instructions['balanced'])}
 
-{jd_section}{section_constraint}{user_constraint}
+{jd_section}{section_constraint}{user_constraint}{direction_block}
 
 CURRENT LATEX RESUME:
 {latex_content}

--- a/backend/app/workers/orchestrator.py
+++ b/backend/app/workers/orchestrator.py
@@ -104,6 +104,11 @@ def optimize_and_compile_task(
     compiler: str = "pdflatex",
     timeout_seconds: Optional[int] = None,
     persona: Optional[str] = None,
+    industry: Optional[str] = None,
+    seniority: Optional[str] = None,
+    tone: Optional[str] = None,
+    emphasize: Optional[List[str]] = None,
+    downplay: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Full pipeline: LLM optimize → pdflatex compile → ATS score.
@@ -164,6 +169,11 @@ def optimize_and_compile_task(
             custom_instructions=custom_instructions,
             model=model,
             persona=persona,
+            industry=industry,
+            seniority=seniority,
+            tone=tone,
+            emphasize=emphasize,
+            downplay=downplay,
         )
 
         if is_cancelled(job_id):
@@ -363,6 +373,11 @@ def _run_llm_stage(
     custom_instructions: Optional[str] = None,
     model: Optional[str] = None,
     persona: Optional[str] = None,
+    industry: Optional[str] = None,
+    seniority: Optional[str] = None,
+    tone: Optional[str] = None,
+    emphasize: Optional[List[str]] = None,
+    downplay: Optional[List[str]] = None,
 ) -> tuple[str, List[Dict], int, float]:
     """
     Stream OpenAI tokens through a delimiter state machine.
@@ -383,6 +398,11 @@ def _run_llm_stage(
         latex_content, job_description, keywords, optimization_level,
         target_sections=target_sections,
         custom_instructions=custom_instructions,
+        industry=industry,
+        seniority=seniority,
+        tone=tone,
+        emphasize=emphasize,
+        downplay=downplay,
     )
 
     publish_event(job_id, "job.progress", {
@@ -798,6 +818,11 @@ def submit_optimize_and_compile(
     compiler: str = "pdflatex",
     timeout_seconds: Optional[int] = None,
     persona: Optional[str] = None,
+    industry: Optional[str] = None,
+    seniority: Optional[str] = None,
+    tone: Optional[str] = None,
+    emphasize: Optional[List[str]] = None,
+    downplay: Optional[List[str]] = None,
 ) -> str:
     """Enqueue optimize_and_compile_task on the combined queue."""
     if priority is None:
@@ -827,6 +852,11 @@ def submit_optimize_and_compile(
             "compiler": compiler,
             "timeout_seconds": compile_timeout,
             "persona": persona,
+            "industry": industry,
+            "seniority": seniority,
+            "tone": tone,
+            "emphasize": emphasize,
+            "downplay": downplay,
         })
         logger.info(f"Modal spawn: orchestrator for job {job_id} (compiler={compiler})")
         return job_id
@@ -848,6 +878,11 @@ def submit_optimize_and_compile(
             "compiler": compiler,
             "timeout_seconds": compile_timeout,
             "persona": persona,
+            "industry": industry,
+            "seniority": seniority,
+            "tone": tone,
+            "emphasize": emphasize,
+            "downplay": downplay,
         },
         priority=priority,
         queue="combined",

--- a/backend/test/test_guided_intake_prompt.py
+++ b/backend/test/test_guided_intake_prompt.py
@@ -1,0 +1,54 @@
+"""Guided-intake direction fields flow into the optimization prompt.
+
+Covers the input-driven-optimization P1 backend (PRD 2026-08-02): industry,
+seniority, tone, emphasize, downplay are the user's explicit direction and must
+appear in the prompt so the model honours them over generic ATS heuristics.
+"""
+
+from app.services.llm_service import LLMService
+
+_LATEX = r"\documentclass{article}\begin{document}Jane Doe\end{document}"
+
+
+def _prompt(**kwargs) -> str:
+    svc = LLMService()
+    return svc._create_optimization_prompt(  # noqa: SLF001
+        _LATEX,
+        kwargs.pop("job_description", None),
+        kwargs.pop("keywords", []),
+        kwargs.pop("optimization_level", "balanced"),
+        **kwargs,
+    )
+
+
+def test_intake_fields_present_when_provided():
+    p = _prompt(
+        industry="Fintech",
+        seniority="Senior",
+        tone="confident and concise",
+        emphasize=["AWS migration", "team leadership"],
+        downplay=["early internships"],
+    )
+    assert "USER DIRECTION" in p
+    assert "Fintech" in p
+    assert "Senior" in p
+    assert "confident and concise" in p
+    assert "AWS migration" in p and "team leadership" in p
+    assert "early internships" in p
+    # De-emphasize must be explicit that it does NOT remove content.
+    assert "do NOT remove" in p
+
+
+def test_no_direction_block_when_absent():
+    p = _prompt()
+    assert "USER DIRECTION" not in p
+
+
+def test_partial_fields_only_include_given_lines():
+    p = _prompt(industry="Healthcare")
+    assert "USER DIRECTION" in p
+    assert "Healthcare" in p
+    # Fields not provided must not appear as empty direction lines.
+    assert "Seniority level:" not in p
+    assert "Voice/tone:" not in p
+    assert "Emphasize these" not in p

--- a/docs/prd/2026-08-02-external-sources-to-resume.md
+++ b/docs/prd/2026-08-02-external-sources-to-resume.md
@@ -1,0 +1,154 @@
+# PRD: External Sources → Resume ("Import your real projects")
+
+- **Status:** Draft for review (no implementation this session)
+- **Date:** 2026-08-02
+- **Owner:** TBD
+- **Tier:** Premium / AI-personalization (optional, opt-in)
+- **Related:** [Input-Driven Optimization PRD](2026-08-02-input-driven-optimization.md)
+
+---
+
+## 1. Summary
+
+Let users optionally pull their **real projects and experience** from external sources so the AI grounds resume content in verifiable work instead of generic phrasing. Sources, in priority order:
+
+1. **GitHub** — read the user's public repos, rank their top projects, and draft resume-ready bullets from README/description/stack. **Build first.**
+2. **Portfolio / arbitrary project URLs** — fetch and extract content from a personal site or project link. **Build second (reuses the existing scraper).**
+3. **LinkedIn** — via the user's **own data export** upload or resume-PDF upload only. **Never scrape LinkedIn.** **Build third.**
+
+Everything is optional, opt-in per source, gated to the premium AI tier, and **always routed through a user review/edit step** before anything is written to the resume.
+
+## 2. Problem & motivation
+
+Today the AI optimizer rewrites the *existing* resume text; it has no access to the user's real body of work. Users must hand-type every project. This is friction, and it caps quality — the model can only polish what's already there. Founder's framing: for users doing AI personalization, let them **bring real evidence** (GitHub, portfolio, LinkedIn export, or pasted project links) and have the AI weave it into the LaTeX resume.
+
+**Strategic wedge:** Latexy is a *LaTeX* resume builder — its audience skews technical/developer. GitHub import is **high-value and rare** in the market (only developer-niche tools like the JSON Resume ecosystem do it). This is a genuine differentiator, not a me-too feature.
+
+## 3. Goals / Non-goals
+
+**Goals**
+- Reduce time-to-a-real-resume by importing verifiable projects with one connect/upload.
+- Improve AI output quality by grounding bullets in cited evidence (less hallucination).
+- Do it legally and privately (explicit consent, encrypted tokens, delete/disconnect, no ToS violations).
+- Reuse existing infrastructure (GitHub OAuth, SSRF-guarded scraper, encryption, entitlements) — minimize net-new surface.
+
+**Non-goals**
+- No automated LinkedIn scraping or third-party LinkedIn data vendors (see §7).
+- No auto-writing to the resume — imports produce *suggestions* the user reviews.
+- No headless-browser rendering in v1 (static fetch only for URLs).
+- Not building a general "web research" agent — scoped to project/experience evidence.
+
+## 4. Current state (from codebase audit — reuse map)
+
+| Capability | Status | Location |
+|---|---|---|
+| GitHub OAuth (connect/callback/status/disconnect), Fernet-encrypted token on `User` | **EXISTS** — but scope is `repo` and it's used only to **sync `.tex` files to a private repo** (backup), not to read profile/repos | `backend/app/api/github_routes.py`, `github_sync_service.py`, `User.github_access_token/username` (`models.py:48-49`) |
+| Authenticated GitHub httpx client + token decryption | **EXISTS** (reuse) | `github_sync_service.py` |
+| SSRF-guarded URL fetcher + readability HTML→clean-text + JSON-LD + platform handlers + 24h cache | **EXISTS** (production-grade, used by the job-description scraper) | `backend/app/services/job_scraper_service.py` (`_SSRFGuardTransport`, `_assert_public_url`, `_html_to_clean_text`, `_extract_generic_html`) |
+| "Pull external structured data → format → insert into resume" flow | **EXISTS** as ORCID publications → LaTeX block | `ai_routes.py:1782` `POST /generate-publications`, frontend `PublicationsPanel` |
+| Resume parsers (PDF/DOCX → text) | **EXISTS** | `backend/app/parsers/`, `MultiFormatUpload` |
+| Fernet token encryption | **EXISTS** (reuse) | `encryption_service.py` |
+| Entitlement gating (`require_feature` + admin matrix) + quota (`enforce_quota`) | **EXISTS** (reuse) | `feature_registry.py`, `middleware/entitlements.py`, `PLAN_QUOTAS` in `config.py` |
+| **GitHub repo listing / README reading / project extraction** | **ABSENT** — the `repo` scope grant is broad enough, but no code consumes it | net-new |
+| **LinkedIn** import (OAuth/scrape/parse) | **ABSENT** — frontend `workspace/new` has an instructional "save-to-PDF then upload" stub only | net-new (compliant path) |
+| **"Paste project links / describe projects" input + generic URL project ingest** | **ABSENT** | net-new (reuses scraper) |
+
+**Takeaway:** GitHub import is ~50% plumbing you already own (OAuth + encrypted token + authed client). URL ingest reuses the SSRF scraper. Only the *consumers* are net-new.
+
+## 5. Proposed solution — phased
+
+### Phase 1 — GitHub import (BUILD FIRST)
+
+**Why first:** official API (zero ToS risk), effectively free rate limits, highest recruiter signal, and half-built.
+
+**Flow:** Connect GitHub (or reuse existing connection) → `POST /github/import-projects` → Celery `github_import_worker` → fetch + rank + summarize → return **candidate `ProjectEvidence` records** → user reviews/edits/selects → selected items feed the optimizer (or insert as an Experience/Projects section) → user approves before write.
+
+**Fetch (hybrid GraphQL + REST):**
+- One **GraphQL** call: `user.pinnedItems(first:6)` (user-curated = highest signal) + `user.repositories(first:100, ownerAffiliations:OWNER, orderBy:{field:STARGAZERS})` → stars, forks, primaryLanguage, topics, description, isFork, pushedAt, README existence. ~1 point of the 5,000/hr budget.
+- **REST** per selected repo: `GET /repos/{o}/{r}/readme`, `GET .../languages`, optionally `contents/{package.json|requirements.txt|go.mod|Cargo.toml}` for stack inference.
+- **Auth:** use the **connecting user's own OAuth token** so each user gets their own 5,000/hr bucket. Read **public repos only**. Serialize per-user fetches (avoid GitHub secondary rate limits).
+
+**Ranking heuristic** (take top 4–6, always include pinned, exclude forks by default):
+```
+score = 3.0*log10(stars+1) + 1.5*log10(forks+1)
+      + 2.0*e^(-months_since_push/12) + 1.0*has_readable_README
+      + 0.5*has_topics + 0.5*has_description + BIG_BOOST_if_pinned
+penalize/exclude: isFork, isArchived, README<100 chars
+```
+
+**LLM summarization:** truncate/summarize each README (first ~1,500 tokens or an "extract what/why/tech" pass) before it hits the prompt. Under **BYOK this runs on the user's own key → ~zero marginal cost to Latexy.**
+
+### Phase 2 — Portfolio / project URL ingest
+
+Generalize `job_scraper_service` into a shared `ContentIngestService` and add `POST /ingest/url`. **Static fetch only** (Trafilatura or the existing scorer); **skip JS-heavy pages** with a clear "couldn't read this page" message rather than spinning up headless Chrome. Honor **robots.txt**; enforce the existing **SSRF guard**, redirect/size/content-type/timeout caps on every fetch. LLM structures cleaned text into `ProjectEvidence`. Lower signal-to-noise than GitHub → build after it.
+
+### Phase 3 — LinkedIn via user-owned data (COMPLIANT ONLY)
+
+Three user-initiated, ToS-safe paths (no automated access, ever):
+1. **Upload LinkedIn data archive** (Settings → Data Privacy → *Get a copy of your data* → parse `Positions.csv`, `Skills.csv`, `Education.csv`, `Profile.csv`). Note: the large archive takes 24–72h for the user to generate → async "come back later" UX.
+2. **Upload existing resume PDF/DOCX** — reuse `backend/app/parsers/`. Fastest, highest-conversion; covers most users.
+3. **Paste public profile text** — user-initiated copy = compliant.
+
+## 6. Data model & API
+
+**New tables:**
+- `external_source_connections(id, user_id, provider, encrypted_token, scopes, connected_at, expires_at)` — reuse the Fernet encryption pattern.
+- `ingested_projects(id, user_id, source, evidence_json, raw_hash, fetched_at, expires_at)` — cache normalized evidence.
+
+**Normalized shape** (decouples ingestion from optimization):
+```
+ProjectEvidence { source, title, description, tech[],
+                  metrics{stars,forks,...}, dates, url, raw_excerpt, confidence }
+```
+
+**Endpoints (all gated + metered):**
+- `POST /github/import-projects` → job id; `GET /github/import-projects/{id}` → candidate evidence
+- `POST /ingest/url` → evidence for one URL
+- `POST /import/linkedin-archive` (ZIP) / reuse resume-upload → evidence
+- Evidence feeds either the optimizer's new `evidence:` prompt block or a "generate Projects section" insert (clone the ORCID publications pattern).
+
+**Caching:** normalized evidence in Postgres + Redis hot layer (`latexy:ingest:{user}:{source}`, TTL ~24h) keyed by content hash. GitHub data changes slowly — don't re-fetch/re-spend LLM on every edit.
+
+## 7. Legal & privacy (must-dos) ⚠️
+
+**LinkedIn is a legal minefield — decisions locked here:**
+- LinkedIn's official API (OpenID Connect) returns **only name/email/photo** — no positions/experience. Rich data is Partner-only, effectively unavailable to a small SaaS.
+- **Scraping LinkedIn violates its User Agreement.** `hiQ v. LinkedIn` ended with hiQ enjoined + $500K to LinkedIn (no-CFAA-crime ≠ permitted — it's breach-of-contract). **Proxycurl was sued and shut down (July 2025)** under a permanent injunction. Third-party LinkedIn data vendors (Bright Data, PDL) carry the same exposure LinkedIn is actively litigating.
+- **Competitors that "paste your LinkedIn URL to import" are scraping and violating ToS. Do not copy this.**
+- **Verdict: never scrape LinkedIn or buy LinkedIn data. Only user-owned data uploads.**
+
+**Cross-cutting:**
+- **Explicit opt-in per source.** GitHub consent copy: *"Latexy will read your **public** GitHub repositories (names, descriptions, READMEs, languages, stars) to suggest resume content. We do not read private repositories. You can disconnect anytime."*
+- **Narrowest scope:** for the import, request read-only `public_repo`/`read:user` — do **not** reuse the sync feature's write-capable `repo` scope for a read-only import (consider a separate, tighter grant).
+- **Encrypted tokens** (Fernet, already in place); **delete/disconnect** purges `ingested_projects` + revokes tokens (GDPR erasure).
+- **Never auto-write to the resume** — human review required.
+- **URLs:** SSRF guard mandatory, robots.txt honored, provenance logged.
+
+## 8. Entitlement & metering
+
+- Add `FeatureDef` keys to `feature_registry.py`: `ai_import_github`, `ai_import_url`, `ai_import_linkedin_archive` (category `integrations` or a new `ai_personalization`), bound to the premium AI tier via the admin matrix.
+- Gate routes with `Depends(require_feature("ai_import_github"))` etc.
+- Meter with `enforce_quota(...)` — reuse `ai_assists` (or add an `imports` dimension to `QUOTA_DIMENSIONS` + `PLAN_QUOTAS`). Per-user rate-limit URL ingestion.
+
+## 9. Success metrics
+
+- % of AI-tier users who connect ≥1 source; % of imports that result in ≥1 accepted project bullet.
+- Reduction in time-to-first-optimized-resume for importers vs non-importers.
+- AI output quality (accepted-suggestion rate — ties to PRD 2's review loop) for grounded vs ungrounded runs.
+- Zero ToS/abuse incidents (SSRF, rate-limit) — guardrail metric.
+
+## 10. Effort & sequencing (rough)
+
+| Phase | Scope | Effort | Risk |
+|---|---|---|---|
+| 1 GitHub | new endpoints + worker + ranking + README summarize + review UI (reuses OAuth/token/client) | ~1–1.5 wk | Low (official API) |
+| 2 URL ingest | generalize scraper → `ContentIngestService` + endpoint + review UI | ~0.5–1 wk | Low-med (abuse controls) |
+| 3 LinkedIn (user data) | archive parser + resume-upload path + review UI | ~0.5–1 wk | Low (compliant) |
+
+## 11. Open decisions for founder
+
+1. **Positioning:** lead marketing with **GitHub import** as the developer differentiator? (Recommended.)
+2. **Scope tightening:** accept a second, read-only GitHub OAuth grant (`public_repo`) for imports, or reuse the existing `repo` token to avoid a second consent screen? (Recommend the tighter scope for trust.)
+3. **Insert model:** should imported projects feed the *optimizer prompt* as evidence, or generate a standalone **Projects/Experience section** the user drops in (ORCID-style)? (Recommend: both — evidence for optimize, and a "generate section" quick action.)
+4. **Tier & quota:** which plans get imports, and what monthly cap (reuse `ai_assists` vs a new `imports` dimension)?
+5. **LinkedIn UX:** ship the async data-archive path in v1, or start with just resume-PDF upload (fastest) and add archive later?

--- a/docs/prd/2026-08-02-input-driven-optimization.md
+++ b/docs/prd/2026-08-02-input-driven-optimization.md
@@ -1,0 +1,124 @@
+# PRD: Input-Driven, Collaborative Resume Optimization
+
+- **Status:** Draft for review (no implementation this session)
+- **Date:** 2026-08-02
+- **Owner:** TBD
+- **Tier:** Core UX (applies to all optimize users; some steps AI-tier)
+- **Related:** [External Sources → Resume PRD](2026-08-02-external-sources-to-resume.md)
+
+---
+
+## 1. Summary
+
+Shift resume optimization from **"AI auto-rewrites the whole document, take it or leave it"** to **"AI drafts, you direct and approve."** Concretely: a **per-change accept/reject/edit review layer**, preceded by a **short guided-intake step**, with a **one-line rationale** on each suggested change, and (later) **steer-and-regenerate** controls. This makes users feel heard, improves actual output quality, and — because none of the market's resume tools have a clean Grammarly-style per-change review — it's a differentiator Latexy is uniquely positioned to build (the diff/variants/checkpoint machinery already exists).
+
+## 2. Problem & motivation
+
+Founder's insight: today Latexy **forces** ATS-driven changes onto users; they'd trust and value the product more if their **input were respected first**. This matches the research:
+- Full auto-rewrite is the pattern users resent; the best-reviewed competitor UX (Teal) sits on the **suggest + per-item control** side, and Rezi explicitly applies changes section-by-section "to avoid overwhelming rewrites."
+- Human-in-the-loop research: "when behavior is predictable and control is clear, people lean in rather than work around the system"; override/undo mechanisms restore trust.
+- For a document as personal as a resume, **ownership drives trust and retention** — full automation maximizes speed but minimizes ownership.
+
+## 3. Goals / Non-goals
+
+**Goals**
+- Make AI edits feel collaborative (accept/reject/edit per change), not imposed.
+- Respect and *reflect back* user direction (role, seniority, tone, what to emphasize/downplay).
+- Keep real ATS value while avoiding keyword-stuffing harm.
+- Reuse existing diff/variants/checkpoint/request-field infrastructure — mostly UX sequencing, not a rebuild.
+
+**Non-goals**
+- Not removing the fast one-shot "optimize everything" path — keep it as an option for users who want speed.
+- Not a full conversational editor rebuild.
+- Not over-asking: intake stays short (progressive disclosure).
+
+## 4. Current state (from codebase audit)
+
+The optimize flow **already accepts rich inputs but spends them on a one-shot auto-rewrite:**
+
+| Thing | Status | Location |
+|---|---|---|
+| Request fields: `job_description`, `optimization_level`, `industry`, `target_sections`, `custom_instructions`, `persona`, `model` | **EXISTS** (input plumbing is end-to-end) | `JobSubmissionRequest` `job_routes.py:160-174` |
+| Prompt threading of level/JD-keywords/target_sections/custom_instructions/persona | **EXISTS** | `orchestrator.py:356-410`, `llm_service._create_optimization_prompt:290-358`, `optimization_personas.py` |
+| **`industry` collected but UNUSED in the rewrite prompt** (only feeds ATS scoring) | **GAP** (quick win) | `job_routes.py:493` |
+| Structured change metadata `changes_made` (`{section, change_type, reason}`) | **EXISTS** but advisory-only | `orchestrator.py:539-547` |
+| **`OptimizationChange` dataclass already has `original_text`/`new_text` fields** — just not populated by the streaming path | **PARTIAL** (key enabler for P0) | `llm_service.py:360-376` |
+| Whole-document diff review (Compare before/after, Diff viewer, checkpoints, variants) | **EXISTS** (scaffolding for granular review) | `optimize/page.tsx` CompareModal/DiffViewerModal/VersionHistoryPanel; `getResumeDiffWithParent` |
+| Per-suggestion accept/reject UI + incremental apply | **ABSENT** | net-new |
+| ATS scoring surfaced to user | **EXISTS**, advisory only, **not fed back into the prompt** | `ats_scoring_service.py`, `ATSScoreCard`/`AtsSimulatorPanel` |
+| Editor AI helpers (bullets/summary/rewrite/translate), metered `ai_assists` | **EXISTS** (separate from optimize) | `ai_routes.py` |
+
+**Takeaway:** the model today is *auto-rewrite whole doc → whole-document diff → accept-all-or-discard → manual "Save as New Version."* Granular, input-first collaboration is a **targeted extension** of existing pieces.
+
+## 5. Market grounding (why this specific shape)
+
+- **Nobody in the resume-SaaS set (Teal, Rezi, Enhancv, Kickresume, Jobscan, Careerflow, Huntr, Standard Resume) has a clean per-change accept/reject/edit diff for optimization.** Open gap Latexy can own.
+- **JD-paste + match-score-before-acting is table stakes** — Latexy already takes JD input, but spends it on one-shot rewrite instead of a review loop.
+- **Transparency raises agreement** (revealing AI reasoning lifted agreement ~2–4 pts, significant) — **but** extensive reasoning can cause **over-trust that crowds out the user's own judgment.** → Keep rationales **short, contrastive, ATS-tied**, always paired with an easy reject.
+- **ATS reality:** keyword filters are near-universal (~99.7% of recruiters), **but keyword stuffing backfires** (NLP screening penalizes unnatural density; "perfect score" is a myth — ~80% is the sweet spot). The credible rule: **"prove the keyword in a real achievement,"** which is itself the justification for asking the user for input. Parsing failures are the underrated risk — clean, single-column, standard-heading formatting is where ATS value is genuinely won, and **parse-clean LaTeX templates are an ownable differentiator** (most builders lose >50% of data on re-parse).
+
+## 6. Proposed solution — prioritized
+
+### P0 — Per-change suggestion / accept–reject review layer (highest impact)
+
+Turn the one-shot rewrite into an **interactive review**: the optimizer returns **atomic, individually-applicable changes** (per bullet/section), each with `original_text` + `new_text` (fields already exist on `OptimizationChange`). The user **accepts / rejects / edits** each; accepted changes apply incrementally to the LaTeX; recompile reflects the partial acceptance.
+
+- **Reuses:** the delimiter state machine that already separates rewritten LaTeX from change metadata (`orchestrator.py:424-555`); diff-vs-parent; checkpoints (natural undo/branch points).
+- **Net-new:** (1) optimizer emits **structured atomic changes** instead of one blob (populate `original_text`/`new_text` + a stable anchor per change); (2) accept/reject/edit UI; (3) selective apply + recompile.
+- **Framing:** *AI drafts, you direct and approve* (Grammarly/Copilot norm).
+
+### P1 — Lightweight guided intake before optimize (high impact, low effort)
+
+A **3–4 field pre-step** (progressive disclosure, smart defaults, advanced collapsed):
+- Target role / JD (already have it) · Seniority · Tone/voice · "Which 1–3 achievements to emphasize / anything to downplay."
+- **Reuses:** `optimization_level`, `industry`, `custom_instructions`, `persona` already in the request — this is mostly a **UI surface + defaulting layer**, plus feeding "emphasize/downplay" and (finally) **`industry` into the prompt**.
+- **The "feel heard" win:** *reflect the choices back in the output* — a short "what changed & why" recap ("emphasized your AWS migration; kept to 1 page; added 'Kubernetes' from the JD"). Visible cause→effect is the strongest antidote to "the AI forced changes."
+- Keep it short — research warns hard against the wall-of-configuration.
+
+### P2 — Rationale on each suggestion (cheap trust multiplier once P0 lands)
+
+Attach a **one-line, ATS-tied reason** per atomic change ("adds 'CI/CD' — required keyword missing from JD"; "quantified impact — recruiters favor metrics"). Concise, contrastive, actionable — **not essays**, always paired with reject (avoid the over-trust/crowding-out effect).
+
+### P3 — Steer-and-regenerate loop (delight layer)
+
+Per bullet/section: tone control + quick actions ("more concise / more impact-focused / more technical") + **regenerate-with-a-note**. **Reuses the variants system** — each regeneration is a variant the user promotes.
+
+### Cross-cutting guardrails (from ATS research)
+
+- **Cap keyword additions; warn on unnatural density.** Sell "prove the keyword in a real bullet," not stuffing. Surface a warning when skills-vs-bullets mismatch grows.
+- **Validate & market template parse-cleanliness** — run Latexy's templates through parse checks; make "parse-safe" a marketing claim if it holds.
+
+## 7. Detailed design notes
+
+- **Optimizer output contract:** change the LLM output from `<<<LATEX>>>…<<<CHANGES>>>` (whole doc) to a list of atomic changes: `{id, section, anchor, original_text, new_text, change_type, rationale}` + the final assembled LaTeX (for recompile). The parser (`orchestrator.py:424-555`) and `OptimizationChange` (`llm_service.py:360-376`) already model most of this.
+- **Apply engine:** map accepted change ids → text replacements in the current LaTeX (anchored, order-independent) → recompile via the existing compile path. Rejected changes leave the original span untouched.
+- **Intake → prompt:** thread new fields (`emphasize[]`, `downplay[]`, `tone`, `seniority`, and the already-collected `industry`) into `_create_optimization_prompt` as explicit blocks (parallel to `custom_instructions`).
+- **Keep the one-shot path** for speed-seekers; the review layer is the default for the AI tier.
+- **Metering:** the optimize run already consumes `optimizations`. Regenerate-with-note (P3) and per-bullet AI (existing) consume `ai_assists`. No new dimension required.
+
+## 8. Success metrics
+
+- **Accepted-suggestion rate** (accepted / proposed) — primary quality signal; expect higher than accept-all-or-discard.
+- Optimize→save conversion (do more users keep the result?).
+- Retention / repeat-optimize rate (ownership → retention hypothesis).
+- Reduction in "restore original / discard" rate vs today's one-shot.
+- ATS score delta *without* density-warning triggers (real value, not stuffing).
+
+## 9. Effort & sequencing (rough)
+
+| Phase | Scope | Effort | Notes |
+|---|---|---|---|
+| P1 intake | UI step + defaulting + wire `industry`/`emphasize`/`downplay`/`tone` into prompt + "what changed" recap | ~0.5–1 wk | Mostly UI over existing fields; ship this + the industry fix first for a fast win |
+| P0 review layer | structured atomic-change output + accept/reject/edit UI + selective apply + recompile | ~1.5–2.5 wk | Highest impact; the real build |
+| P2 rationale | one-line rationale per change (needs P0's structured output) | ~2–4 days | Cheap once P0 lands |
+| P3 steer/regenerate | inline tone/quick-actions + single-bullet regenerate via variants | ~1 wk | Deferred delight |
+
+*P1 + P0 together deliver ~80% of the "feel heard, not forced" outcome and lean mostly on existing infrastructure.*
+
+## 10. Open decisions for founder
+
+1. **Default flow:** make the review layer the **default** for the AI tier (one-shot as an explicit "optimize everything" button), or keep one-shot default and review opt-in? (Recommend: review default for AI tier.)
+2. **Intake length:** exactly which 3–4 fields? Confirm seniority + tone + emphasize/downplay is the right minimal set, or swap one.
+3. **Granularity:** per-bullet vs per-section change atoms (bullet = more control but more clicks; section = faster). Recommend per-bullet with section grouping.
+4. **Rationale copy:** how prescriptive should the ATS reasons be (risk of over-trust)? Keep to one contrastive line.
+5. **Parse-clean claim:** do we invest in validating templates against real ATS parsers to market "parse-safe"? (Recommended — genuine differentiator.)


### PR DESCRIPTION
First tranche of the input-driven-optimization build (PRD in docs/prd/). Threads the user's explicit intake direction into the LLM optimization prompt:
- **industry** — was collected but never used in the rewrite prompt (now fixed) — plus new **seniority / tone / emphasize / downplay**.
- Injected as an explicit `USER DIRECTION` block, each line only when provided; de-emphasize is explicit that it must NOT remove content.
- Threaded end-to-end: request schema → job_routes combined branch → submit_optimize_and_compile (Modal + Celery) → optimize_and_compile_task → _run_llm_stage → _create_optimization_prompt.

Also lands both **PRDs** (docs/prd/) with the founder-approved decisions (compliant LinkedIn only; build both; tier/quota deferred).

Verified: 3 new tests pass; orchestrator/jobs/llm regressions green; ruff clean.

refs #1039, closes #1040.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided intake options for industry, seniority, tone, emphasis, and content to downplay.
  * Resume optimization now incorporates selected preferences throughout submission and generation workflows.
  * Supports partial guidance while preserving default behavior when no preferences are provided.

* **Documentation**
  * Added draft plans for importing external project and experience evidence.
  * Added a draft plan for collaborative, input-driven resume optimization with review controls and regeneration options.

* **Tests**
  * Added coverage for complete, partial, and empty guided-intake preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->