### PR TITLE
F2-P1: guided-intake UI on the optimize page

### DIFF
--- a/frontend/src/__tests__/guided-intake-client.test.ts
+++ b/frontend/src/__tests__/guided-intake-client.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { apiClient } from '../lib/api-client'
+import { EMPTY_INTAKE, intakeActiveCount, intakeIsEmpty, type GuidedIntake } from '../lib/guided-intake'
+
+function mockFetch(responseBody: object = { success: true, job_id: 'job-1', message: 'ok' }) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      json: () => Promise.resolve(responseBody),
+      text: () => Promise.resolve(JSON.stringify(responseBody)),
+    })
+  )
+}
+
+function lastBody(): Record<string, unknown> {
+  const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+  return JSON.parse(init.body as string)
+}
+
+afterEach(() => {
+  apiClient.setAuthToken(null)
+  vi.unstubAllGlobals()
+})
+
+describe('intakeIsEmpty', () => {
+  test('EMPTY_INTAKE is empty', () => {
+    expect(intakeIsEmpty(EMPTY_INTAKE)).toBe(true)
+  })
+
+  test('any single populated field makes it non-empty', () => {
+    expect(intakeIsEmpty({ ...EMPTY_INTAKE, industry: 'Fintech' })).toBe(false)
+    expect(intakeIsEmpty({ ...EMPTY_INTAKE, seniority: 'Senior' })).toBe(false)
+    expect(intakeIsEmpty({ ...EMPTY_INTAKE, tone: 'Formal' })).toBe(false)
+    expect(intakeIsEmpty({ ...EMPTY_INTAKE, emphasize: ['AWS'] })).toBe(false)
+    expect(intakeIsEmpty({ ...EMPTY_INTAKE, downplay: ['internships'] })).toBe(false)
+  })
+
+  test('whitespace-only text fields are treated as empty', () => {
+    expect(intakeIsEmpty({ ...EMPTY_INTAKE, industry: '   ', tone: '\t' })).toBe(true)
+  })
+})
+
+describe('intakeActiveCount', () => {
+  test('counts each populated field once', () => {
+    expect(intakeActiveCount(EMPTY_INTAKE)).toBe(0)
+    expect(
+      intakeActiveCount({
+        industry: 'Fintech',
+        seniority: 'Senior',
+        tone: 'Formal',
+        emphasize: ['AWS', 'K8s'],
+        downplay: ['internships'],
+      })
+    ).toBe(5)
+    expect(intakeActiveCount({ ...EMPTY_INTAKE, emphasize: ['AWS', 'K8s'] })).toBe(1)
+  })
+})
+
+describe('optimizeAndCompile guided-intake plumbing', () => {
+  const LATEX = '\\documentclass{article}\\begin{document}Hi\\end{document}'
+
+  test('forwards all guided-intake fields into the combined-job body', async () => {
+    mockFetch()
+    const intake: GuidedIntake = {
+      industry: 'Fintech',
+      seniority: 'Senior',
+      tone: 'Impact-focused',
+      emphasize: ['AWS migration', 'team leadership'],
+      downplay: ['early internships'],
+    }
+
+    await apiClient.optimizeAndCompile({
+      latex_content: LATEX,
+      job_description: 'Backend role',
+      optimization_level: 'balanced',
+      industry: intake.industry,
+      seniority: intake.seniority,
+      tone: intake.tone,
+      emphasize: intake.emphasize,
+      downplay: intake.downplay,
+    })
+
+    const body = lastBody()
+    expect(body.job_type).toBe('combined')
+    expect(body.industry).toBe('Fintech')
+    expect(body.seniority).toBe('Senior')
+    expect(body.tone).toBe('Impact-focused')
+    expect(body.emphasize).toEqual(['AWS migration', 'team leadership'])
+    expect(body.downplay).toEqual(['early internships'])
+  })
+
+  test('omits guided-intake fields when not provided', async () => {
+    mockFetch()
+
+    await apiClient.optimizeAndCompile({
+      latex_content: LATEX,
+      optimization_level: 'balanced',
+    })
+
+    const body = lastBody()
+    expect(body.job_type).toBe('combined')
+    expect('seniority' in body).toBe(false)
+    expect('tone' in body).toBe(false)
+    expect('emphasize' in body).toBe(false)
+    expect('downplay' in body).toBe(false)
+  })
+})

--- a/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
@@ -25,6 +25,8 @@ import { usePushNotifications } from '@/hooks/usePushNotifications'
 import AtsSimulatorPanel from '@/components/ats/AtsSimulatorPanel'
 import KeywordDensityMap from '@/components/KeywordDensityMap'
 import PublicationsPanel from '@/components/PublicationsPanel'
+import GuidedIntakePanel from '@/components/GuidedIntakePanel'
+import { EMPTY_INTAKE, intakeIsEmpty, type GuidedIntake } from '@/lib/guided-intake'
 
 const TRIM_INSTRUCTION =
   'Condense this resume to fit on exactly ONE page. Prioritize recent and most impactful content. Remove less critical details, condense bullet points, reduce descriptions. Do NOT remove any job titles, companies, degrees, or institution names.'
@@ -80,6 +82,9 @@ export default function OptimizationSuitePage() {
 
   // Optimization persona (Feature 56)
   const [persona, setPersona] = useState<string | null>(null)
+
+  // Guided intake — user direction for the rewrite (input-driven optimization P1)
+  const [intake, setIntake] = useState<GuidedIntake>(EMPTY_INTAKE)
 
   // Industry override for ATS calibration (Feature 46)
   const [industryOverride, setIndustryOverride] = useState<string | null>(null)
@@ -225,6 +230,11 @@ export default function OptimizationSuitePage() {
         optimization_level: 'balanced',
         compiler,
         persona: persona ?? undefined,
+        industry: intake.industry || undefined,
+        seniority: intake.seniority || undefined,
+        tone: intake.tone || undefined,
+        emphasize: intake.emphasize.length ? intake.emphasize : undefined,
+        downplay: intake.downplay.length ? intake.downplay : undefined,
       })
 
       if (!response.success || !response.job_id) {
@@ -328,6 +338,11 @@ export default function OptimizationSuitePage() {
         job_description: jobDescription,
         optimization_level: 'aggressive',
         custom_instructions: TRIM_INSTRUCTION,
+        industry: intake.industry || undefined,
+        seniority: intake.seniority || undefined,
+        tone: intake.tone || undefined,
+        emphasize: intake.emphasize.length ? intake.emphasize : undefined,
+        downplay: intake.downplay.length ? intake.downplay : undefined,
       })
       if (!response.success || !response.job_id) {
         throw new Error(response.message || 'Failed to start trim')
@@ -340,7 +355,7 @@ export default function OptimizationSuitePage() {
     } finally {
       setIsSubmitting(false)
     }
-  }, [resume?.latex_content, jobDescription])
+  }, [resume?.latex_content, jobDescription, intake])
 
   const handleHistoryRestore = useCallback((latex: string) => {
     editorRef.current?.setValue(latex)
@@ -554,6 +569,9 @@ export default function OptimizationSuitePage() {
               disabled={isProcessing}
               className="scrollbar-subtle mt-2 h-56 w-full resize-none rounded-xl border border-white/10 bg-black/40 p-4 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
             />
+            <div className="mt-3">
+              <GuidedIntakePanel value={intake} onChange={setIntake} />
+            </div>
             <button
               onClick={runOptimization}
               disabled={isProcessing || isSubmitting}
@@ -561,6 +579,19 @@ export default function OptimizationSuitePage() {
             >
               {isProcessing || isSubmitting ? 'Processing...' : jobDescription.trim() ? 'Optimize for this Role' : 'Optimize Resume'}
             </button>
+            {!intakeIsEmpty(intake) && (
+              <p className="mt-2 text-[10px] leading-relaxed text-zinc-600">
+                The AI will follow your direction —
+                {[
+                  intake.industry && ` ${intake.industry} industry`,
+                  intake.seniority && ` ${intake.seniority} level`,
+                  intake.tone && ` ${intake.tone.toLowerCase()} tone`,
+                  intake.emphasize.length ? ` emphasizing ${intake.emphasize.join(', ')}` : '',
+                  intake.downplay.length ? ` downplaying ${intake.downplay.join(', ')}` : '',
+                ].filter(Boolean).join(' ·')}
+                .
+              </p>
+            )}
           </section>
 
           <AnimatePresence>

--- a/frontend/src/components/GuidedIntakePanel.tsx
+++ b/frontend/src/components/GuidedIntakePanel.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, SlidersHorizontal } from 'lucide-react'
+import {
+  SENIORITY_OPTIONS as SENIORITY,
+  TONE_OPTIONS as TONE,
+  intakeActiveCount,
+  type GuidedIntake,
+} from '@/lib/guided-intake'
+
+/**
+ * Guided-intake direction for AI optimization (input-driven optimization, PRD
+ * 2026-08-02). A short, optional, progressively-disclosed set of fields that let
+ * the user steer the rewrite (industry / seniority / tone / emphasize / downplay)
+ * instead of having ATS heuristics forced on them. Collapsed by default with
+ * sensible empty defaults — never a wall of configuration. Types and helpers
+ * live in `@/lib/guided-intake` (React-free, unit tested).
+ */
+
+function TagInput({
+  label,
+  hint,
+  values,
+  onChange,
+  accent,
+}: {
+  label: string
+  hint: string
+  values: string[]
+  onChange: (v: string[]) => void
+  accent: 'emerald' | 'zinc'
+}) {
+  const [draft, setDraft] = useState('')
+  const add = () => {
+    const t = draft.trim()
+    if (t && !values.includes(t)) onChange([...values, t])
+    setDraft('')
+  }
+  const chip =
+    accent === 'emerald'
+      ? 'bg-emerald-500/15 text-emerald-200 ring-emerald-400/20'
+      : 'bg-white/[0.06] text-zinc-300 ring-white/10'
+  return (
+    <div>
+      <label className="text-[11px] font-semibold uppercase tracking-[0.14em] text-zinc-400">{label}</label>
+      <p className="mt-0.5 text-[10px] text-zinc-600">{hint}</p>
+      <div className="mt-1.5 flex flex-wrap gap-1.5">
+        {values.map((v) => (
+          <button
+            key={v}
+            type="button"
+            onClick={() => onChange(values.filter((x) => x !== v))}
+            className={`rounded-md px-2 py-0.5 text-[11px] ring-1 ${chip} transition hover:opacity-80`}
+            title="Remove"
+          >
+            {v} ×
+          </button>
+        ))}
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ',') {
+              e.preventDefault()
+              add()
+            }
+          }}
+          onBlur={add}
+          placeholder="type + Enter"
+          className="min-w-[110px] flex-1 bg-transparent text-[11px] text-zinc-200 placeholder:text-zinc-600 focus:outline-none"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default function GuidedIntakePanel({
+  value,
+  onChange,
+}: {
+  value: GuidedIntake
+  onChange: (v: GuidedIntake) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const set = <K extends keyof GuidedIntake>(k: K, v: GuidedIntake[K]) => onChange({ ...value, [k]: v })
+  const activeCount = intakeActiveCount(value)
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.02]">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between px-3 py-2.5 text-left"
+      >
+        <span className="flex items-center gap-2 text-xs font-semibold text-zinc-300">
+          <SlidersHorizontal size={13} className="text-orange-300/80" />
+          Fine-tune the AI (optional)
+          {activeCount > 0 && (
+            <span className="rounded-full bg-orange-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-orange-200">
+              {activeCount}
+            </span>
+          )}
+        </span>
+        <ChevronDown size={14} className={`text-zinc-500 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div className="space-y-3 border-t border-white/10 px-3 py-3">
+          <p className="text-[10px] text-zinc-600">
+            Tell the AI what matters — it respects these over generic ATS defaults. All optional.
+          </p>
+
+          <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-3">
+            <div>
+              <label className="text-[11px] font-semibold uppercase tracking-[0.14em] text-zinc-400">Industry</label>
+              <input
+                value={value.industry}
+                onChange={(e) => set('industry', e.target.value)}
+                placeholder="e.g. Fintech"
+                className="mt-1 w-full rounded-md border border-white/10 bg-white/[0.03] px-2 py-1.5 text-xs text-zinc-200 placeholder:text-zinc-600 focus:border-orange-400/40 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="text-[11px] font-semibold uppercase tracking-[0.14em] text-zinc-400">Seniority</label>
+              <select
+                value={value.seniority}
+                onChange={(e) => set('seniority', e.target.value)}
+                className="mt-1 w-full rounded-md border border-white/10 bg-white/[0.03] px-2 py-1.5 text-xs text-zinc-200 focus:border-orange-400/40 focus:outline-none"
+              >
+                <option value="">Auto</option>
+                {SENIORITY.map((s) => (
+                  <option key={s} value={s} className="bg-zinc-900">
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-[11px] font-semibold uppercase tracking-[0.14em] text-zinc-400">Tone</label>
+              <select
+                value={value.tone}
+                onChange={(e) => set('tone', e.target.value)}
+                className="mt-1 w-full rounded-md border border-white/10 bg-white/[0.03] px-2 py-1.5 text-xs text-zinc-200 focus:border-orange-400/40 focus:outline-none"
+              >
+                <option value="">Auto</option>
+                {TONE.map((t) => (
+                  <option key={t} value={t} className="bg-zinc-900">
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <TagInput
+              label="Emphasize"
+              hint="Achievements / skills to make prominent"
+              values={value.emphasize}
+              onChange={(v) => set('emphasize', v)}
+              accent="emerald"
+            />
+            <TagInput
+              label="Downplay"
+              hint="Keep but reduce — never deleted"
+              values={value.downplay}
+              onChange={(v) => set('downplay', v)}
+              accent="zinc"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -77,6 +77,11 @@ export interface JobSubmitRequest {
   metadata?: Record<string, unknown>
   compiler?: LatexCompiler
   persona?: string
+  // Guided-intake direction (input-driven optimization)
+  seniority?: string
+  tone?: string
+  emphasize?: string[]
+  downplay?: string[]
 }
 
 export interface OptimizationHistoryEntry {
@@ -1357,6 +1362,12 @@ class ApiClient {
     resume_id?: string
     compiler?: LatexCompiler
     persona?: string
+    // Guided-intake direction (input-driven optimization)
+    industry?: string
+    seniority?: string
+    tone?: string
+    emphasize?: string[]
+    downplay?: string[]
   }): Promise<JobSubmitResponse> {
     return this.submitJob({
       job_type: 'combined',
@@ -1371,6 +1382,11 @@ class ApiClient {
       metadata: body.resume_id ? { resume_id: body.resume_id } : undefined,
       compiler: body.compiler,
       persona: body.persona,
+      industry: body.industry,
+      seniority: body.seniority,
+      tone: body.tone,
+      emphasize: body.emphasize,
+      downplay: body.downplay,
     })
   }
 

--- a/frontend/src/lib/guided-intake.ts
+++ b/frontend/src/lib/guided-intake.ts
@@ -1,0 +1,61 @@
+/**
+ * Guided-intake direction for AI optimization (input-driven optimization, PRD
+ * 2026-08-02). Pure types + helpers, kept free of React/JSX so they can be unit
+ * tested and reused by the api-client mapping. The UI lives in
+ * `components/GuidedIntakePanel.tsx`.
+ */
+
+export interface GuidedIntake {
+  industry: string
+  seniority: string
+  tone: string
+  emphasize: string[]
+  downplay: string[]
+}
+
+export const EMPTY_INTAKE: GuidedIntake = {
+  industry: '',
+  seniority: '',
+  tone: '',
+  emphasize: [],
+  downplay: [],
+}
+
+export const SENIORITY_OPTIONS = [
+  'Intern',
+  'Junior',
+  'Mid',
+  'Senior',
+  'Staff / Lead',
+  'Manager',
+  'Director+',
+]
+
+export const TONE_OPTIONS = [
+  'Confident & concise',
+  'Impact-focused',
+  'Technical',
+  'Formal',
+  'Conversational',
+]
+
+export function intakeIsEmpty(v: GuidedIntake): boolean {
+  return (
+    !v.industry.trim() &&
+    !v.seniority.trim() &&
+    !v.tone.trim() &&
+    v.emphasize.length === 0 &&
+    v.downplay.length === 0
+  )
+}
+
+/** Count of populated direction fields — drives the "active" badge. */
+export function intakeActiveCount(v: GuidedIntake): number {
+  return (
+    (v.industry.trim() ? 1 : 0) +
+    (v.seniority.trim() ? 1 : 0) +
+    (v.tone.trim() ? 1 : 0) +
+    (v.emphasize.length ? 1 : 0) +
+    (v.downplay.length ? 1 : 0)
+  )
+}


### PR DESCRIPTION
Closes #1045.

Adds the **guided-intake** direction layer to the optimize page so users steer the AI rewrite instead of having ATS heuristics forced on them (Input-Driven Optimization PRD, P1). The backend prompt-threading half shipped in #1041; this is the frontend + client plumbing.

## What's in it
- **`lib/guided-intake.ts`** — React-free types + helpers (`EMPTY_INTAKE`, `intakeIsEmpty`, `intakeActiveCount`, option lists).
- **`GuidedIntakePanel.tsx`** — collapsible, progressive-disclosure panel (industry / seniority / tone / emphasize[] / downplay[]) with an active-count badge; collapsed by default (never a wall of config).
- **`api-client.ts`** — `seniority/tone/emphasize/downplay` added to `JobSubmitRequest`; `optimizeAndCompile` forwards all five direction fields (with `industry`) into the combined-job body.
- **optimize page** — mounts the panel under the JD textarea, threads the fields into both the main-optimize and trim-to-one-page calls, and shows a *'direction applied'* recap that reflects the user's choices back (the "feel heard" win).

## Testing
- New `guided-intake-client.test.ts`: 6 tests — helper edge cases + asserts the fields are forwarded into the body (and omitted when absent).
- Full frontend unit suite: **475 passed**. `tsc --noEmit` clean, ESLint clean.