### PR TITLE
F2-P0: per-change accept/reject review backend

### DIFF
--- a/backend/app/api/optimize_routes.py
+++ b/backend/app/api/optimize_routes.py
@@ -1,0 +1,145 @@
+"""Per-change accept/reject review endpoints (Feature 2 / P0).
+
+Additive, stateless review layer on top of the existing optimize flow. The
+frontend already holds the original + optimized LaTeX after an optimize run
+(via variants/diff); these endpoints:
+
+  * POST /optimize/segment-changes — compute the server-side diff and return
+    discrete, independently-applicable change hunks + a summary.
+  * POST /optimize/apply-changes   — reconstruct the final LaTeX from the
+    original + the subset of hunk ids the user accepted (for recompile).
+
+Auth is optional (mirrors compile/segment being a pure transform on
+client-supplied text). Both are pure/stateless — no DB, no Redis, no LLM.
+See docs/prd/2026-08-02-input-driven-optimization.md.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..core.logging import get_logger
+from ..middleware.auth_middleware import get_current_user_optional
+from ..services.resume_diff_service import (
+    ChangeHunk,
+    apply_changes,
+    segment_changes,
+    summarize,
+)
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/optimize", tags=["optimize-review"])
+
+# Cap per-document LaTeX well under the global MAX_REQUEST_BODY_BYTES (12MB) so a
+# malformed/hostile body is rejected with a clear 422 before the O(n) diff runs.
+_MAX_LATEX_CHARS = 500_000
+# A resume never has thousands of atomic changes; bound the apply payload.
+_MAX_HUNKS = 2_000
+
+
+class ChangeHunkModel(BaseModel):
+    """Wire representation of a diff hunk (mirrors ChangeHunk)."""
+
+    id: str
+    kind: str  # "modified" | "added" | "removed"
+    original_text: str
+    new_text: str
+    before_context: str = ""
+    after_context: str = ""
+    section: Optional[str] = None
+    rationale: Optional[str] = None
+    original_start: int = 0
+    original_end: int = 0
+
+
+class SegmentChangesRequest(BaseModel):
+    original_latex: str = Field(..., description="Original LaTeX before optimization")
+    optimized_latex: str = Field(..., description="LLM-optimized LaTeX")
+    change_reasons: Optional[List[dict]] = Field(
+        default=None,
+        description="Advisory [{section, change_type, reason}] from the optimizer; "
+        "used only to label hunks, never to decide applied text.",
+    )
+
+
+class SegmentSummary(BaseModel):
+    total: int
+    added: int
+    modified: int
+    removed: int
+
+
+class SegmentChangesResponse(BaseModel):
+    hunks: List[ChangeHunkModel]
+    summary: SegmentSummary
+
+
+class ApplyChangesRequest(BaseModel):
+    original_latex: str = Field(..., description="Original LaTeX to reconstruct from")
+    hunks: List[ChangeHunkModel] = Field(..., description="Hunks from /optimize/segment-changes")
+    accepted_ids: List[str] = Field(
+        default_factory=list, description="Ids of hunks to apply; others keep the original span"
+    )
+
+
+class ApplyChangesResponse(BaseModel):
+    latex: str
+
+
+def _validate_latex_size(*values: str) -> None:
+    for v in values:
+        if len(v) > _MAX_LATEX_CHARS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"LaTeX content exceeds {_MAX_LATEX_CHARS} character limit.",
+            )
+
+
+@router.post("/segment-changes", response_model=SegmentChangesResponse)
+async def segment_changes_endpoint(
+    request: SegmentChangesRequest,
+    _user_id: Optional[str] = Depends(get_current_user_optional),
+):
+    """Compute the original→optimized diff as discrete, applicable change hunks."""
+    _validate_latex_size(request.original_latex, request.optimized_latex)
+    try:
+        hunks: list[ChangeHunk] = segment_changes(
+            request.original_latex,
+            request.optimized_latex,
+            request.change_reasons,
+        )
+    except Exception as exc:  # pragma: no cover - defensive; diff is pure
+        logger.error(f"segment-changes failed: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to segment changes")
+
+    return SegmentChangesResponse(
+        hunks=[ChangeHunkModel(**h.to_dict()) for h in hunks],
+        summary=SegmentSummary(**summarize(hunks)),
+    )
+
+
+@router.post("/apply-changes", response_model=ApplyChangesResponse)
+async def apply_changes_endpoint(
+    request: ApplyChangesRequest,
+    _user_id: Optional[str] = Depends(get_current_user_optional),
+):
+    """Reconstruct the final LaTeX from the original + the accepted hunk ids."""
+    _validate_latex_size(request.original_latex)
+    if len(request.hunks) > _MAX_HUNKS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Too many hunks (max {_MAX_HUNKS}).",
+        )
+    try:
+        latex = apply_changes(
+            request.original_latex,
+            [h.model_dump() for h in request.hunks],
+            set(request.accepted_ids),
+        )
+    except Exception as exc:  # pragma: no cover - defensive; apply is pure
+        logger.error(f"apply-changes failed: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to apply changes")
+
+    return ApplyChangesResponse(latex=latex)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -202,6 +202,11 @@ from .telemetry_routes import router as telemetry_router
 router.include_router(application_router)
 router.include_router(telemetry_router)
 
+# Include per-change accept/reject review routes (Feature 2 / P0)
+from .optimize_routes import router as optimize_review_router
+
+router.include_router(optimize_review_router)
+
 
 def _check_cors_origins_on_startup() -> None:
     """CONFIG-002: Warn if CORS origins include localhost in a production-like environment."""

--- a/backend/app/services/resume_diff_service.py
+++ b/backend/app/services/resume_diff_service.py
@@ -1,0 +1,334 @@
+"""Deterministic server-side diff engine for per-change accept/reject review.
+
+Feature 2 / P0 of docs/prd/2026-08-02-input-driven-optimization.md — the
+flagship "AI drafts, you direct and approve" review layer.
+
+The optimize pipeline (orchestrator.py) produces ``optimized_latex`` plus an
+advisory ``changes_made`` list (``[{section, change_type, reason}]``) from the
+LLM. We do NOT trust the LLM to emit exact substrings for granular apply.
+Instead this module computes the diff **server-side** between the original and
+optimized LaTeX, segments it into discrete, independently-applicable
+``ChangeHunk`` objects, and applies only the hunks the client accepted.
+
+Design invariants (see tests in test_resume_diff.py):
+  * ``apply_changes(orig, hunks, ALL_ids) == optimized`` — every meaningful
+    non-equal region is a hunk, so accepting all reconstructs the optimized doc
+    exactly.
+  * ``apply_changes(orig, hunks, set()) == original`` — rejecting all keeps
+    every original span byte-for-byte.
+  * Order-independent w.r.t. the accepted set (hunks are re-sorted by original
+    position before reconstruction).
+  * Pure — no LLM calls, no I/O, O(n) in document size, fully deterministic.
+
+The advisory ``change_reasons`` are used ONLY to *label* hunks (map a rationale
+by nearest section) — never to decide what text to apply.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import asdict, dataclass
+from difflib import SequenceMatcher
+from typing import Iterable, Optional
+
+# Headings we treat as section anchors when inferring which resume section a
+# hunk belongs to. Best-effort: captures the first brace group of common
+# sectioning commands and resume-template subheadings.
+_SECTION_RE = re.compile(
+    r"\\(?:section|subsection|subsubsection|paragraph)\*?\s*\{([^}]*)\}"
+    r"|\\resume(?:SubHeading|Subheading|SubSubHeading|ProjectHeading)\s*\{([^}]*)\}",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class ChangeHunk:
+    """One discrete, independently-applicable change between original and optimized LaTeX.
+
+    ``id`` is stable across identical inputs (hash of the original span + new
+    span + ordinal index) so the client can accept/reject by id and re-post the
+    same list. ``original_start``/``original_end`` are character offsets into the
+    *original* document; the apply engine uses them to reconstruct exactly and
+    order-independently.
+    """
+
+    id: str
+    kind: str  # "modified" | "added" | "removed"
+    original_text: str
+    new_text: str
+    before_context: str
+    after_context: str
+    section: Optional[str] = None
+    rationale: Optional[str] = None
+    # Character offsets of the hunk's span in the ORIGINAL document. For an
+    # "added" hunk the span is empty (original_start == original_end == insertion
+    # point).
+    original_start: int = 0
+    original_end: int = 0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _line_char_offsets(lines: list[str]) -> list[int]:
+    """Return char offset of the start of each line, plus a final total-length entry.
+
+    ``offsets[i]`` is the char index where ``lines[i]`` begins; ``offsets[len]``
+    is the total document length. Built from ``splitlines(keepends=True)`` output
+    so ``"".join(lines)`` reproduces the source exactly.
+    """
+    offsets = [0]
+    total = 0
+    for ln in lines:
+        total += len(ln)
+        offsets.append(total)
+    return offsets
+
+
+def _normalise_reasons(change_reasons: Optional[Iterable[dict]]) -> list[dict]:
+    reasons: list[dict] = []
+    for r in change_reasons or []:
+        if not isinstance(r, dict):
+            continue
+        reason_text = r.get("reason")
+        if not reason_text:
+            continue
+        reasons.append(
+            {
+                "section": (r.get("section") or "").strip(),
+                "change_type": (r.get("change_type") or "").strip().lower(),
+                "reason": str(reason_text),
+                "_used": False,
+            }
+        )
+    return reasons
+
+
+def _infer_section(original_latex: str, position: int) -> Optional[str]:
+    """Nearest preceding ``\\section``/``\\subsection``/resume-subheading before ``position``."""
+    nearest: Optional[str] = None
+    for m in _SECTION_RE.finditer(original_latex, 0, position):
+        heading = m.group(1) if m.group(1) is not None else m.group(2)
+        if heading is not None:
+            nearest = heading.strip()
+    return nearest or None
+
+
+def _match_rationale(
+    section: Optional[str], kind: str, reasons: list[dict]
+) -> Optional[str]:
+    """Best-effort: pick a reason whose section matches this hunk's section.
+
+    Prefers a reason with a matching ``change_type`` too; consumes the reason so
+    the same rationale is not reused for multiple hunks. Returns None when no
+    section match exists — advisory labels never block the apply path.
+    """
+    if not section or not reasons:
+        return None
+    sec_l = section.strip().lower()
+
+    # First pass: section AND change_type match.
+    for r in reasons:
+        if r["_used"]:
+            continue
+        if r["section"].lower() == sec_l and r["change_type"] == kind:
+            r["_used"] = True
+            return r["reason"]
+    # Second pass: section match only.
+    for r in reasons:
+        if r["_used"]:
+            continue
+        if r["section"].lower() == sec_l:
+            r["_used"] = True
+            return r["reason"]
+    return None
+
+
+def _stable_id(index: int, original_text: str, new_text: str) -> str:
+    digest = hashlib.sha1(
+        f"{index}\x00{original_text}\x00{new_text}".encode("utf-8")
+    ).hexdigest()
+    return digest[:16]
+
+
+def segment_changes(
+    original_latex: str,
+    optimized_latex: str,
+    change_reasons: Optional[Iterable[dict]] = None,
+) -> list[ChangeHunk]:
+    """Segment the original→optimized diff into discrete, applicable change hunks.
+
+    Line-based ``SequenceMatcher`` (robust and simple for LaTeX). Consecutive
+    non-equal opcodes are grouped into a single hunk. Pure-whitespace-only hunks
+    (the two sides are equal after ``.strip()``) are ignored — they are cosmetic
+    reflows the user should not have to review. Hunks are returned ordered by
+    original position with stable ids.
+
+    ``change_reasons`` (``[{section, change_type, reason}]``, advisory) only
+    labels hunks with a rationale by nearest section; it is never used to decide
+    applied text.
+    """
+    orig_lines = original_latex.splitlines(keepends=True)
+    opt_lines = optimized_latex.splitlines(keepends=True)
+    offsets = _line_char_offsets(orig_lines)
+    reasons = _normalise_reasons(change_reasons)
+
+    matcher = SequenceMatcher(a=orig_lines, b=opt_lines, autojunk=False)
+    opcodes = matcher.get_opcodes()
+
+    hunks: list[ChangeHunk] = []
+    index = 0
+    i = 0
+    n = len(opcodes)
+    while i < n:
+        tag, i1, i2, j1, j2 = opcodes[i]
+        if tag == "equal":
+            i += 1
+            continue
+
+        # Group a run of consecutive non-equal opcodes into one hunk. (In
+        # practice get_opcodes separates non-equal blocks with 'equal', so a run
+        # is normally length 1 — this loop is defensive.)
+        run_i1, run_i2 = i1, i2
+        run_j1, run_j2 = j1, j2
+        k = i + 1
+        while k < n and opcodes[k][0] != "equal":
+            _, _, e_i2, _, e_j2 = opcodes[k]
+            run_i2 = e_i2
+            run_j2 = e_j2
+            k += 1
+        i = k
+
+        original_text = "".join(orig_lines[run_i1:run_i2])
+        new_text = "".join(opt_lines[run_j1:run_j2])
+
+        # Ignore cosmetic whitespace-only reflows.
+        if original_text.strip() == new_text.strip():
+            continue
+
+        if run_i1 == run_i2:
+            kind = "added"
+        elif run_j1 == run_j2:
+            kind = "removed"
+        else:
+            kind = "modified"
+
+        char_start = offsets[run_i1]
+        char_end = offsets[run_i2]
+
+        section = _infer_section(original_latex, char_start)
+        rationale = _match_rationale(section, kind, reasons)
+
+        before_context = orig_lines[run_i1 - 1].rstrip("\n") if run_i1 > 0 else ""
+        after_context = orig_lines[run_i2].rstrip("\n") if run_i2 < len(orig_lines) else ""
+
+        hunks.append(
+            ChangeHunk(
+                id=_stable_id(index, original_text, new_text),
+                kind=kind,
+                original_text=original_text,
+                new_text=new_text,
+                before_context=before_context.strip(),
+                after_context=after_context.strip(),
+                section=section,
+                rationale=rationale,
+                original_start=char_start,
+                original_end=char_end,
+            )
+        )
+        index += 1
+
+    return hunks
+
+
+def summarize(hunks: Iterable[ChangeHunk]) -> dict:
+    """Count hunks by kind for the review summary card."""
+    total = added = modified = removed = 0
+    for h in hunks:
+        total += 1
+        if h.kind == "added":
+            added += 1
+        elif h.kind == "removed":
+            removed += 1
+        else:
+            modified += 1
+    return {"total": total, "added": added, "modified": modified, "removed": removed}
+
+
+def _hunk_span(
+    original_latex: str, h: dict
+) -> Optional[tuple[int, int, str, str, Optional[str]]]:
+    """Resolve a hunk dict to (start, end, original_text, new_text, id) in original_latex.
+
+    Trusts the stored offsets when they still match the original span; otherwise
+    falls back to locating ``original_text`` by search. Returns None when the
+    hunk cannot be placed deterministically (dropped rather than mis-applied).
+    """
+    hid = h.get("id")
+    original_text = h.get("original_text", "") or ""
+    new_text = h.get("new_text", "") or ""
+    start = h.get("original_start")
+    end = h.get("original_end")
+
+    n = len(original_latex)
+    if (
+        isinstance(start, int)
+        and isinstance(end, int)
+        and 0 <= start <= end <= n
+        and original_latex[start:end] == original_text
+    ):
+        return start, end, original_text, new_text, hid
+
+    # Offsets missing/stale — try to locate the original span by content.
+    if original_text:
+        idx = original_latex.find(original_text)
+        if idx != -1:
+            return idx, idx + len(original_text), original_text, new_text, hid
+        return None
+
+    # "added" hunk (empty original span) with no usable offset: cannot place.
+    return None
+
+
+def apply_changes(
+    original_latex: str,
+    hunks: Iterable[dict],
+    accepted_ids: Iterable[str],
+) -> str:
+    """Reconstruct the final LaTeX from the original + the accepted hunk ids.
+
+    Walks the original left-to-right. For each hunk (re-sorted by original
+    position, so the result is independent of the order/contents of
+    ``accepted_ids``): emit ``new_text`` when the hunk id is accepted, otherwise
+    keep the original span untouched. Untouched (equal) regions are copied
+    verbatim.
+
+    Guarantees ``apply_changes(orig, segment(orig, opt), ALL) == opt`` and
+    ``apply_changes(orig, segment(orig, opt), set()) == orig`` whenever every
+    non-equal region was captured as a hunk (i.e. no cosmetic whitespace-only
+    regions were dropped).
+    """
+    accepted = set(accepted_ids)
+
+    spans: list[tuple[int, int, str, str, Optional[str]]] = []
+    for h in hunks:
+        resolved = _hunk_span(original_latex, dict(h))
+        if resolved is not None:
+            spans.append(resolved)
+
+    # Sort by original position; makes the walk order-independent w.r.t. input order.
+    spans.sort(key=lambda s: (s[0], s[1]))
+
+    out: list[str] = []
+    cursor = 0
+    for start, end, original_text, new_text, hid in spans:
+        if start < cursor:
+            # Overlapping spans (should not happen for hunks from segment_changes)
+            # — skip to keep reconstruction deterministic and non-corrupting.
+            continue
+        out.append(original_latex[cursor:start])
+        out.append(new_text if hid in accepted else original_text)
+        cursor = end
+    out.append(original_latex[cursor:])
+    return "".join(out)

--- a/backend/test/test_resume_diff.py
+++ b/backend/test/test_resume_diff.py
@@ -1,0 +1,338 @@
+"""Tests for the per-change accept/reject diff engine (Feature 2 / P0).
+
+Correctness-critical: the round-trip invariant (accept-all == optimized,
+accept-none == original) is what makes selective apply safe. See
+app/services/resume_diff_service.py.
+"""
+
+import pytest
+
+from app.services.resume_diff_service import (
+    apply_changes,
+    segment_changes,
+    summarize,
+)
+
+# ── Realistic LaTeX resume samples (multi-section) ───────────────────────────
+
+_BASE = r"""\documentclass[letterpaper,11pt]{article}
+\begin{document}
+\section*{Experience}
+\textbf{Software Engineer} at Acme Corp \hfill 2020--Present
+\begin{itemize}
+    \item Built distributed systems serving 1M users
+    \item Reduced latency by 40 percent through caching
+    \item Mentored two junior engineers
+\end{itemize}
+\section*{Skills}
+Python, TypeScript, PostgreSQL, Redis
+\section*{Education}
+BSc Computer Science, State University
+\end{document}
+"""
+
+# Reworded a line (modified).
+_REWORDED = _BASE.replace(
+    "    \\item Built distributed systems serving 1M users\n",
+    "    \\item Architected distributed systems serving 1M+ users with 99.9\\% uptime\n",
+)
+
+# Added a bullet (insert).
+_ADDED = _BASE.replace(
+    "    \\item Mentored two junior engineers\n",
+    "    \\item Mentored two junior engineers\n    \\item Led migration to Kubernetes\n",
+)
+
+# Removed a bullet (delete).
+_REMOVED = _BASE.replace(
+    "    \\item Reduced latency by 40 percent through caching\n",
+    "",
+)
+
+# Changes in two different sections at once.
+_MULTI = _BASE.replace(
+    "    \\item Built distributed systems serving 1M users\n",
+    "    \\item Architected distributed systems serving 1M+ users\n",
+).replace(
+    "Python, TypeScript, PostgreSQL, Redis\n",
+    "Python, TypeScript, Go, PostgreSQL, Redis, Docker\n",
+)
+
+_ALL_PAIRS = {
+    "reworded": (_BASE, _REWORDED),
+    "added": (_BASE, _ADDED),
+    "removed": (_BASE, _REMOVED),
+    "multi_section": (_BASE, _MULTI),
+}
+
+
+def _apply_all(original, optimized):
+    hunks = segment_changes(original, optimized)
+    ids = [h.id for h in hunks]
+    return apply_changes(original, [h.to_dict() for h in hunks], set(ids)), hunks
+
+
+# ── Round-trip invariant ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", sorted(_ALL_PAIRS))
+def test_round_trip_accept_all_equals_optimized(name):
+    original, optimized = _ALL_PAIRS[name]
+    result, hunks = _apply_all(original, optimized)
+    assert hunks, f"{name}: expected at least one hunk"
+    assert result == optimized, f"{name}: accept-all must reproduce the optimized doc exactly"
+
+
+@pytest.mark.parametrize("name", sorted(_ALL_PAIRS))
+def test_round_trip_accept_none_equals_original(name):
+    original, optimized = _ALL_PAIRS[name]
+    hunks = segment_changes(original, optimized)
+    result = apply_changes(original, [h.to_dict() for h in hunks], set())
+    assert result == original, f"{name}: accept-none must reproduce the original doc exactly"
+
+
+def test_round_trip_is_order_independent():
+    """Reconstruction must not depend on the order of accepted_ids."""
+    original, optimized = _BASE, _MULTI
+    hunks = segment_changes(original, optimized)
+    ids = [h.id for h in hunks]
+    forward = apply_changes(original, [h.to_dict() for h in hunks], ids)
+    reverse = apply_changes(original, [h.to_dict() for h in hunks], list(reversed(ids)))
+    # Passing hunks in reversed order to apply must also work (spans are re-sorted).
+    reordered = apply_changes(
+        original, [h.to_dict() for h in reversed(hunks)], set(ids)
+    )
+    assert forward == optimized
+    assert reverse == optimized
+    assert reordered == optimized
+
+
+def test_identical_documents_yield_no_hunks():
+    assert segment_changes(_BASE, _BASE) == []
+    assert apply_changes(_BASE, [], set()) == _BASE
+
+
+# ── Partial acceptance (hand-checked) ────────────────────────────────────────
+
+
+def test_partial_acceptance_hand_checked():
+    original = (
+        "\\section*{Experience}\n"
+        "\\item Alpha original\n"
+        "\\item KEEP THIS LINE\n"
+        "\\item Beta original\n"
+    )
+    optimized = (
+        "\\section*{Experience}\n"
+        "\\item Alpha changed\n"
+        "\\item KEEP THIS LINE\n"
+        "\\item Beta changed\n"
+    )
+    hunks = segment_changes(original, optimized)
+    assert len(hunks) == 2, "expected two distinct hunks separated by the kept line"
+
+    hunk_alpha = next(h for h in hunks if "Alpha" in h.original_text)
+    hunk_beta = next(h for h in hunks if "Beta" in h.original_text)
+
+    # Accept only the Alpha hunk.
+    result = apply_changes(
+        original, [h.to_dict() for h in hunks], {hunk_alpha.id}
+    )
+    expected = (
+        "\\section*{Experience}\n"
+        "\\item Alpha changed\n"      # accepted -> new_text
+        "\\item KEEP THIS LINE\n"     # untouched equal region
+        "\\item Beta original\n"      # rejected -> original span
+    )
+    assert result == expected
+
+    # Accept only the Beta hunk (symmetric).
+    result2 = apply_changes(
+        original, [h.to_dict() for h in hunks], {hunk_beta.id}
+    )
+    assert "Alpha original" in result2
+    assert "Beta changed" in result2
+
+
+# ── Stable ids ───────────────────────────────────────────────────────────────
+
+
+def test_ids_are_stable_across_identical_inputs():
+    a = segment_changes(_BASE, _MULTI)
+    b = segment_changes(_BASE, _MULTI)
+    assert [h.id for h in a] == [h.id for h in b]
+
+
+def test_ids_differ_across_distinct_hunks():
+    hunks = segment_changes(_BASE, _MULTI)
+    ids = [h.id for h in hunks]
+    assert len(ids) == len(set(ids)), "each hunk must have a unique id"
+
+
+# ── Kind classification ──────────────────────────────────────────────────────
+
+
+def test_kind_added():
+    hunks = segment_changes(_BASE, _ADDED)
+    assert len(hunks) == 1
+    assert hunks[0].kind == "added"
+    assert hunks[0].original_text == ""
+    assert "Kubernetes" in hunks[0].new_text
+
+
+def test_kind_removed():
+    hunks = segment_changes(_BASE, _REMOVED)
+    assert len(hunks) == 1
+    assert hunks[0].kind == "removed"
+    assert hunks[0].new_text == ""
+    assert "caching" in hunks[0].original_text
+
+
+def test_kind_modified():
+    hunks = segment_changes(_BASE, _REWORDED)
+    assert len(hunks) == 1
+    assert hunks[0].kind == "modified"
+
+
+# ── Section + rationale inference ────────────────────────────────────────────
+
+
+def test_section_inference_starred_heading():
+    hunks = segment_changes(_BASE, _REWORDED)
+    assert hunks[0].section == "Experience"
+
+
+def test_section_inference_multiple_sections():
+    hunks = segment_changes(_BASE, _MULTI)
+    by_section = {h.section for h in hunks}
+    assert "Experience" in by_section
+    assert "Skills" in by_section
+
+
+def test_section_inference_nonstarred_heading():
+    original = "\\section{Projects}\n\\item Original project line\n"
+    optimized = "\\section{Projects}\n\\item Rewritten project line\n"
+    hunks = segment_changes(original, optimized)
+    assert len(hunks) == 1
+    assert hunks[0].section == "Projects"
+
+
+def test_rationale_maps_by_section():
+    reasons = [
+        {"section": "Experience", "change_type": "modified", "reason": "Stronger action verb + quantified impact"},
+    ]
+    hunks = segment_changes(_BASE, _REWORDED, change_reasons=reasons)
+    assert hunks[0].rationale == "Stronger action verb + quantified impact"
+
+
+def test_rationale_none_when_no_matching_section():
+    reasons = [{"section": "Publications", "change_type": "modified", "reason": "n/a"}]
+    hunks = segment_changes(_BASE, _REWORDED, change_reasons=reasons)
+    assert hunks[0].rationale is None
+
+
+def test_rationale_none_when_no_reasons_supplied():
+    hunks = segment_changes(_BASE, _REWORDED)
+    assert hunks[0].rationale is None
+
+
+# ── Whitespace-only diffs are ignored ────────────────────────────────────────
+
+
+def test_whitespace_only_indentation_ignored():
+    original = "\\section*{Skills}\n\\item Python and Go\n"
+    optimized = "\\section*{Skills}\n        \\item Python and Go\n"  # indent only
+    assert segment_changes(original, optimized) == []
+
+
+def test_whitespace_only_blank_line_ignored():
+    original = "\\item A\n\\item B\n"
+    optimized = "\\item A\n\n\\item B\n"  # inserted blank line
+    assert segment_changes(original, optimized) == []
+
+
+def test_meaningful_change_not_ignored_despite_whitespace():
+    original = "\\item  Python\n"
+    optimized = "\\item Python and Go\n"
+    hunks = segment_changes(original, optimized)
+    assert len(hunks) == 1
+
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+
+def test_summarize_counts():
+    hunks = segment_changes(_BASE, _MULTI)
+    summary = summarize(hunks)
+    assert summary["total"] == len(hunks)
+    assert summary["total"] == summary["added"] + summary["modified"] + summary["removed"]
+
+
+# ── apply_changes robustness ─────────────────────────────────────────────────
+
+
+def test_apply_tolerates_stale_offsets_via_content_search():
+    """If offsets are missing, apply falls back to locating original_text."""
+    hunks = segment_changes(_BASE, _REWORDED)
+    payload = []
+    for h in hunks:
+        d = h.to_dict()
+        d.pop("original_start", None)
+        d.pop("original_end", None)
+        payload.append(d)
+    ids = {h.id for h in hunks}
+    assert apply_changes(_BASE, payload, ids) == _REWORDED
+
+
+def test_apply_unknown_ids_are_noops():
+    hunks = segment_changes(_BASE, _REWORDED)
+    result = apply_changes(_BASE, [h.to_dict() for h in hunks], {"does-not-exist"})
+    assert result == _BASE
+
+
+# ── Endpoint smoke tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_segment_then_apply_all_endpoint(client):
+    seg = await client.post(
+        "/optimize/segment-changes",
+        json={"original_latex": _BASE, "optimized_latex": _MULTI},
+    )
+    assert seg.status_code == 200
+    body = seg.json()
+    assert body["summary"]["total"] == len(body["hunks"])
+    assert body["hunks"], "expected hunks"
+
+    accepted = [h["id"] for h in body["hunks"]]
+    apply = await client.post(
+        "/optimize/apply-changes",
+        json={"original_latex": _BASE, "hunks": body["hunks"], "accepted_ids": accepted},
+    )
+    assert apply.status_code == 200
+    assert apply.json()["latex"] == _MULTI
+
+
+@pytest.mark.asyncio
+async def test_apply_none_endpoint_returns_original(client):
+    seg = await client.post(
+        "/optimize/segment-changes",
+        json={"original_latex": _BASE, "optimized_latex": _MULTI},
+    )
+    hunks = seg.json()["hunks"]
+    apply = await client.post(
+        "/optimize/apply-changes",
+        json={"original_latex": _BASE, "hunks": hunks, "accepted_ids": []},
+    )
+    assert apply.status_code == 200
+    assert apply.json()["latex"] == _BASE
+
+
+@pytest.mark.asyncio
+async def test_segment_rejects_oversized_latex(client):
+    huge = "x" * 500_001
+    resp = await client.post(
+        "/optimize/segment-changes",
+        json={"original_latex": huge, "optimized_latex": huge},
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
Closes #1047.

The flagship **"AI drafts, you direct and approve"** review backend (Input-Driven Optimization PRD, P0). Computes the original→optimized diff **server-side** and segments it into discrete, independently-applicable change hunks, so the client can accept/reject/edit each one and we apply only what's accepted — no trusting the LLM to emit exact substrings.

## What's in it
- **`resume_diff_service.py`** — pure, deterministic engine. `segment_changes` (line-based `SequenceMatcher`, keepends) → `ChangeHunk` list with stable SHA1 ids, character offsets, kind (`modified`/`added`/`removed`), `before/after_context`, and section + rationale labels; `apply_changes` walks the original left-to-right and reconstructs order-independently; `summarize` counts by kind.
- **`optimize_routes.py`** — `POST /optimize/segment-changes` and `POST /optimize/apply-changes`. Stateless, auth-optional (mirrors compile), input-capped (500k chars/doc → 422, 2000 hunks max).
- **`routes.py`** — registers the router.

## Invariants (proven by tests)
- accept-all == `optimized` exactly; accept-none == `original` exactly (byte-for-byte, via `keepends=True` + exact char offsets).
- Order-independent w.r.t. `accepted_ids` and hunk order.
- Cosmetic whitespace-only reflows are skipped; stale/unplaceable offsets fall back to content search then drop rather than mis-apply.

## Testing
- `test_resume_diff.py`: **31 passed** (round-trip, classification, whitespace skips, stale-offset fallback + 3 live-ASGI endpoint smoke tests: segment 200, apply-all, apply-none, oversized 422).
- `ruff check` clean on all files.