### PR TITLE
F1 Phase 1: GitHub project import backend

### DIFF
--- a/backend/app/api/github_routes.py
+++ b/backend/app/api/github_routes.py
@@ -2,8 +2,9 @@
 
 import secrets
 import urllib.parse
+import uuid
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -12,15 +13,18 @@ from pydantic import BaseModel
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..core.config import settings
+from ..core.config import resolve_plan_family, settings
 from ..core.logging import get_logger
-from ..core.redis import cache_manager
+from ..core.redis import cache_manager, get_redis_client
 from ..database.connection import get_db
 from ..database.models import Resume, User
 from ..middleware.auth_middleware import get_current_user_required
 from ..middleware.entitlements import require_feature
+from ..services import github_projects_service as gh_projects
+from ..services.api_key_service import api_key_service
 from ..services.encryption_service import encryption_service
 from ..services.github_sync_service import github_sync_service
+from ..workers.github_import_worker import submit_github_import
 
 logger = get_logger(__name__)
 
@@ -52,6 +56,16 @@ class GitHubResumeStatus(BaseModel):
     github_sync_enabled: bool
     github_repo_name: Optional[str] = None
     github_last_sync_at: Optional[str] = None
+
+
+class GitHubImportStartResponse(BaseModel):
+    job_id: str
+
+
+class GitHubImportResultResponse(BaseModel):
+    status: str  # pending | completed | failed
+    projects: List[dict] = []
+    error: Optional[str] = None
 
 
 # ── OAuth flow ───────────────────────────────────────────────────────────────
@@ -390,6 +404,82 @@ async def pull_from_github(
 
 
 # ── Resume GitHub status ─────────────────────────────────────────────────────
+
+@router.post("/import-projects", response_model=GitHubImportStartResponse)
+async def import_github_projects(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(require_feature("ai_import_github")),
+):
+    """Enqueue an async import of the user's top PUBLIC GitHub projects.
+
+    Reads public repository data only (see github_projects_service). Requires a
+    connected GitHub account; summarization runs on the user's own LLM key when
+    they have one (BYOK), otherwise on the platform key.
+    """
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user or not user.github_access_token:
+        raise HTTPException(
+            status_code=400,
+            detail="GitHub not connected. Go to Settings → GitHub Integration to connect your account.",
+        )
+
+    github_token = encryption_service.decrypt(user.github_access_token)
+
+    # Resolve the LLM key the same way optimize/cover-letter do: the user's own
+    # OpenAI key (BYOK) when present, else fall back to the platform key inside
+    # the worker (api_key=None → worker uses settings.OPENAI_API_KEY).
+    api_key = None
+    try:
+        api_key = await api_key_service.get_user_provider(db, user_id, "openai")
+    except Exception:
+        api_key = None
+
+    user_plan = "free"
+    if isinstance(user.subscription_plan, str) and user.subscription_plan:
+        user_plan = user.subscription_plan
+
+    job_id = str(uuid.uuid4())
+    try:
+        submit_github_import(
+            job_id=job_id,
+            user_id=user_id,
+            github_token=github_token,
+            api_key=api_key,
+            user_plan=resolve_plan_family(user_plan),
+        )
+    except Exception as exc:
+        logger.error(f"Failed to submit GitHub import job {job_id}: {exc}")
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to start GitHub import. Please try again.",
+        )
+
+    return GitHubImportStartResponse(job_id=job_id)
+
+
+@router.get("/import-projects/{job_id}", response_model=GitHubImportResultResponse)
+async def get_github_import_result(
+    job_id: str,
+    user_id: str = Depends(require_feature("ai_import_github")),
+):
+    """Return the candidate ProjectEvidence for an import job.
+
+    ``status`` is ``pending`` until the worker writes a result (~1h TTL),
+    then ``completed`` or ``failed``.
+    """
+    redis = await get_redis_client()
+    raw = await redis.get(gh_projects.import_result_key(job_id))
+    envelope = gh_projects.decode_result(raw)
+    if envelope is None:
+        return GitHubImportResultResponse(status="pending", projects=[])
+
+    return GitHubImportResultResponse(
+        status=envelope.get("status", "pending"),
+        projects=envelope.get("projects", []),
+        error=envelope.get("error"),
+    )
+
 
 @router.get("/resumes/{resume_id}/status", response_model=GitHubResumeStatus)
 async def get_resume_github_status(

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -47,6 +47,7 @@ celery_app = Celery(
         "app.workers.cover_letter_worker",
         "app.workers.interview_prep_worker",
         "app.workers.converter_worker",
+        "app.workers.github_import_worker",
     ]
 )
 
@@ -70,6 +71,7 @@ celery_app.conf.update(
         "app.workers.cover_letter_worker.*": {"queue": "llm"},
         "app.workers.interview_prep_worker.*": {"queue": "llm"},
         "app.workers.converter_worker.*": {"queue": "llm"},
+        "app.workers.github_import_worker.*": {"queue": "llm"},
     },
 
     # Task configuration

--- a/backend/app/core/feature_registry.py
+++ b/backend/app/core/feature_registry.py
@@ -89,6 +89,8 @@ FEATURE_REGISTRY: list[FeatureDef] = [
                "Import references from Zotero."),
     FeatureDef("integration_mendeley", "Mendeley Integration", "integrations",
                "Import references from Mendeley."),
+    FeatureDef("ai_import_github", "GitHub Project Import", "integrations",
+               "Import your top public GitHub projects as AI-summarized resume evidence."),
     # ---- analytics --------------------------------------------------------
     FeatureDef("analytics", "Analytics Dashboard", "analytics",
                "Usage and performance analytics dashboard."),

--- a/backend/app/services/github_projects_service.py
+++ b/backend/app/services/github_projects_service.py
@@ -1,0 +1,467 @@
+"""GitHub project-import service (Feature 1 — external sources to resume).
+
+Pure, testable building blocks that turn a connected user's **public** GitHub
+projects into resume-ready ``ProjectEvidence`` records:
+
+    fetch_candidate_repos → rank_repos → (fetch_repo_readme + fetch_repo_languages)
+        → summarize_project → build_project_evidence
+
+PRIVACY: this module reads PUBLIC repository data only. The GraphQL query is
+scoped to ``ownerAffiliations: OWNER`` and every REST call targets a repo the
+authenticated user owns, but only public fields (README, languages, stars) are
+consumed. No private repository content is ever read, summarized, or stored.
+
+All network + LLM calls are injectable (pass a ``client``) so tests can mock
+them without touching the network. Per-user REST calls are made serially by the
+caller (the worker) to stay well under GitHub's secondary rate limits.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ..core.config import settings
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+GITHUB_API = "https://api.github.com"
+GITHUB_GRAPHQL = "https://api.github.com/graphql"
+
+# Minimum README length (chars) for a repo to count as documented. Repos with a
+# shorter/absent README are excluded from ranking — there is nothing to summarize.
+_MIN_README_CHARS = 100
+
+# README excerpt is truncated to ~1500 tokens before it reaches the LLM. ~4 chars
+# per token is the usual English approximation, so 6000 chars is the ceiling.
+_README_TRUNCATE_CHARS = 6000
+
+_MAX_RESULTS = 6
+
+
+# ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+
+def _headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+# One GraphQL call fetches pinned + top-starred owned, non-fork repos plus README
+# existence, staying at ~1 point of the 5,000/hr budget. ``viewer`` is the
+# authenticated user, so no username round-trip is needed.
+_REPO_FIELDS = """
+  name
+  description
+  url
+  stargazerCount
+  forkCount
+  isArchived
+  pushedAt
+  primaryLanguage { name }
+  repositoryTopics(first: 10) { nodes { topic { name } } }
+  owner { login }
+  readmeMd: object(expression: "HEAD:README.md") { ... on Blob { byteSize } }
+  readmePlain: object(expression: "HEAD:README") { ... on Blob { byteSize } }
+  readmeRst: object(expression: "HEAD:README.rst") { ... on Blob { byteSize } }
+  readmeLower: object(expression: "HEAD:readme.md") { ... on Blob { byteSize } }
+"""
+
+_CANDIDATES_QUERY = f"""
+query {{
+  viewer {{
+    login
+    pinnedItems(first: 6, types: REPOSITORY) {{
+      nodes {{ ... on Repository {{ {_REPO_FIELDS} }} }}
+    }}
+    repositories(
+      first: 100
+      ownerAffiliations: OWNER
+      isFork: false
+      orderBy: {{ field: STARGAZERS, direction: DESC }}
+    ) {{
+      nodes {{ {_REPO_FIELDS} }}
+    }}
+  }}
+}}
+"""
+
+
+def _readme_bytes(node: Dict[str, Any]) -> int:
+    """Largest byteSize across the README aliases (0 when none exist)."""
+    sizes = []
+    for alias in ("readmeMd", "readmePlain", "readmeRst", "readmeLower"):
+        obj = node.get(alias)
+        if isinstance(obj, dict) and isinstance(obj.get("byteSize"), int):
+            sizes.append(obj["byteSize"])
+    return max(sizes) if sizes else 0
+
+
+def _parse_repo_node(node: Dict[str, Any], pinned: bool) -> Optional[Dict[str, Any]]:
+    """Normalize a GraphQL Repository node to a flat candidate dict."""
+    if not node or not node.get("name"):
+        return None
+
+    primary = node.get("primaryLanguage") or {}
+    topic_nodes = (node.get("repositoryTopics") or {}).get("nodes") or []
+    topics = [
+        t["topic"]["name"]
+        for t in topic_nodes
+        if isinstance(t, dict) and t.get("topic", {}).get("name")
+    ]
+    owner = (node.get("owner") or {}).get("login") or ""
+
+    return {
+        "name": node["name"],
+        "owner": owner,
+        "description": node.get("description"),
+        "url": node.get("url"),
+        "stars": node.get("stargazerCount") or 0,
+        "forks": node.get("forkCount") or 0,
+        "primary_language": primary.get("name"),
+        "topics": topics,
+        "pushed_at": node.get("pushedAt"),
+        "is_archived": bool(node.get("isArchived")),
+        "readme_bytes": _readme_bytes(node),
+        "pinned": pinned,
+    }
+
+
+def fetch_candidate_repos(
+    token: str, *, client: Optional[httpx.Client] = None
+) -> List[Dict[str, Any]]:
+    """Fetch pinned + top owned public repos in ONE GraphQL call.
+
+    Returns a de-duplicated list of normalized candidate dicts. Pinned repos are
+    flagged (``pinned=True``) so ranking can boost them.
+    """
+    owns_client = client is None
+    client = client or httpx.Client(timeout=20)
+    try:
+        resp = client.post(
+            GITHUB_GRAPHQL,
+            headers=_headers(token),
+            json={"query": _CANDIDATES_QUERY},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    finally:
+        if owns_client:
+            client.close()
+
+    if data.get("errors"):
+        logger.warning(f"GitHub GraphQL returned errors: {data['errors']}")
+
+    viewer = (data.get("data") or {}).get("viewer") or {}
+    pinned_nodes = (viewer.get("pinnedItems") or {}).get("nodes") or []
+    repo_nodes = (viewer.get("repositories") or {}).get("nodes") or []
+
+    by_key: Dict[str, Dict[str, Any]] = {}
+    # Pinned first so a repo appearing in both keeps pinned=True.
+    for node in pinned_nodes:
+        parsed = _parse_repo_node(node, pinned=True)
+        if parsed:
+            by_key[f"{parsed['owner']}/{parsed['name']}"] = parsed
+    for node in repo_nodes:
+        parsed = _parse_repo_node(node, pinned=False)
+        if parsed:
+            key = f"{parsed['owner']}/{parsed['name']}"
+            if key not in by_key:
+                by_key[key] = parsed
+
+    return list(by_key.values())
+
+
+# ── Ranking (pure) ───────────────────────────────────────────────────────────
+
+
+def _months_since(pushed_at: Optional[str]) -> float:
+    """Months since the last push. Large (→ recency term ~0) when unknown."""
+    if not pushed_at:
+        return 120.0
+    try:
+        dt = datetime.fromisoformat(pushed_at.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return 120.0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - dt
+    return max(delta.days, 0) / 30.0
+
+
+# A pinned repo is user-curated — the single strongest signal — so it always
+# outranks organic repos. Larger than any organic score the formula can produce.
+_PINNED_BOOST = 100.0
+
+
+def _score(repo: Dict[str, Any]) -> float:
+    stars = repo.get("stars", 0) or 0
+    forks = repo.get("forks", 0) or 0
+    has_readme = 1.0 if (repo.get("readme_bytes", 0) or 0) >= _MIN_README_CHARS else 0.0
+    has_topics = 1.0 if repo.get("topics") else 0.0
+    has_description = 1.0 if repo.get("description") else 0.0
+
+    score = (
+        3.0 * math.log10(stars + 1)
+        + 1.5 * math.log10(forks + 1)
+        + 2.0 * math.exp(-_months_since(repo.get("pushed_at")) / 12.0)
+        + 1.0 * has_readme
+        + 0.5 * has_topics
+        + 0.5 * has_description
+    )
+    if repo.get("pinned"):
+        score += _PINNED_BOOST
+    return score
+
+
+def rank_repos(repos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Rank candidate repos and return the top ``_MAX_RESULTS``.
+
+    Excludes archived repos and repos whose README is shorter than
+    ``_MIN_README_CHARS`` (nothing worth summarizing). Pinned repos always sort
+    to the top via a large boost. Each returned dict carries its ``score``.
+    """
+    ranked: List[Dict[str, Any]] = []
+    for repo in repos:
+        if repo.get("is_archived"):
+            continue
+        if (repo.get("readme_bytes", 0) or 0) < _MIN_README_CHARS:
+            continue
+        scored = dict(repo)
+        scored["score"] = _score(repo)
+        ranked.append(scored)
+
+    ranked.sort(key=lambda r: r["score"], reverse=True)
+    return ranked[:_MAX_RESULTS]
+
+
+# ── Per-repo REST fetches ────────────────────────────────────────────────────
+
+
+def fetch_repo_readme(
+    token: str, owner: str, name: str, *, client: Optional[httpx.Client] = None
+) -> Optional[str]:
+    """Fetch and base64-decode a repo's README. None when absent/too short/error."""
+    owns_client = client is None
+    client = client or httpx.Client(timeout=15)
+    try:
+        resp = client.get(
+            f"{GITHUB_API}/repos/{owner}/{name}/readme", headers=_headers(token)
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning(f"README fetch failed for {owner}/{name}: {exc}")
+        return None
+    finally:
+        if owns_client:
+            client.close()
+
+    content = data.get("content")
+    if not content:
+        return None
+    try:
+        text = base64.b64decode(content).decode("utf-8", errors="replace")
+    except (ValueError, TypeError) as exc:
+        logger.warning(f"README decode failed for {owner}/{name}: {exc}")
+        return None
+
+    return text if len(text.strip()) >= _MIN_README_CHARS else None
+
+
+def fetch_repo_languages(
+    token: str, owner: str, name: str, *, client: Optional[httpx.Client] = None
+) -> Dict[str, int]:
+    """Fetch a repo's language byte breakdown ({language: bytes}). Empty on error."""
+    owns_client = client is None
+    client = client or httpx.Client(timeout=15)
+    try:
+        resp = client.get(
+            f"{GITHUB_API}/repos/{owner}/{name}/languages", headers=_headers(token)
+        )
+        if resp.status_code == 404:
+            return {}
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning(f"Languages fetch failed for {owner}/{name}: {exc}")
+        return {}
+    finally:
+        if owns_client:
+            client.close()
+
+    return {k: v for k, v in data.items() if isinstance(v, int)}
+
+
+# ── LLM summarization ────────────────────────────────────────────────────────
+
+_SUMMARY_SYSTEM_PROMPT = (
+    "You are a resume-writing assistant. Given a GitHub project's metadata and "
+    "README, produce concise, resume-ready material. Respond with ONLY a JSON "
+    "object, no prose and no markdown fences, of the exact shape:\n"
+    '{"summary": "one or two sentences on what the project does and its impact", '
+    '"suggested_bullets": ["achievement-oriented resume bullet", "..."], '
+    '"tech": ["Key", "Technologies"]}\n'
+    "Rules: 2-4 suggested_bullets, each starting with a strong action verb and "
+    "quantified where the README supports it; never invent metrics that are not "
+    "present; tech is the concrete stack (languages, frameworks, infra)."
+)
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL)
+
+
+def _extract_json_object(text: str) -> Dict[str, Any]:
+    """Best-effort parse of an LLM JSON object (tolerates markdown fences)."""
+    if not text:
+        return {}
+    candidate = text.strip()
+    fence = _JSON_FENCE_RE.search(candidate)
+    if fence:
+        candidate = fence.group(1).strip()
+    else:
+        start = candidate.find("{")
+        end = candidate.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            candidate = candidate[start : end + 1]
+    try:
+        parsed = json.loads(candidate)
+        return parsed if isinstance(parsed, dict) else {}
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+def _normalize_str_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(v).strip() for v in value if isinstance(v, (str, int, float)) and str(v).strip()]
+
+
+def summarize_project(
+    repo: Dict[str, Any],
+    readme: Optional[str],
+    languages: Dict[str, int],
+    api_key: str,
+    *,
+    client: Any = None,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Summarize one project into ``{summary, suggested_bullets, tech}`` via the LLM.
+
+    The README is truncated to ~1500 tokens before it reaches the prompt. On any
+    LLM error the function degrades to a metadata-only summary rather than raising
+    so a single bad repo never fails the whole import.
+    """
+    truncated_readme = (readme or "")[:_README_TRUNCATE_CHARS]
+    lang_names = list(languages.keys())
+
+    user_prompt = (
+        f"Project: {repo.get('name')}\n"
+        f"Description: {repo.get('description') or '(none)'}\n"
+        f"Primary language: {repo.get('primary_language') or '(unknown)'}\n"
+        f"Languages: {', '.join(lang_names) if lang_names else '(unknown)'}\n"
+        f"Topics: {', '.join(repo.get('topics') or []) or '(none)'}\n"
+        f"Stars: {repo.get('stars', 0)}  Forks: {repo.get('forks', 0)}\n\n"
+        f"README (truncated):\n{truncated_readme or '(no README)'}"
+    )
+
+    fallback_tech = list(dict.fromkeys(lang_names + (repo.get("topics") or [])))[:8]
+
+    if not api_key:
+        return {
+            "summary": repo.get("description") or "",
+            "suggested_bullets": [],
+            "tech": fallback_tech,
+        }
+
+    try:
+        if client is None:
+            import openai  # noqa: PLC0415 — lazy so import stays cheap/offline-safe
+
+            client = openai.OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model=model or settings.OPENAI_MODEL,
+            messages=[
+                {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            max_tokens=600,
+            temperature=0.4,
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception as exc:
+        logger.warning(f"summarize_project LLM call failed for {repo.get('name')}: {exc}")
+        return {
+            "summary": repo.get("description") or "",
+            "suggested_bullets": [],
+            "tech": fallback_tech,
+        }
+
+    parsed = _extract_json_object(raw)
+    tech = _normalize_str_list(parsed.get("tech")) or fallback_tech
+    return {
+        "summary": (str(parsed.get("summary")).strip() if parsed.get("summary") else "")
+        or repo.get("description")
+        or "",
+        "suggested_bullets": _normalize_str_list(parsed.get("suggested_bullets")),
+        "tech": tech,
+    }
+
+
+# ── Evidence normalization ───────────────────────────────────────────────────
+
+
+def build_project_evidence(repo: Dict[str, Any], summary: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a repo + its LLM summary into a ``ProjectEvidence`` record."""
+    return {
+        "source": "github",
+        "title": repo.get("name"),
+        "description": summary.get("summary") or repo.get("description") or "",
+        "tech": summary.get("tech") or [],
+        "metrics": {
+            "stars": repo.get("stars", 0) or 0,
+            "forks": repo.get("forks", 0) or 0,
+        },
+        "dates": {"last_active": repo.get("pushed_at")},
+        "url": repo.get("url"),
+        "suggested_bullets": summary.get("suggested_bullets") or [],
+        "raw_excerpt": (repo.get("raw_excerpt") or "")[:2000],
+    }
+
+
+# ── Redis result envelope (shared by worker + endpoint) ──────────────────────
+
+# Candidate evidence is cached in Redis (not Postgres) for v1 — Modal does not
+# auto-run migrations, so a DB table would need a manual migration step. TTL ~1h.
+IMPORT_RESULT_TTL = 3600
+
+
+def import_result_key(job_id: str) -> str:
+    """Redis key holding an import job's result envelope."""
+    return f"latexy:github_import:{job_id}"
+
+
+def encode_result(payload: Dict[str, Any]) -> str:
+    """Serialize a result envelope to a base64(JSON) string for Redis."""
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+
+
+def decode_result(raw: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Decode a base64(JSON) result envelope. None on miss/corruption."""
+    if not raw:
+        return None
+    try:
+        return json.loads(base64.b64decode(raw).decode("utf-8"))
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return None

--- a/backend/app/workers/github_import_worker.py
+++ b/backend/app/workers/github_import_worker.py
@@ -1,0 +1,212 @@
+"""GitHub project-import worker (Feature 1 — external sources to resume).
+
+Runs the fetch → rank → (README + languages per top repo) → summarize → evidence
+pipeline as an async job, publishes progress events, and stores the resulting
+candidate ``ProjectEvidence`` list in Redis for the frontend to review.
+
+PRIVACY: only PUBLIC repository data is read (see github_projects_service).
+
+Runs on the 'llm' queue (the work is LLM-bound). On Modal there is no Celery
+worker, so ``submit_github_import`` routes to the ``run_github_import_task``
+Modal function instead of enqueueing to a broker with no consumer.
+"""
+
+import os
+import uuid
+from typing import Any, Dict, List, Optional
+
+import httpx
+from celery.exceptions import SoftTimeLimitExceeded
+
+from ..core.celery_app import celery_app, get_task_priority
+from ..core.logging import get_logger
+from ..services import github_projects_service as gh
+from ..workers.event_publisher import get_worker_redis, is_cancelled, publish_event
+
+logger = get_logger(__name__)
+
+
+def _store_result(job_id: str, payload: Dict[str, Any]) -> None:
+    """Persist the import result envelope to Redis with a ~1h TTL."""
+    r = get_worker_redis()
+    r.setex(
+        gh.import_result_key(job_id),
+        gh.IMPORT_RESULT_TTL,
+        gh.encode_result(payload),
+    )
+
+
+@celery_app.task(
+    bind=True,
+    name="app.workers.github_import_worker.import_github_projects_task",
+    max_retries=1,
+    default_retry_delay=60,
+    time_limit=300,
+    soft_time_limit=270,
+    queue="llm",
+)
+def import_github_projects_task(
+    self,
+    job_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    github_token: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Import + summarize a user's top public GitHub projects.
+
+    ``github_token`` authenticates the (public-only) GitHub reads; ``api_key`` is
+    the user's LLM key when BYOK, else the platform key, for README summarization.
+
+    Publishes: job.started, job.progress (per stage), job.completed / job.failed.
+    Stores the result at ``latexy:github_import:{job_id}``.
+    """
+    if job_id is None:
+        job_id = str(uuid.uuid4())
+
+    task_id = self.request.id
+    worker_id = f"github-import-{task_id}"
+    logger.info(f"GitHub import task {task_id} starting for job {job_id}")
+
+    if not github_token:
+        publish_event(job_id, "job.failed", {
+            "stage": "github_import",
+            "error_code": "github_not_connected",
+            "error_message": "No GitHub token available for this import.",
+            "retryable": False,
+        })
+        _store_result(job_id, {"status": "failed", "projects": [],
+                               "error": "GitHub not connected"})
+        return {"success": False, "job_id": job_id, "error": "GitHub not connected"}
+
+    publish_event(job_id, "job.started", {"worker_id": worker_id, "stage": "github_import"})
+
+    # One HTTP client for every GitHub call → serial requests keep us clear of
+    # GitHub's secondary rate limits.
+    client = httpx.Client(timeout=20)
+    try:
+        publish_event(job_id, "job.progress", {
+            "percent": 10, "stage": "github_import",
+            "message": "Fetching your GitHub projects",
+        })
+        candidates = gh.fetch_candidate_repos(github_token, client=client)
+
+        publish_event(job_id, "job.progress", {
+            "percent": 25, "stage": "github_import",
+            "message": "Ranking your top projects",
+        })
+        top = gh.rank_repos(candidates)
+
+        if not top:
+            _store_result(job_id, {"status": "completed", "projects": []})
+            publish_event(job_id, "job.completed", {
+                "stage": "github_import", "project_count": 0,
+            })
+            logger.info(f"GitHub import job {job_id}: no eligible projects")
+            return {"success": True, "job_id": job_id, "project_count": 0}
+
+        projects: List[Dict[str, Any]] = []
+        total = len(top)
+        for idx, repo in enumerate(top):
+            if is_cancelled(job_id):
+                publish_event(job_id, "job.cancelled", {})
+                _store_result(job_id, {"status": "failed", "projects": projects,
+                                       "error": "cancelled"})
+                return {"success": False, "job_id": job_id, "cancelled": True}
+
+            owner, name = repo["owner"], repo["name"]
+            readme = gh.fetch_repo_readme(github_token, owner, name, client=client)
+            if not readme:
+                # rank_repos already excludes short READMEs via GraphQL byteSize;
+                # a miss here means the file is unreadable — skip rather than
+                # summarize nothing.
+                continue
+            languages = gh.fetch_repo_languages(github_token, owner, name, client=client)
+            repo["raw_excerpt"] = readme[:2000]
+
+            summary = gh.summarize_project(repo, readme, languages, api_key)
+            projects.append(gh.build_project_evidence(repo, summary))
+
+            percent = 25 + int(70 * (idx + 1) / total)
+            publish_event(job_id, "job.progress", {
+                "percent": percent, "stage": "github_import",
+                "message": f"Summarized {name}",
+            })
+
+        _store_result(job_id, {"status": "completed", "projects": projects})
+        publish_event(job_id, "job.completed", {
+            "stage": "github_import", "project_count": len(projects),
+        })
+        logger.info(f"GitHub import job {job_id}: {len(projects)} projects imported")
+        return {"success": True, "job_id": job_id, "project_count": len(projects)}
+
+    except SoftTimeLimitExceeded:
+        logger.error(f"GitHub import task {task_id} exceeded soft time limit for job {job_id}")
+        publish_event(job_id, "job.failed", {
+            "stage": "github_import",
+            "error_code": "timeout",
+            "error_message": "Import exceeded time limit",
+            "retryable": False,
+        })
+        _store_result(job_id, {"status": "failed", "projects": [], "error": "timeout"})
+        return {"success": False, "job_id": job_id, "error": "Task exceeded time limit"}
+
+    except Exception as exc:
+        from celery.exceptions import Retry
+        if isinstance(exc, Retry):
+            raise
+        logger.error(f"GitHub import task {task_id} raised: {exc}")
+        has_retries_left = self.request.retries < self.max_retries
+        publish_event(job_id, "job.failed", {
+            "stage": "github_import",
+            "error_code": "github_import_error",
+            "error_message": str(exc),
+            "retryable": has_retries_left,
+        })
+        if has_retries_left:
+            raise self.retry(countdown=60, exc=exc)
+        _store_result(job_id, {"status": "failed", "projects": [], "error": str(exc)})
+        return {"success": False, "job_id": job_id, "error": str(exc)}
+
+    finally:
+        client.close()
+
+
+# ------------------------------------------------------------------ #
+#  Submission helper                                                   #
+# ------------------------------------------------------------------ #
+
+def submit_github_import(
+    job_id: str,
+    user_id: str,
+    github_token: str,
+    api_key: Optional[str] = None,
+    user_plan: str = "free",
+) -> str:
+    """Enqueue import_github_projects_task on the llm queue (or Modal spawn)."""
+    priority = get_task_priority(user_plan)
+
+    # On Modal there is no Celery worker consuming the llm queue, so an
+    # unconditional apply_async() would hand back a job id for work nothing runs.
+    if os.environ.get("DEPLOY_TARGET") == "modal":
+        from ..core.modal_dispatch import spawn
+        spawn("run_github_import_task", {
+            "job_id": job_id,
+            "user_id": user_id,
+            "github_token": github_token,
+            "api_key": api_key,
+        })
+        logger.info(f"Dispatched GitHub import to Modal for job {job_id}")
+        return job_id
+
+    import_github_projects_task.apply_async(
+        kwargs={
+            "job_id": job_id,
+            "user_id": user_id,
+            "github_token": github_token,
+            "api_key": api_key,
+        },
+        priority=priority,
+        queue="llm",
+    )
+    logger.info(f"Submitted GitHub import for job {job_id}")
+    return job_id

--- a/backend/modal_app.py
+++ b/backend/modal_app.py
@@ -282,6 +282,19 @@ def run_interview_prep_task(payload: dict) -> None:
     timeout=300,
     scaledown_window=60,
 )
+def run_github_import_task(payload: dict) -> None:
+    """Import + summarize a user's top public GitHub projects."""
+    _init_worker_redis()
+    from app.workers.github_import_worker import import_github_projects_task
+    import_github_projects_task.apply(kwargs=payload, throw=False)
+
+
+@app.function(
+    image=worker_image,
+    secrets=_secrets,
+    timeout=300,
+    scaledown_window=60,
+)
 def run_document_conversion_task(payload: dict) -> None:
     """LLM document conversion (imported resume -> LaTeX)."""
     _init_worker_redis()

--- a/backend/test/test_admin_control_plane_api.py
+++ b/backend/test/test_admin_control_plane_api.py
@@ -94,7 +94,7 @@ class TestGetEntitlements:
         body = resp.json()
         assert set(body.keys()) == {"registry", "kill_switches", "matrix", "plan_families"}
         assert body["plan_families"] == ["free", "basic", "pro", "byok", "team"]
-        assert len(body["registry"]) == 27
+        assert len(body["registry"]) == 28
 
 
 # ── PATCH /admin/entitlements/kill-switch/{key} ──────────────────────────────
@@ -306,7 +306,7 @@ class TestConfigEntitlements:
         assert resp.status_code == 200
         body = resp.json()
         assert "features" in body
-        assert len(body["features"]) == 27
+        assert len(body["features"]) == 28
         assert body["features"]["compile"] is True
 
     async def test_anonymous(self, client: AsyncClient):
@@ -314,7 +314,7 @@ class TestConfigEntitlements:
         assert resp.status_code == 200
         body = resp.json()
         assert "features" in body
-        assert len(body["features"]) == 27
+        assert len(body["features"]) == 28
 
     async def test_anonymous_reflects_free_matrix_disable(
         self, client: AsyncClient, db_session: AsyncSession

--- a/backend/test/test_entitlement_service.py
+++ b/backend/test/test_entitlement_service.py
@@ -103,11 +103,11 @@ class TestHasFeatureToggles:
 
 class TestEffectiveFeaturesAndState:
 
-    async def test_effective_features_all_27_keys(self):
+    async def test_effective_features_all_28_keys(self):
         free = _user(plan="free")
         eff = await entitlement_service.effective_features(free)
         assert set(eff.keys()) == {f.key for f in FEATURE_REGISTRY}
-        assert len(eff) == 27
+        assert len(eff) == 28
         # Non-gateable always True.
         assert eff["compile"] is True
 
@@ -134,7 +134,7 @@ class TestEffectiveFeaturesAndState:
             assert set(state["matrix"][family].keys()) == gateable
 
         # registry entries carry the expected fields.
-        assert len(state["registry"]) == 27
+        assert len(state["registry"]) == 28
         sample = state["registry"][0]
         assert set(sample.keys()) == {"key", "label", "category", "gateable"}
 

--- a/backend/test/test_feature_registry.py
+++ b/backend/test/test_feature_registry.py
@@ -15,12 +15,12 @@ from app.core.feature_registry import (
 )
 
 
-def test_registry_has_27_entries():
-    assert len(FEATURE_REGISTRY) == 27
+def test_registry_has_28_entries():
+    assert len(FEATURE_REGISTRY) == 28
 
 
-def test_registry_has_26_gateable():
-    assert len(gateable_keys()) == 26
+def test_registry_has_27_gateable():
+    assert len(gateable_keys()) == 27
 
 
 def test_compile_present_and_non_gateable():

--- a/backend/test/test_github_import.py
+++ b/backend/test/test_github_import.py
@@ -1,0 +1,204 @@
+"""Tests for GitHub project import (Feature 1 — external sources to resume)."""
+
+import uuid
+
+from sqlalchemy import text
+
+from app.services import github_projects_service as gh
+from app.services.encryption_service import encryption_service
+
+# ── rank_repos (pure, no network) ────────────────────────────────────────────
+
+
+def _repo(name, *, stars=0, forks=0, pinned=False, archived=False,
+          readme_bytes=500, topics=None, description="A project",
+          pushed_at="2026-07-01T00:00:00Z"):
+    return {
+        "name": name,
+        "owner": "octocat",
+        "description": description,
+        "url": f"https://github.com/octocat/{name}",
+        "stars": stars,
+        "forks": forks,
+        "primary_language": "Python",
+        "topics": topics or [],
+        "pushed_at": pushed_at,
+        "is_archived": archived,
+        "readme_bytes": readme_bytes,
+        "pinned": pinned,
+    }
+
+
+class TestRankRepos:
+    def test_orders_by_score_stars_dominate(self):
+        repos = [
+            _repo("low", stars=1, forks=0),
+            _repo("high", stars=5000, forks=800),
+            _repo("mid", stars=100, forks=20),
+        ]
+        ranked = gh.rank_repos(repos)
+        assert [r["name"] for r in ranked] == ["high", "mid", "low"]
+        # scores are attached and monotonically non-increasing
+        scores = [r["score"] for r in ranked]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_pinned_boost_beats_a_more_popular_organic_repo(self):
+        repos = [
+            _repo("popular", stars=100000, forks=50000, pinned=False),
+            _repo("pinned", stars=3, forks=1, pinned=True),
+        ]
+        ranked = gh.rank_repos(repos)
+        assert ranked[0]["name"] == "pinned"
+
+    def test_excludes_archived_and_short_readme(self):
+        repos = [
+            _repo("good", stars=10),
+            _repo("archived", stars=999, archived=True),
+            _repo("stub", stars=999, readme_bytes=40),  # README < 100 chars
+        ]
+        ranked = gh.rank_repos(repos)
+        names = {r["name"] for r in ranked}
+        assert names == {"good"}
+
+    def test_returns_at_most_six(self):
+        repos = [_repo(f"r{i}", stars=i) for i in range(20)]
+        ranked = gh.rank_repos(repos)
+        assert len(ranked) == 6
+
+
+# ── build_project_evidence (pure) ────────────────────────────────────────────
+
+
+class TestBuildProjectEvidence:
+    def test_shape(self):
+        repo = _repo("acme", stars=42, forks=7, pushed_at="2026-06-15T00:00:00Z")
+        repo["raw_excerpt"] = "# Acme\nDoes things." * 5
+        summary = {
+            "summary": "Acme does things well.",
+            "suggested_bullets": ["Built X", "Shipped Y"],
+            "tech": ["Python", "Redis"],
+        }
+        ev = gh.build_project_evidence(repo, summary)
+
+        assert ev["source"] == "github"
+        assert ev["title"] == "acme"
+        assert ev["description"] == "Acme does things well."
+        assert ev["tech"] == ["Python", "Redis"]
+        assert ev["metrics"] == {"stars": 42, "forks": 7}
+        assert ev["dates"] == {"last_active": "2026-06-15T00:00:00Z"}
+        assert ev["url"] == "https://github.com/octocat/acme"
+        assert ev["suggested_bullets"] == ["Built X", "Shipped Y"]
+        assert "raw_excerpt" in ev
+        # required keys, exactly
+        assert set(ev.keys()) == {
+            "source", "title", "description", "tech", "metrics",
+            "dates", "url", "suggested_bullets", "raw_excerpt",
+        }
+
+    def test_falls_back_to_repo_description_when_summary_blank(self):
+        repo = _repo("acme", description="Fallback desc")
+        ev = gh.build_project_evidence(repo, {"summary": "", "tech": [], "suggested_bullets": []})
+        assert ev["description"] == "Fallback desc"
+
+
+# ── result envelope round-trip ───────────────────────────────────────────────
+
+
+def test_result_envelope_round_trip():
+    payload = {"status": "completed", "projects": [{"title": "x"}]}
+    encoded = gh.encode_result(payload)
+    assert gh.decode_result(encoded) == payload
+    assert gh.decode_result(None) is None
+    assert gh.decode_result("!!not-base64!!") is None
+
+
+# ── Endpoint tests ───────────────────────────────────────────────────────────
+
+
+async def _connect_github(db_session, headers) -> str:
+    """Set an encrypted GitHub token on the auth_headers user; return user_id."""
+    row = await db_session.execute(
+        text('SELECT "userId" FROM session WHERE token = :t'),
+        {"t": headers["Authorization"].replace("Bearer ", "")},
+    )
+    user_id = row.scalar_one()
+    await db_session.execute(
+        text("UPDATE users SET github_access_token = :tok, github_username = 'octocat' WHERE id = :id"),
+        {"tok": encryption_service.encrypt("gho_testtoken"), "id": user_id},
+    )
+    await db_session.commit()
+    return user_id
+
+
+class TestImportEndpoints:
+    async def test_post_requires_connected_github(self, client, auth_headers):
+        """Without a connected GitHub account the POST returns 400."""
+        resp = await client.post("/github/import-projects", headers=auth_headers)
+        assert resp.status_code == 400
+        assert "not connected" in resp.json()["detail"].lower()
+
+    async def test_post_returns_job_id(self, client, auth_headers, db_session, monkeypatch):
+        await _connect_github(db_session, auth_headers)
+
+        captured = {}
+
+        def _fake_submit(*, job_id, user_id, github_token, api_key, user_plan="free"):
+            captured.update(
+                job_id=job_id, user_id=user_id, github_token=github_token,
+                api_key=api_key, user_plan=user_plan,
+            )
+            return job_id
+
+        monkeypatch.setattr(
+            "app.api.github_routes.submit_github_import", _fake_submit
+        )
+
+        resp = await client.post("/github/import-projects", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "job_id" in body and body["job_id"]
+        # the decrypted GitHub token is handed to the worker; no BYOK key → None
+        assert captured["github_token"] == "gho_testtoken"
+        assert captured["api_key"] is None
+        assert captured["job_id"] == body["job_id"]
+
+    async def test_get_returns_pending_when_absent(self, client, auth_headers):
+        resp = await client.get(
+            f"/github/import-projects/{uuid.uuid4()}", headers=auth_headers
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "pending"
+        assert body["projects"] == []
+
+    async def test_get_returns_stored_evidence(self, client, auth_headers):
+        from app.core.redis import get_redis_client
+
+        job_id = str(uuid.uuid4())
+        projects = [{
+            "source": "github", "title": "acme", "description": "does things",
+            "tech": ["Python"], "metrics": {"stars": 9, "forks": 2},
+            "dates": {"last_active": "2026-07-01T00:00:00Z"},
+            "url": "https://github.com/octocat/acme",
+            "suggested_bullets": ["Built acme"], "raw_excerpt": "# acme",
+        }]
+        redis = await get_redis_client()
+        await redis.setex(
+            gh.import_result_key(job_id),
+            gh.IMPORT_RESULT_TTL,
+            gh.encode_result({"status": "completed", "projects": projects}),
+        )
+
+        resp = await client.get(
+            f"/github/import-projects/{job_id}", headers=auth_headers
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "completed"
+        assert body["projects"] == projects
+
+    async def test_endpoints_require_auth(self, client):
+        assert (await client.post("/github/import-projects")).status_code in (401, 403)
+        assert (
+            await client.get(f"/github/import-projects/{uuid.uuid4()}")
+        ).status_code in (401, 403)


### PR DESCRIPTION
Closes #1049.

Import a connected user's top **public** GitHub projects as AI-summarized `ProjectEvidence` for injection into the resume — Phase 1 of the External-Sources-to-Resume PRD (GitHub first: the LaTeX audience is developers, and this is the differentiator). **Reads public repository data only** — the GraphQL query is scoped to `ownerAffiliations: OWNER` and only public fields are consumed; no private content is ever read.

## What's in it
- **`github_projects_service.py`** — pure, injectable pipeline: `fetch_candidate_repos` (one GraphQL call: pinned + top owned non-fork repos incl. README byteSize), `rank_repos` (log-star + fork + recency + readme/topics/description scoring; pinned boost; top 6; excludes archived & undocumented), `fetch_repo_readme`/`fetch_repo_languages`, `summarize_project` (BYOK-aware LLM → `{summary, suggested_bullets, tech}`, README truncated ~1500 tokens, degrades to metadata-only on LLM error), `build_project_evidence`, Redis-envelope helpers.
- **`github_import_worker.py`** — `import_github_projects_task` (llm queue) with progress events; `submit_github_import` with Modal-spawn + Celery branches.
- **`github_routes.py`** — `POST /github/import-projects` (resolves BYOK/platform LLM key + decrypts the stored Fernet GitHub token) and `GET /github/import-projects/{job_id}`.
- **`feature_registry.py`** — `ai_import_github` gate (quota deferred per product).
- **`celery_app.py`** + **`modal_app.py`** — worker registration + `run_github_import_task` (calls `_init_worker_redis()` first, per the parity guard).

## Notes
- Candidate evidence cached in Redis (`latexy:github_import:{job_id}`, base64(JSON), 1h TTL) — no new DB table/migration (Modal doesn't auto-migrate).
- Gate only, no hard quota (deferred).
- The worker takes an extra `github_token` arg beyond the PRD's 3-arg sketch — repo fetching requires it.

## Testing
- `test_github_import.py`: **12 passed**. Parity + registry/entitlement suites: green (53 in the combined run). `ruff` clean.