### PR TITLE
F1 frontend: GitHub project import UI

### DIFF
--- a/frontend/src/__tests__/change-review-client.test.ts
+++ b/frontend/src/__tests__/change-review-client.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { apiClient, type ChangeHunk } from '../lib/api-client'
+
+function mockFetch(responseBody: object) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      json: () => Promise.resolve(responseBody),
+      text: () => Promise.resolve(JSON.stringify(responseBody)),
+    })
+  )
+}
+
+function lastCall(): { url: string; init: RequestInit; body: Record<string, unknown> } {
+  const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+  return { url, init, body: JSON.parse(init.body as string) }
+}
+
+afterEach(() => {
+  apiClient.setAuthToken(null)
+  vi.unstubAllGlobals()
+})
+
+const HUNK: ChangeHunk = {
+  id: 'abc123',
+  kind: 'modified',
+  original_text: 'old bullet',
+  new_text: 'new bullet',
+  before_context: '',
+  after_context: '',
+  section: 'Experience',
+  rationale: 'quantified impact',
+  original_start: 10,
+  original_end: 20,
+}
+
+describe('segmentChanges', () => {
+  test('POSTs original + optimized latex and returns hunks + summary', async () => {
+    mockFetch({ hunks: [HUNK], summary: { total: 1, added: 0, modified: 1, removed: 0 } })
+
+    const res = await apiClient.segmentChanges({
+      original_latex: 'A',
+      optimized_latex: 'B',
+    })
+
+    const { url, init, body } = lastCall()
+    expect(url).toContain('/optimize/segment-changes')
+    expect(init.method).toBe('POST')
+    expect(body.original_latex).toBe('A')
+    expect(body.optimized_latex).toBe('B')
+    expect(res.hunks).toHaveLength(1)
+    expect(res.summary.modified).toBe(1)
+  })
+
+  test('forwards change_reasons when provided', async () => {
+    mockFetch({ hunks: [], summary: { total: 0, added: 0, modified: 0, removed: 0 } })
+
+    await apiClient.segmentChanges({
+      original_latex: 'A',
+      optimized_latex: 'B',
+      change_reasons: [{ section: 'Experience', change_type: 'modified', reason: 'clarity' }],
+    })
+
+    expect(lastCall().body.change_reasons).toEqual([
+      { section: 'Experience', change_type: 'modified', reason: 'clarity' },
+    ])
+  })
+})
+
+describe('applyChanges', () => {
+  test('POSTs original latex, hunks, and accepted ids; returns reconstructed latex', async () => {
+    mockFetch({ latex: 'RECONSTRUCTED' })
+
+    const res = await apiClient.applyChanges({
+      original_latex: 'ORIG',
+      hunks: [HUNK],
+      accepted_ids: ['abc123'],
+    })
+
+    const { url, init, body } = lastCall()
+    expect(url).toContain('/optimize/apply-changes')
+    expect(init.method).toBe('POST')
+    expect(body.original_latex).toBe('ORIG')
+    expect(body.accepted_ids).toEqual(['abc123'])
+    expect((body.hunks as ChangeHunk[])[0].id).toBe('abc123')
+    expect(res.latex).toBe('RECONSTRUCTED')
+  })
+
+  test('an empty accepted set is still a valid apply payload', async () => {
+    mockFetch({ latex: 'ORIG' })
+
+    const res = await apiClient.applyChanges({
+      original_latex: 'ORIG',
+      hunks: [HUNK],
+      accepted_ids: [],
+    })
+
+    expect(lastCall().body.accepted_ids).toEqual([])
+    expect(res.latex).toBe('ORIG')
+  })
+})

--- a/frontend/src/__tests__/github-import.test.ts
+++ b/frontend/src/__tests__/github-import.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { apiClient, type ProjectEvidence } from '../lib/api-client'
+import { escapeLatex, projectsToLatex } from '../lib/github-projects-latex'
+
+function mockFetch(responseBody: object) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      json: () => Promise.resolve(responseBody),
+      text: () => Promise.resolve(JSON.stringify(responseBody)),
+    })
+  )
+}
+
+afterEach(() => {
+  apiClient.setAuthToken(null)
+  vi.unstubAllGlobals()
+})
+
+const PROJECT: ProjectEvidence = {
+  source: 'github',
+  title: 'my_project',
+  description: 'A cool tool for R&D',
+  tech: ['Python', 'FastAPI'],
+  metrics: { stars: 42, forks: 3 },
+  dates: { last_active: '2026-01-01T00:00:00Z' },
+  url: 'https://github.com/me/my_project',
+  suggested_bullets: ['Built X, cutting latency 30%', 'Shipped Y to 10k users'],
+  raw_excerpt: '',
+}
+
+describe('escapeLatex', () => {
+  test('escapes LaTeX special characters', () => {
+    expect(escapeLatex('R&D')).toBe('R\\&D')
+    expect(escapeLatex('my_project')).toBe('my\\_project')
+    expect(escapeLatex('100% #1 $x')).toBe('100\\% \\#1 \\$x')
+    expect(escapeLatex('a~b^c')).toBe('a\\textasciitilde{}b\\textasciicircum{}c')
+  })
+
+  test('escapes backslash before other specials to avoid double-escaping', () => {
+    expect(escapeLatex('a\\b')).toBe('a\\textbackslash{}b')
+  })
+})
+
+describe('projectsToLatex', () => {
+  test('returns empty string for no selections', () => {
+    expect(projectsToLatex([])).toBe('')
+  })
+
+  test('renders a project with escaped title, tech, repo link, and kept bullets', () => {
+    const out = projectsToLatex([{ project: PROJECT, bullets: PROJECT.suggested_bullets }])
+    expect(out).toContain('\\textbf{my\\_project}')
+    expect(out).toContain('\\href{https://github.com/me/my_project}')
+    expect(out).toContain('\\textit{Python, FastAPI}')
+    expect(out).toContain('\\begin{itemize}')
+    expect(out).toContain('\\item Built X, cutting latency 30\\%')
+    expect(out).toContain('imported from GitHub')
+  })
+
+  test('falls back to description when no bullets are kept', () => {
+    const out = projectsToLatex([{ project: PROJECT, bullets: [] }])
+    expect(out).not.toContain('\\begin{itemize}')
+    expect(out).toContain('A cool tool for R\\&D')
+  })
+
+  test('omits a non-http url (no href injection)', () => {
+    const out = projectsToLatex([
+      { project: { ...PROJECT, url: 'javascript:alert(1)' }, bullets: ['did a thing'] },
+    ])
+    expect(out).not.toContain('\\href')
+    expect(out).toContain('\\item did a thing')
+  })
+
+  test('separates multiple projects with a smallskip', () => {
+    const out = projectsToLatex([
+      { project: PROJECT, bullets: ['one'] },
+      { project: { ...PROJECT, title: 'second' }, bullets: ['two'] },
+    ])
+    expect(out).toContain('\\smallskip')
+    expect(out).toContain('\\textbf{second}')
+  })
+})
+
+describe('GitHub import client', () => {
+  test('importGitHubProjects POSTs and returns a job id', async () => {
+    mockFetch({ job_id: 'gh-job-1' })
+    const res = await apiClient.importGitHubProjects()
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/github/import-projects')
+    expect(init.method).toBe('POST')
+    expect(res.job_id).toBe('gh-job-1')
+  })
+
+  test('getGitHubImportResult GETs the job status envelope', async () => {
+    mockFetch({ status: 'completed', projects: [PROJECT], error: null })
+    const res = await apiClient.getGitHubImportResult('gh-job-1')
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/github/import-projects/gh-job-1')
+    expect(res.status).toBe('completed')
+    expect(res.projects[0].title).toBe('my_project')
+  })
+})

--- a/frontend/src/app/workspace/[resumeId]/edit/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/edit/page.tsx
@@ -70,6 +70,7 @@ import SectionReorderPanel from '@/components/SectionReorderPanel'
 import WatermarkDownloadPopover from '@/components/WatermarkDownloadPopover'
 import CompilerSelector from '@/components/CompilerSelector'
 import TemplateCustomizerPanel from '@/components/TemplateCustomizerPanel'
+import GithubImportModal from '@/components/GithubImportModal'
 import type { TrackedChange } from '@/lib/yjs-track-changes'
 import { GitMerge } from 'lucide-react'
 import { useAutoCompile } from '@/hooks/useAutoCompile'
@@ -741,6 +742,7 @@ export default function ResumeEditPage() {
   const [contactFormatterOpen, setContactFormatterOpen] = useState(false)
   const [salaryEstimatorOpen, setSalaryEstimatorOpen] = useState(false)
   const [sectionReorderOpen, setSectionReorderOpen] = useState(false)
+  const [githubImportOpen, setGithubImportOpen] = useState(false)
   const [showErrorHistory, setShowErrorHistory] = useState(false)
   const [docCommand, setDocCommand] = useState<string | undefined>(undefined)
 
@@ -1912,6 +1914,15 @@ export default function ResumeEditPage() {
             Reorder
           </button>
 
+          <button
+            onClick={() => setGithubImportOpen(true)}
+            title="Import top projects from GitHub"
+            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+          >
+            <Github size={12} />
+            Projects
+          </button>
+
           <Link
             href={`/workspace/${resumeId}/cover-letter`}
             className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-violet-300/80 transition hover:bg-violet-500/10 hover:text-violet-200"
@@ -2895,6 +2906,17 @@ export default function ResumeEditPage() {
           pushUndo('Before section reorder')
           editorRef.current?.setValue(newLatex)
           setLatexContent(newLatex)
+        }}
+      />
+
+      {/* GitHub project import (F1 — external sources to resume) */}
+      <GithubImportModal
+        isOpen={githubImportOpen}
+        onClose={() => setGithubImportOpen(false)}
+        onInsert={(latex) => {
+          pushUndo('Before GitHub project import')
+          editorRef.current?.insertAtCursor(latex)
+          setLatexContent(editorRef.current?.getValue() ?? latexContent)
         }}
       />
 

--- a/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
@@ -19,6 +19,7 @@ import PDFPreview from '@/components/PDFPreview'
 import ATSScoreCard from '@/components/ATSScoreCard'
 import DiffViewerModal from '@/components/DiffViewerModal'
 import CompareModal from '@/components/CompareModal'
+import ChangeReviewModal from '@/components/ChangeReviewModal'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorExplainerPanel from '@/components/ErrorExplainerPanel'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
@@ -55,6 +56,7 @@ export default function OptimizationSuitePage() {
   const [compareOriginalLatex, setCompareOriginalLatex] = useState<string | null>(null)
   const [compareAfterLatex, setCompareAfterLatex] = useState<string | null>(null)
   const [showCompareModal, setShowCompareModal] = useState(false)
+  const [showReviewModal, setShowReviewModal] = useState(false)
 
   // Variant awareness
   const [parentResumeId, setParentResumeId] = useState<string | null>(null)
@@ -271,6 +273,25 @@ export default function OptimizationSuitePage() {
       setIsSubmitting(false)
     }
   }, [isSubmitting, resumeId, compiler])
+
+  // Apply the user's per-change review result (F2-P0): load the reconstructed
+  // LaTeX into the editor, make it the new "after" snapshot, and recompile.
+  const handleApplyReviewedChanges = useCallback(async (latex: string) => {
+    editorRef.current?.setValue(latex)
+    setCompareAfterLatex(latex)
+    setIsSubmitting(true)
+    setPdfUrl(null)
+    try {
+      const response = await apiClient.compileLatex({ latex_content: latex, resume_id: resumeId, compiler })
+      if (!response.success || !response.job_id) throw new Error(response.message || 'Failed to recompile')
+      setActiveJobId(response.job_id)
+      setActiveJobKind('compile')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Recompile failed')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [resumeId, compiler])
 
   const handleCompareWithParent = useCallback(async () => {
     try {
@@ -722,12 +743,20 @@ export default function OptimizationSuitePage() {
                 <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Output Preview</p>
                 <div className="flex items-center gap-3">
                   {compareAfterLatex !== null && compareOriginalLatex !== null && (
-                    <button
-                      onClick={() => setShowCompareModal(true)}
-                      className="text-xs font-semibold text-orange-300 transition hover:text-orange-200"
-                    >
-                      Compare with Original
-                    </button>
+                    <>
+                      <button
+                        onClick={() => setShowReviewModal(true)}
+                        className="text-xs font-semibold text-emerald-300 transition hover:text-emerald-200"
+                      >
+                        Review Changes
+                      </button>
+                      <button
+                        onClick={() => setShowCompareModal(true)}
+                        className="text-xs font-semibold text-orange-300 transition hover:text-orange-200"
+                      >
+                        Compare with Original
+                      </button>
+                    </>
                   )}
                   {pdfUrl && (
                     <a href={pdfUrl} download="optimized_resume.pdf" className="text-xs font-semibold text-zinc-300 transition hover:text-white">
@@ -893,6 +922,16 @@ export default function OptimizationSuitePage() {
             setShowCompareModal(false)
             toast.success('Original restored')
           }}
+        />
+      )}
+
+      {/* Per-change accept/reject review (F2-P0) */}
+      {showReviewModal && compareOriginalLatex !== null && compareAfterLatex !== null && (
+        <ChangeReviewModal
+          originalLatex={compareOriginalLatex}
+          optimizedLatex={compareAfterLatex}
+          onApply={handleApplyReviewedChanges}
+          onClose={() => setShowReviewModal(false)}
         />
       )}
     </div>

--- a/frontend/src/components/ChangeReviewModal.tsx
+++ b/frontend/src/components/ChangeReviewModal.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Check, Loader2, Pencil, RotateCcw, X } from 'lucide-react'
+import { toast } from 'sonner'
+import { apiClient, type ChangeHunk } from '@/lib/api-client'
+
+/**
+ * Per-change accept/reject/edit review (input-driven optimization, F2-P0).
+ * "AI drafts, you direct and approve": segments the original→optimized diff into
+ * discrete hunks, lets the user accept/reject/edit each one, then applies only
+ * the accepted set and hands the reconstructed LaTeX back to the parent to load
+ * into the editor and recompile.
+ *
+ * The apply is done client-agnostically via the server (deterministic
+ * reconstruction), so a locally-edited ``new_text`` is honoured by sending the
+ * edited hunk in the apply payload.
+ */
+
+type HunkState = {
+  accepted: boolean
+  newText: string // editable; defaults to hunk.new_text
+  editing: boolean
+}
+
+const KIND_META: Record<ChangeHunk['kind'], { label: string; cls: string }> = {
+  modified: { label: 'Modified', cls: 'bg-amber-500/15 text-amber-200 ring-amber-400/20' },
+  added: { label: 'Added', cls: 'bg-emerald-500/15 text-emerald-200 ring-emerald-400/20' },
+  removed: { label: 'Removed', cls: 'bg-rose-500/15 text-rose-200 ring-rose-400/20' },
+}
+
+export default function ChangeReviewModal({
+  originalLatex,
+  optimizedLatex,
+  changeReasons,
+  onApply,
+  onClose,
+}: {
+  originalLatex: string
+  optimizedLatex: string
+  changeReasons?: Array<{ section?: string; change_type?: string; reason?: string }>
+  onApply: (latex: string) => void
+  onClose: () => void
+}) {
+  const [hunks, setHunks] = useState<ChangeHunk[] | null>(null)
+  const [state, setState] = useState<Record<string, HunkState>>({})
+  const [loading, setLoading] = useState(true)
+  const [applying, setApplying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await apiClient.segmentChanges({
+          original_latex: originalLatex,
+          optimized_latex: optimizedLatex,
+          change_reasons: changeReasons,
+        })
+        if (cancelled) return
+        setHunks(res.hunks)
+        // Every change starts accepted (the optimized doc is the default), so
+        // "Apply" with no edits reproduces the one-shot result.
+        const init: Record<string, HunkState> = {}
+        for (const h of res.hunks) init[h.id] = { accepted: true, newText: h.new_text, editing: false }
+        setState(init)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to compute changes')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [originalLatex, optimizedLatex, changeReasons])
+
+  const acceptedCount = useMemo(
+    () => Object.values(state).filter((s) => s.accepted).length,
+    [state]
+  )
+
+  const setAll = useCallback((accepted: boolean) => {
+    setState((prev) => {
+      const next: Record<string, HunkState> = {}
+      for (const [id, s] of Object.entries(prev)) next[id] = { ...s, accepted }
+      return next
+    })
+  }, [])
+
+  const toggle = (id: string) =>
+    setState((prev) => ({ ...prev, [id]: { ...prev[id], accepted: !prev[id].accepted } }))
+
+  const startEdit = (id: string) =>
+    setState((prev) => ({ ...prev, [id]: { ...prev[id], editing: true, accepted: true } }))
+
+  const setEditText = (id: string, newText: string) =>
+    setState((prev) => ({ ...prev, [id]: { ...prev[id], newText } }))
+
+  const resetEdit = (id: string, original: string) =>
+    setState((prev) => ({ ...prev, [id]: { ...prev[id], newText: original, editing: false } }))
+
+  const handleApply = async () => {
+    if (!hunks) return
+    setApplying(true)
+    try {
+      // Send hunks with any locally-edited new_text so the server honours edits.
+      const payloadHunks = hunks.map((h) => ({ ...h, new_text: state[h.id]?.newText ?? h.new_text }))
+      const acceptedIds = hunks.filter((h) => state[h.id]?.accepted).map((h) => h.id)
+      const res = await apiClient.applyChanges({
+        original_latex: originalLatex,
+        hunks: payloadHunks,
+        accepted_ids: acceptedIds,
+      })
+      onApply(res.latex)
+      toast.success(
+        acceptedIds.length === hunks.length
+          ? 'Applied all changes'
+          : `Applied ${acceptedIds.length} of ${hunks.length} changes`
+      )
+      onClose()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to apply changes')
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+        onClick={onClose}
+      >
+        <motion.div
+          initial={{ opacity: 0, scale: 0.97, y: 8 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.97 }}
+          className="flex max-h-[88vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-white/10 px-5 py-4">
+            <div>
+              <h2 className="text-sm font-semibold text-zinc-100">Review changes</h2>
+              <p className="mt-0.5 text-[11px] text-zinc-500">
+                Accept, reject, or edit each suggestion. Only accepted changes are applied.
+              </p>
+            </div>
+            <button onClick={onClose} className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-zinc-200">
+              <X size={16} />
+            </button>
+          </div>
+
+          {/* Toolbar */}
+          {hunks && hunks.length > 0 && (
+            <div className="flex items-center justify-between gap-3 border-b border-white/5 px-5 py-2.5">
+              <span className="text-[11px] text-zinc-500">
+                {acceptedCount} of {hunks.length} accepted
+              </span>
+              <div className="flex gap-2">
+                <button onClick={() => setAll(true)} className="rounded-md px-2 py-1 text-[11px] font-medium text-emerald-300 transition hover:bg-emerald-500/10">
+                  Accept all
+                </button>
+                <button onClick={() => setAll(false)} className="rounded-md px-2 py-1 text-[11px] font-medium text-zinc-400 transition hover:bg-white/5">
+                  Reject all
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Body */}
+          <div className="scrollbar-subtle min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            {loading && (
+              <div className="flex items-center justify-center gap-2 py-16 text-sm text-zinc-500">
+                <Loader2 size={16} className="animate-spin" /> Computing changes…
+              </div>
+            )}
+            {error && !loading && (
+              <div className="rounded-lg border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">{error}</div>
+            )}
+            {!loading && !error && hunks && hunks.length === 0 && (
+              <div className="py-16 text-center text-sm text-zinc-500">
+                No substantive changes to review — the optimized result matches your resume.
+              </div>
+            )}
+            {!loading && !error && hunks && hunks.length > 0 && (
+              <ul className="space-y-3">
+                {hunks.map((h) => {
+                  const s = state[h.id]
+                  if (!s) return null
+                  const meta = KIND_META[h.kind]
+                  return (
+                    <li
+                      key={h.id}
+                      className={`rounded-xl border p-3 transition ${
+                        s.accepted ? 'border-white/10 bg-white/[0.02]' : 'border-white/5 bg-transparent opacity-60'
+                      }`}
+                    >
+                      <div className="mb-2 flex items-center gap-2">
+                        <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ${meta.cls}`}>
+                          {meta.label}
+                        </span>
+                        {h.section && <span className="text-[11px] text-zinc-500">{h.section}</span>}
+                        <div className="ml-auto flex items-center gap-1">
+                          <button
+                            onClick={() => startEdit(h.id)}
+                            title="Edit"
+                            className="rounded-md p-1 text-zinc-500 transition hover:bg-white/5 hover:text-zinc-200"
+                          >
+                            <Pencil size={12} />
+                          </button>
+                          <button
+                            onClick={() => toggle(h.id)}
+                            title={s.accepted ? 'Reject' : 'Accept'}
+                            className={`rounded-md p-1 transition ${
+                              s.accepted ? 'text-emerald-300 hover:bg-emerald-500/10' : 'text-zinc-500 hover:bg-white/5'
+                            }`}
+                          >
+                            {s.accepted ? <Check size={13} /> : <X size={13} />}
+                          </button>
+                        </div>
+                      </div>
+
+                      {/* Diff preview */}
+                      {h.original_text.trim() && (
+                        <pre className="mb-1 overflow-x-auto whitespace-pre-wrap rounded-md bg-rose-500/[0.06] px-2 py-1 text-[11px] leading-relaxed text-rose-200/80">
+                          <code>- {h.original_text.trim()}</code>
+                        </pre>
+                      )}
+                      {s.editing ? (
+                        <div>
+                          <textarea
+                            value={s.newText}
+                            onChange={(e) => setEditText(h.id, e.target.value)}
+                            className="scrollbar-subtle h-24 w-full resize-none rounded-md border border-orange-400/30 bg-black/40 px-2 py-1 text-[11px] leading-relaxed text-zinc-100 outline-none focus:border-orange-300/60"
+                          />
+                          <button
+                            onClick={() => resetEdit(h.id, h.new_text)}
+                            className="mt-1 flex items-center gap-1 text-[10px] text-zinc-500 transition hover:text-zinc-300"
+                          >
+                            <RotateCcw size={10} /> Reset to suggestion
+                          </button>
+                        </div>
+                      ) : (
+                        s.newText.trim() && (
+                          <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-emerald-500/[0.06] px-2 py-1 text-[11px] leading-relaxed text-emerald-200/90">
+                            <code>+ {s.newText.trim()}</code>
+                          </pre>
+                        )
+                      )}
+
+                      {h.rationale && (
+                        <p className="mt-1.5 text-[10px] italic text-zinc-500">{h.rationale}</p>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-3 border-t border-white/10 px-5 py-3.5">
+            <button onClick={onClose} className="text-xs font-semibold text-zinc-400 transition hover:text-zinc-200">
+              Cancel
+            </button>
+            <button
+              onClick={handleApply}
+              disabled={applying || loading || !hunks || hunks.length === 0}
+              className="btn-accent px-4 py-2 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {applying ? 'Applying…' : `Apply ${acceptedCount} change${acceptedCount === 1 ? '' : 's'}`}
+            </button>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/components/GithubImportModal.tsx
+++ b/frontend/src/components/GithubImportModal.tsx
@@ -1,0 +1,324 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { ExternalLink, Loader2, Star, X } from 'lucide-react'
+import { toast } from 'sonner'
+import { apiClient, type ProjectEvidence } from '@/lib/api-client'
+import { projectsToLatex, type ProjectSelection } from '@/lib/github-projects-latex'
+
+/**
+ * Import top PUBLIC GitHub projects and insert selected ones into the resume
+ * (External-Sources-to-Resume, F1). Flow: check connection → start import job →
+ * poll → render ranked ProjectEvidence cards with per-bullet checkboxes → build
+ * a LaTeX block from the selection and hand it to the editor via onInsert.
+ *
+ * Everything routes through this review step — nothing is written to the resume
+ * without the user choosing it.
+ */
+
+const POLL_INTERVAL_MS = 2500
+const POLL_TIMEOUT_MS = 120_000
+
+type Phase = 'checking' | 'disconnected' | 'importing' | 'ready' | 'error'
+
+// Per-project selection: which suggested bullets are checked, keyed by project index.
+type Selection = { included: boolean; bullets: Set<number> }
+
+export default function GithubImportModal({
+  isOpen,
+  onClose,
+  onInsert,
+}: {
+  isOpen: boolean
+  onClose: () => void
+  onInsert: (latex: string) => void
+}) {
+  const [phase, setPhase] = useState<Phase>('checking')
+  const [projects, setProjects] = useState<ProjectEvidence[]>([])
+  const [selection, setSelection] = useState<Record<number, Selection>>({})
+  const [error, setError] = useState<string | null>(null)
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelledRef = useRef(false)
+
+  const clearTimer = () => {
+    if (pollTimer.current) {
+      clearTimeout(pollTimer.current)
+      pollTimer.current = null
+    }
+  }
+
+  const startImport = useCallback(async () => {
+    setPhase('importing')
+    setError(null)
+    try {
+      const { job_id } = await apiClient.importGitHubProjects()
+      const deadline = Date.now() + POLL_TIMEOUT_MS
+      const poll = async () => {
+        if (cancelledRef.current) return
+        try {
+          const res = await apiClient.getGitHubImportResult(job_id)
+          if (cancelledRef.current) return
+          if (res.status === 'completed') {
+            setProjects(res.projects)
+            // Default: include every project with all its suggested bullets checked.
+            const init: Record<number, Selection> = {}
+            res.projects.forEach((p, i) => {
+              init[i] = { included: true, bullets: new Set(p.suggested_bullets.map((_, bi) => bi)) }
+            })
+            setSelection(init)
+            setPhase('ready')
+            return
+          }
+          if (res.status === 'failed') {
+            setError(res.error || 'Import failed')
+            setPhase('error')
+            return
+          }
+          if (Date.now() > deadline) {
+            setError('Import timed out. Please try again.')
+            setPhase('error')
+            return
+          }
+          pollTimer.current = setTimeout(poll, POLL_INTERVAL_MS)
+        } catch (e) {
+          if (cancelledRef.current) return
+          setError(e instanceof Error ? e.message : 'Failed to load import result')
+          setPhase('error')
+        }
+      }
+      pollTimer.current = setTimeout(poll, POLL_INTERVAL_MS)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to start import'
+      // The backend returns 400 with a "GitHub not connected" message.
+      if (/not connected/i.test(msg)) setPhase('disconnected')
+      else {
+        setError(msg)
+        setPhase('error')
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+    cancelledRef.current = false
+    let active = true
+    const check = async () => {
+      setPhase('checking')
+      try {
+        const status = await apiClient.getGitHubStatus()
+        if (!active) return
+        if (status.connected) startImport()
+        else setPhase('disconnected')
+      } catch {
+        if (active) startImport() // status is best-effort; let import surface the real error
+      }
+    }
+    check()
+    return () => {
+      active = false
+      cancelledRef.current = true
+      clearTimer()
+    }
+  }, [isOpen, startImport])
+
+  const toggleProject = (i: number) =>
+    setSelection((prev) => ({ ...prev, [i]: { ...prev[i], included: !prev[i].included } }))
+
+  const toggleBullet = (i: number, bi: number) =>
+    setSelection((prev) => {
+      const bullets = new Set(prev[i].bullets)
+      if (bullets.has(bi)) bullets.delete(bi)
+      else bullets.add(bi)
+      return { ...prev, [i]: { ...prev[i], bullets } }
+    })
+
+  const selectedCount = Object.values(selection).filter((s) => s.included).length
+
+  const handleInsert = () => {
+    const selections: ProjectSelection[] = projects
+      .map((p, i) => ({ p, i }))
+      .filter(({ i }) => selection[i]?.included)
+      .map(({ p, i }) => ({
+        project: p,
+        bullets: p.suggested_bullets.filter((_, bi) => selection[i].bullets.has(bi)),
+      }))
+    const latex = projectsToLatex(selections)
+    if (!latex) {
+      toast.error('Select at least one project')
+      return
+    }
+    onInsert(latex)
+    toast.success(`Inserted ${selectedCount} project${selectedCount === 1 ? '' : 's'}`)
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+        onClick={onClose}
+      >
+        <motion.div
+          initial={{ opacity: 0, scale: 0.97, y: 8 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.97 }}
+          className="flex max-h-[88vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between border-b border-white/10 px-5 py-4">
+            <div>
+              <h2 className="text-sm font-semibold text-zinc-100">Import from GitHub</h2>
+              <p className="mt-0.5 text-[11px] text-zinc-500">
+                Your top public projects, AI-summarized into resume bullets. Public data only.
+              </p>
+            </div>
+            <button onClick={onClose} className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-zinc-200">
+              <X size={16} />
+            </button>
+          </div>
+
+          <div className="scrollbar-subtle min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            {phase === 'checking' && (
+              <div className="flex items-center justify-center gap-2 py-16 text-sm text-zinc-500">
+                <Loader2 size={16} className="animate-spin" /> Checking GitHub connection…
+              </div>
+            )}
+
+            {phase === 'importing' && (
+              <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+                <Loader2 size={20} className="animate-spin text-orange-300" />
+                <p className="text-sm text-zinc-300">Fetching and summarizing your projects…</p>
+                <p className="text-[11px] text-zinc-600">This can take up to a minute for the LLM pass.</p>
+              </div>
+            )}
+
+            {phase === 'disconnected' && (
+              <div className="py-12 text-center">
+                <p className="text-sm text-zinc-300">GitHub isn&apos;t connected yet.</p>
+                <p className="mx-auto mt-1 max-w-sm text-[11px] text-zinc-500">
+                  Connect your account in Settings → GitHub Integration, then reopen this import.
+                </p>
+                <a
+                  href="/settings"
+                  className="mt-4 inline-block rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold text-zinc-200 transition hover:bg-white/10"
+                >
+                  Go to Settings
+                </a>
+              </div>
+            )}
+
+            {phase === 'error' && (
+              <div className="py-12 text-center">
+                <div className="mx-auto max-w-md rounded-lg border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+                  {error || 'Something went wrong.'}
+                </div>
+                <button
+                  onClick={startImport}
+                  className="mt-4 rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold text-zinc-200 transition hover:bg-white/10"
+                >
+                  Try again
+                </button>
+              </div>
+            )}
+
+            {phase === 'ready' && projects.length === 0 && (
+              <div className="py-16 text-center text-sm text-zinc-500">
+                No documented public projects found to import.
+              </div>
+            )}
+
+            {phase === 'ready' && projects.length > 0 && (
+              <ul className="space-y-3">
+                {projects.map((p, i) => {
+                  const sel = selection[i]
+                  if (!sel) return null
+                  return (
+                    <li
+                      key={`${p.title}-${i}`}
+                      className={`rounded-xl border p-3 transition ${
+                        sel.included ? 'border-white/10 bg-white/[0.02]' : 'border-white/5 opacity-55'
+                      }`}
+                    >
+                      <div className="flex items-start gap-2.5">
+                        <input
+                          type="checkbox"
+                          checked={sel.included}
+                          onChange={() => toggleProject(i)}
+                          className="mt-1 h-3.5 w-3.5 accent-orange-400"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <p className="truncate text-sm font-semibold text-zinc-100">{p.title}</p>
+                            {p.metrics?.stars > 0 && (
+                              <span className="flex items-center gap-0.5 text-[10px] text-zinc-500">
+                                <Star size={10} /> {p.metrics.stars}
+                              </span>
+                            )}
+                            {p.url && (
+                              <a href={p.url} target="_blank" rel="noopener noreferrer" className="text-zinc-500 hover:text-zinc-300">
+                                <ExternalLink size={11} />
+                              </a>
+                            )}
+                          </div>
+                          {p.description && <p className="mt-0.5 text-[11px] leading-relaxed text-zinc-400">{p.description}</p>}
+                          {p.tech?.length > 0 && (
+                            <div className="mt-1 flex flex-wrap gap-1">
+                              {p.tech.slice(0, 8).map((t) => (
+                                <span key={t} className="rounded bg-white/[0.05] px-1.5 py-0.5 text-[9px] text-zinc-400">
+                                  {t}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                          {sel.included && p.suggested_bullets.length > 0 && (
+                            <div className="mt-2 space-y-1">
+                              {p.suggested_bullets.map((b, bi) => (
+                                <label key={bi} className="flex cursor-pointer items-start gap-2 text-[11px] text-zinc-300">
+                                  <input
+                                    type="checkbox"
+                                    checked={sel.bullets.has(bi)}
+                                    onChange={() => toggleBullet(i, bi)}
+                                    className="mt-0.5 h-3 w-3 accent-emerald-400"
+                                  />
+                                  <span className="leading-relaxed">{b}</span>
+                                </label>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between gap-3 border-t border-white/10 px-5 py-3.5">
+            <span className="text-[11px] text-zinc-500">
+              {phase === 'ready' ? `${selectedCount} of ${projects.length} selected` : ''}
+            </span>
+            <div className="flex items-center gap-3">
+              <button onClick={onClose} className="text-xs font-semibold text-zinc-400 transition hover:text-zinc-200">
+                Cancel
+              </button>
+              <button
+                onClick={handleInsert}
+                disabled={phase !== 'ready' || selectedCount === 0}
+                className="btn-accent px-4 py-2 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Insert into resume
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -685,6 +685,25 @@ export interface GitHubPullResponse {
   latex_content: string
 }
 
+/** A single imported GitHub project (public data only). */
+export interface ProjectEvidence {
+  source: string
+  title: string
+  description: string
+  tech: string[]
+  metrics: { stars: number; forks: number }
+  dates: { last_active: string | null }
+  url: string | null
+  suggested_bullets: string[]
+  raw_excerpt: string
+}
+
+export interface GitHubImportResult {
+  status: 'pending' | 'completed' | 'failed'
+  projects: ProjectEvidence[]
+  error: string | null
+}
+
 // Dropbox Integration (Feature 77)
 export interface DropboxStatusResponse {
   connected: boolean
@@ -2573,6 +2592,20 @@ class ApiClient {
     return this.request<GitHubPullResponse>(`/github/resumes/${encodeURIComponent(resumeId)}/pull`, {
       method: 'POST',
     })
+  }
+
+  /**
+   * Start an async import of the user's top PUBLIC GitHub projects (F1). Returns
+   * a job id to poll via {@link getGitHubImportResult}. Requires a connected
+   * GitHub account (400 otherwise).
+   */
+  async importGitHubProjects(): Promise<{ job_id: string }> {
+    return this.request<{ job_id: string }>('/github/import-projects', { method: 'POST' })
+  }
+
+  /** Poll a GitHub-import job for its ranked, AI-summarized ProjectEvidence. */
+  async getGitHubImportResult(jobId: string): Promise<GitHubImportResult> {
+    return this.request<GitHubImportResult>(`/github/import-projects/${encodeURIComponent(jobId)}`)
   }
 
   // ---------------------------------------------------------------- //

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -84,6 +84,25 @@ export interface JobSubmitRequest {
   downplay?: string[]
 }
 
+/** One discrete, independently-applicable change from /optimize/segment-changes. */
+export interface ChangeHunk {
+  id: string
+  kind: 'modified' | 'added' | 'removed'
+  original_text: string
+  new_text: string
+  before_context: string
+  after_context: string
+  section: string | null
+  rationale: string | null
+  original_start: number
+  original_end: number
+}
+
+export interface SegmentChangesResponse {
+  hunks: ChangeHunk[]
+  summary: { total: number; added: number; modified: number; removed: number }
+}
+
 export interface OptimizationHistoryEntry {
   id: string
   created_at: string
@@ -1392,6 +1411,38 @@ class ApiClient {
 
   async getPersonas(): Promise<Array<{ key: string; label: string; description: string }>> {
     return this.request('/ai/personas')
+  }
+
+  // ---------------------------------------------------------------- //
+  //  Per-change review (input-driven optimization, F2-P0)             //
+  // ---------------------------------------------------------------- //
+
+  /**
+   * Segment the original→optimized diff into discrete, individually-applicable
+   * change hunks (server-side, deterministic). The frontend renders these for
+   * accept/reject/edit, then calls {@link applyChanges} with the accepted ids.
+   */
+  async segmentChanges(body: {
+    original_latex: string
+    optimized_latex: string
+    change_reasons?: Array<{ section?: string; change_type?: string; reason?: string }>
+  }): Promise<SegmentChangesResponse> {
+    return this.request<SegmentChangesResponse>('/optimize/segment-changes', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+  }
+
+  /** Reconstruct the final LaTeX from the original + the accepted hunk ids. */
+  async applyChanges(body: {
+    original_latex: string
+    hunks: ChangeHunk[]
+    accepted_ids: string[]
+  }): Promise<{ latex: string }> {
+    return this.request<{ latex: string }>('/optimize/apply-changes', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
   }
 
   // ---------------------------------------------------------------- //

--- a/frontend/src/lib/github-projects-latex.ts
+++ b/frontend/src/lib/github-projects-latex.ts
@@ -1,0 +1,77 @@
+/**
+ * Turn selected imported GitHub projects into an insertable LaTeX snippet
+ * (External-Sources-to-Resume, F1). Pure + React-free so it is unit tested and
+ * reused by the import modal.
+ *
+ * The output is a template-agnostic block (bold title + optional repo link,
+ * tech line, and an itemize of the user-selected bullets) guarded by a comment
+ * so the user can see where it came from and move/edit it.
+ */
+
+import type { ProjectEvidence } from './api-client'
+
+/** One project the user chose to insert, with the subset of bullets they kept. */
+export interface ProjectSelection {
+  project: ProjectEvidence
+  bullets: string[]
+}
+
+const _LATEX_ESCAPES: Record<string, string> = {
+  '\\': '\\textbackslash{}',
+  '&': '\\&',
+  '%': '\\%',
+  $: '\\$',
+  '#': '\\#',
+  _: '\\_',
+  '{': '\\{',
+  '}': '\\}',
+  '~': '\\textasciitilde{}',
+  '^': '\\textasciicircum{}',
+}
+
+/**
+ * Escape the LaTeX special characters that appear in free text. Single-pass so
+ * the braces introduced by \textbackslash{} etc. are not themselves re-escaped.
+ */
+export function escapeLatex(text: string): string {
+  return text.replace(/[\\&%$#_{}~^]/g, (c) => _LATEX_ESCAPES[c])
+}
+
+function projectBlock({ project, bullets }: ProjectSelection): string {
+  const title = escapeLatex(project.title || 'Project')
+  const lines: string[] = []
+
+  const link =
+    project.url && /^https?:\/\//i.test(project.url)
+      ? ` \\href{${project.url}}{\\texttt{repo}}`
+      : ''
+  lines.push(`\\textbf{${title}}${link}`)
+
+  const tech = (project.tech || []).filter(Boolean)
+  if (tech.length > 0) {
+    lines.push(`\\textit{${escapeLatex(tech.join(', '))}}`)
+  }
+
+  const kept = bullets.filter((b) => b && b.trim())
+  if (kept.length > 0) {
+    lines.push('\\begin{itemize}')
+    for (const b of kept) lines.push(`  \\item ${escapeLatex(b.trim())}`)
+    lines.push('\\end{itemize}')
+  } else if (project.description) {
+    lines.push(escapeLatex(project.description.trim()))
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Render the chosen projects (each with its kept bullets) into one LaTeX block.
+ * Returns '' when nothing is selected so the caller can no-op.
+ */
+export function projectsToLatex(selections: ProjectSelection[]): string {
+  const usable = selections.filter((s) => s.project && (s.bullets.length > 0 || s.project.description))
+  if (usable.length === 0) return ''
+
+  const blocks = usable.map(projectBlock).join('\n\n\\smallskip\n\n')
+  return `% Projects imported from GitHub — edit freely\n${blocks}\n`
+}


### PR DESCRIPTION
Closes #1053.

Frontend for the GitHub import backend (#1050). A **Projects** tool on the resume edit page imports the user's top **public** GitHub projects (AI-summarized) and lets them pick projects + bullets to insert as LaTeX. Everything routes through this review step — nothing is written to the resume without the user choosing it.

## What's in it
- **`api-client.ts`** — `ProjectEvidence` / `GitHubImportResult` types + `importGitHubProjects` / `getGitHubImportResult`.
- **`lib/github-projects-latex.ts`** — React-free `escapeLatex` (single-pass, no double-escaping) + `projectsToLatex` (template-agnostic block: bold title, http-only `\href` repo link, tech line, itemize of kept bullets; description fallback).
- **`GithubImportModal.tsx`** — connection check → start import → poll (2.5s, 120s timeout) → ranked project cards with per-project + per-bullet checkboxes → insert. Disconnected (→ Settings), error (→ retry), and empty states.
- **edit page** — *Projects* toolbar button + modal wired to `insertAtCursor` behind an undo checkpoint.

## Testing
- `github-import.test.ts`: 9 tests — LaTeX escaping (incl. the backslash-ordering edge case), project rendering, description fallback, **non-http url is not turned into `\href`** (injection guard), multi-project separation, and client plumbing.
- Full frontend unit suite: **488 passed**. `tsc` + ESLint clean.