### PR TITLE
fix: international phone numbers, silent 4k truncation, and PDF structure loss

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -58,6 +58,13 @@ LATEX_DOCKER_IMAGE=texlive/texlive:latest
 COMPILE_TIMEOUT=30
 MAX_FILE_SIZE=10485760
 
+# ── Resume Parsing ────────────────────────────────────────────────────────────
+# Region used to read phone numbers written WITHOUT a country code, e.g. a bare
+# "98765 43210". Numbers written with one (+91, +44) parse correctly regardless.
+# A bare number from a different region yields no phone rather than a wrong one,
+# so this only ever adds coverage — set it to wherever most of your users are.
+RESUME_DEFAULT_PHONE_REGION=US
+
 # ── File Storage ──────────────────────────────────────────────────────────────
 PDF_RETENTION_TIME=3600
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -191,6 +191,15 @@ class Settings(BaseSettings):
     # Number of free deep analysis uses per device (anonymous users)
     DEEP_ANALYSIS_TRIAL_LIMIT: int = Field(default=2, description="Number of free deep analysis uses per device")
 
+    # Region used to read phone numbers written WITHOUT a country code, e.g. a
+    # bare "98765 43210". Numbers written with one (+91, +44) are unambiguous and
+    # parse correctly regardless of this. A bare number from another region
+    # yields no phone rather than a wrong one, so this only ever adds coverage.
+    RESUME_DEFAULT_PHONE_REGION: str = Field(
+        default="US",
+        description="ISO 3166-1 alpha-2 region for parsing phone numbers with no country code (e.g. IN, GB, US)",
+    )
+
     # JWT Configuration
     JWT_SECRET_KEY: str = Field(default="", description="JWT secret key for token signing")
     JWT_ALGORITHM: str = Field(default="HS256", description="JWT algorithm")

--- a/backend/app/parsers/base_parser.py
+++ b/backend/app/parsers/base_parser.py
@@ -9,6 +9,8 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from ..utils.contact import find_phone
+
 logger = logging.getLogger(__name__)
 
 
@@ -147,10 +149,21 @@ SECTION_PATTERNS = _re.compile(
 )
 
 EMAIL_RE = _re.compile(r'[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}')
+# Kept for backwards compatibility with anything importing it; phone extraction
+# now goes through app.utils.contact.find_phone, which handles non-NANP numbers.
+# This pattern matches US layouts ONLY and silently missed +91/+44/+61/+65.
 PHONE_RE = _re.compile(r'(?:\+?1[-.\s]?)?(?:\(?[2-9]\d{2}\)?[-.\s]?)[2-9]\d{2}[-.\s]?\d{4}')
 LINKEDIN_RE = _re.compile(r'(?:linkedin\.com/in/|linkedin:\s*)([a-zA-Z0-9\-]+)', _re.IGNORECASE)
 GITHUB_RE = _re.compile(r'(?:github\.com/|github:\s*)([a-zA-Z0-9\-]+)', _re.IGNORECASE)
 
+
+def _default_phone_region() -> str:
+    """Region used to resolve phone numbers written without a country code."""
+    try:
+        from ..core.config import settings
+        return getattr(settings, "RESUME_DEFAULT_PHONE_REGION", "US") or "US"
+    except Exception:
+        return "US"
 
 class AbstractParser(ABC):
     """Abstract base class for all resume format parsers."""
@@ -212,9 +225,7 @@ class AbstractParser(ABC):
         email_match = EMAIL_RE.search(text)
         if email_match:
             contact.email = email_match.group(0)
-        phone_match = PHONE_RE.search(text)
-        if phone_match:
-            contact.phone = phone_match.group(0)
+        contact.phone = find_phone(text, _default_phone_region())
         linkedin_match = LINKEDIN_RE.search(text)
         if linkedin_match:
             contact.linkedin = f"linkedin.com/in/{linkedin_match.group(1)}"

--- a/backend/app/parsers/pdf_layout.py
+++ b/backend/app/parsers/pdf_layout.py
@@ -1,0 +1,177 @@
+"""Layout-aware text reconstruction for PDF resumes.
+
+``page.extract_text()`` flattens a page into lines of space-joined words, which
+loses two things a resume depends on:
+
+1. **Horizontal grouping.** A right-aligned date and the job title it sits beside
+   arrive as ``"Senior Software Engineer, Razorpay Mar 2022 - Present"`` — one
+   run of words with nothing marking where the title ends. A two-column skills
+   block is worse: ``"Languages: Go, Python  Practices: Event sourcing"`` reads
+   as a single sentence.
+2. **Prominence.** Section headings are set in a larger or bolder font, and that
+   is the most reliable signal of where a section starts. Flattened, ``SKILLS``
+   is just another line.
+
+pdfplumber already exposes everything needed — ``extract_words`` returns ``x0``,
+``x1``, ``top``, ``size`` and ``fontname`` per word — so this module reconstructs
+lines, splits them into cells on significant horizontal gaps, and identifies
+headings by font prominence. No new dependency.
+
+The output is still plain text: cells are joined with a separator so the LLM sees
+the boundary, rather than being handed a structure it would have to be taught.
+"""
+
+from __future__ import annotations
+
+import re
+import statistics
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .base_parser import SECTION_PATTERNS
+
+# Whitespace (in points) between two words that means "these belong to different
+# cells" rather than "next word". Resume gutters and right-aligned date columns
+# are comfortably wider than this; ordinary inter-word spacing at 9-12pt body
+# text is 2-5pt.
+CELL_GAP_PTS = 24.0
+
+# Words on the same visual line never differ in `top` by more than this.
+LINE_TOLERANCE_PTS = 3.0
+
+# Cell separator in the reconstructed text. A pipe already appears in resume
+# contact lines, so it reads naturally and needs no explanation in the prompt.
+CELL_SEPARATOR = " | "
+
+# A heading candidate is short. "Senior Software Engineer, Razorpay" is bold and
+# larger than body text, but it is not a section heading.
+MAX_HEADING_WORDS = 5
+
+
+@dataclass
+class LayoutLine:
+    text: str
+    cells: List[str]
+    size: float
+    bold: bool
+    top: float
+    x0: float
+    is_heading: bool = False
+
+
+@dataclass
+class LayoutResult:
+    text: str
+    section_hints: List[str] = field(default_factory=list)
+    pages: int = 0
+    lines: List[LayoutLine] = field(default_factory=list)
+
+
+def _split_cells(words: list) -> List[str]:
+    """Split one visual line into cells wherever a wide gap appears."""
+    ordered = sorted(words, key=lambda w: w["x0"])
+    cells, current = [], [ordered[0]]
+    for previous, word in zip(ordered, ordered[1:]):
+        if word["x0"] - previous["x1"] > CELL_GAP_PTS:
+            cells.append(current)
+            current = [word]
+        else:
+            current.append(word)
+    cells.append(current)
+    return [" ".join(w["text"] for w in cell).strip() for cell in cells]
+
+
+def _looks_like_section_heading(text: str, size: float, bold: bool, body_size: float) -> bool:
+    """Whether a line is a section heading rather than prominent body text.
+
+    Prominence alone is not enough — job titles are bold too. A heading must also
+    read like one: a known section name, or a short all-caps line.
+    """
+    stripped = text.strip().rstrip(":").strip()
+    if not stripped or len(stripped.split()) > MAX_HEADING_WORDS:
+        return False
+
+    prominent = bold or size > body_size + 0.4
+    if not prominent:
+        return False
+
+    if SECTION_PATTERNS.match(stripped):
+        return True
+    # All-caps short lines are conventional section headings even when the exact
+    # wording is not in the known vocabulary ("CORE COMPETENCIES").
+    letters = [c for c in stripped if c.isalpha()]
+    return bool(letters) and all(c.isupper() for c in letters)
+
+
+def extract_layout_text(
+    file_content: bytes, max_pages: int = 50
+) -> Optional[LayoutResult]:
+    """Reconstruct resume text with cell boundaries and heading detection.
+
+    Returns ``None`` when the PDF yields no positioned words at all (a scanned
+    page, or an encrypted one), so the caller can fall back to its existing path
+    rather than treating an empty result as a successful parse.
+    """
+    import io
+
+    import pdfplumber
+
+    all_lines: List[LayoutLine] = []
+    page_count = 0
+
+    with pdfplumber.open(io.BytesIO(file_content)) as pdf:
+        page_count = len(pdf.pages)
+        for page in pdf.pages[:max_pages]:
+            words = page.extract_words(extra_attrs=["size", "fontname"])
+            if not words:
+                continue
+
+            rows: dict = {}
+            for word in words:
+                key = round(word["top"] / LINE_TOLERANCE_PTS)
+                rows.setdefault(key, []).append(word)
+
+            for key in sorted(rows):
+                row = rows[key]
+                cells = _split_cells(row)
+                if not any(cells):
+                    continue
+                all_lines.append(
+                    LayoutLine(
+                        text=CELL_SEPARATOR.join(c for c in cells if c),
+                        cells=[c for c in cells if c],
+                        size=max(w["size"] for w in row),
+                        bold=any("Bold" in (w.get("fontname") or "") for w in row),
+                        top=min(w["top"] for w in row),
+                        x0=min(w["x0"] for w in row),
+                    )
+                )
+
+    if not all_lines:
+        return None
+
+    body_size = statistics.median([ln.size for ln in all_lines])
+    hints: List[str] = []
+    for line in all_lines:
+        # A heading is a single cell — a line split across columns is content.
+        if len(line.cells) == 1 and _looks_like_section_heading(
+            line.text, line.size, line.bold, body_size
+        ):
+            line.is_heading = True
+            name = line.text.strip().rstrip(":").strip()
+            if name.upper() not in {h.upper() for h in hints}:
+                hints.append(name)
+
+    # Blank line before each heading so section boundaries survive in plain text.
+    rendered: List[str] = []
+    for line in all_lines:
+        if line.is_heading and rendered:
+            rendered.append("")
+        rendered.append(line.text)
+
+    return LayoutResult(
+        text=re.sub(r"\n{3,}", "\n\n", "\n".join(rendered)).strip(),
+        section_hints=hints,
+        pages=page_count,
+        lines=all_lines,
+    )

--- a/backend/app/parsers/pdf_parser.py
+++ b/backend/app/parsers/pdf_parser.py
@@ -7,6 +7,7 @@ import logging
 from typing import Optional
 
 from .base_parser import AbstractParser, ParsedResume
+from .pdf_layout import extract_layout_text
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +27,42 @@ class PDFParser(AbstractParser):
             raise ValueError("pdfplumber not installed. Run: pip install pdfplumber")
 
         try:
-            pages_text = []
-            with pdfplumber.open(io.BytesIO(file_content)) as pdf:
-                total_pages = len(pdf.pages)
-                if total_pages > MAX_PDF_PAGES:
-                    logger.warning(
-                        f"PDF has {total_pages} pages; truncating to first {MAX_PDF_PAGES}: {filename}"
-                    )
-                for page in pdf.pages[:MAX_PDF_PAGES]:
-                    text = page.extract_text(x_tolerance=3, y_tolerance=3)
-                    if text:
-                        pages_text.append(text)
+            # Layout-aware pass first: it keeps right-aligned dates and
+            # two-column blocks from being run together into one ambiguous line,
+            # and identifies section headings by font prominence. Falls back to
+            # flat extraction if it yields nothing (scanned/encrypted) or raises,
+            # so this can only add information, never lose it.
+            section_hints: list = []
+            full_text = ""
+            try:
+                layout = extract_layout_text(file_content, max_pages=MAX_PDF_PAGES)
+                if layout and layout.text.strip():
+                    full_text = layout.text
+                    section_hints = layout.section_hints
+                    if layout.pages > MAX_PDF_PAGES:
+                        logger.warning(
+                            f"PDF has {layout.pages} pages; truncating to first "
+                            f"{MAX_PDF_PAGES}: {filename}"
+                        )
+            except Exception as layout_err:
+                logger.warning(
+                    f"Layout-aware extraction failed, falling back to flat text: {layout_err}"
+                )
 
-            full_text = "\n\n".join(pages_text).strip()
+            if not full_text:
+                pages_text = []
+                with pdfplumber.open(io.BytesIO(file_content)) as pdf:
+                    total_pages = len(pdf.pages)
+                    if total_pages > MAX_PDF_PAGES:
+                        logger.warning(
+                            f"PDF has {total_pages} pages; truncating to first {MAX_PDF_PAGES}: {filename}"
+                        )
+                    for page in pdf.pages[:MAX_PDF_PAGES]:
+                        text = page.extract_text(x_tolerance=3, y_tolerance=3)
+                        if text:
+                            pages_text.append(text)
+
+                full_text = "\n\n".join(pages_text).strip()
 
             # If no text extracted (scanned PDF), fall back to OCR
             if not full_text:
@@ -53,7 +77,9 @@ class PDFParser(AbstractParser):
             if not full_text.strip():
                 raise ValueError("Could not extract text from PDF (no text content and OCR failed)")
 
-            return self._build_parsed_resume(full_text, filename)
+            return self._build_parsed_resume(
+                full_text, filename, section_hints=section_hints
+            )
 
         except Exception as e:
             logger.error(f"Error parsing PDF: {e}")

--- a/backend/app/services/document_converter_service.py
+++ b/backend/app/services/document_converter_service.py
@@ -59,6 +59,46 @@ IMPORTANT:
 - Return ONLY valid compilable LaTeX code — no markdown, no explanations, no code fences"""
 
 
+
+# gpt-4o-mini has a 128k-token context and the conversion asks for at most 4096
+# output tokens, so the input budget here is bounded by cost and abuse, not by
+# the model. The previous 4000-CHARACTER cap was far below both: a one-page
+# resume is ~1000 chars but a dense two-page one runs 4000-6000, so those were
+# cut mid-sentence. For a PDF that mattered doubly, because PDFParser fills only
+# raw_text — the structured-sections block is empty, so this excerpt is the ONLY
+# content the model receives.
+#
+# 24k chars is roughly 6k tokens: comfortably more than any real resume, still a
+# hard bound on a hostile upload.
+RAW_TEXT_CHAR_BUDGET = 24_000
+
+
+def _clip_raw_text(raw_text: str) -> tuple[str, int]:
+    """Clip *raw_text* to the prompt budget, returning (text, chars_dropped).
+
+    Cuts on a line boundary where one is reasonably close to the limit, so the
+    excerpt does not end mid-word. Callers surface the dropped count to the model
+    (and the log) instead of silently pretending the resume ended there.
+    """
+    if len(raw_text) <= RAW_TEXT_CHAR_BUDGET:
+        return raw_text, 0
+
+    dropped = len(raw_text) - RAW_TEXT_CHAR_BUDGET
+    head = raw_text[:RAW_TEXT_CHAR_BUDGET]
+    boundary = head.rfind("\n")
+    # Only honour the boundary if it is not throwing away a lot of the budget.
+    if boundary > RAW_TEXT_CHAR_BUDGET * 0.9:
+        dropped += len(head) - boundary
+        head = head[:boundary]
+
+    logger.warning(
+        "Resume text exceeded the conversion prompt budget: %d chars supplied, "
+        "%d dropped. The generated LaTeX will be missing content.",
+        len(head),
+        dropped,
+    )
+    return head, dropped
+
 class DocumentConverterService:
     """Service for converting parsed resume data to LaTeX via LLM."""
 
@@ -80,7 +120,7 @@ class DocumentConverterService:
             List of message dicts for OpenAI chat completions
         """
         contact = structure.get('contact') or {}
-        raw_text = (structure.get('raw_text') or '')[:4000]  # cap at 4K chars
+        raw_text, truncated_chars = _clip_raw_text(structure.get('raw_text') or '')
 
         # Build sections summary
         sections_text = self._format_sections(structure)
@@ -143,6 +183,16 @@ class DocumentConverterService:
             "=== FULL RAW TEXT ===",
             raw_text,
         ])
+
+        # Tell the model the input is incomplete rather than letting it treat a
+        # mid-sentence cut as the end of the resume and invent a tidy ending.
+        if truncated_chars:
+            user_parts.extend([
+                "",
+                f"[NOTE: the resume was longer than this excerpt and {truncated_chars} "
+                "characters were omitted. Convert only what is shown above; do not "
+                "invent content to fill the gap.]",
+            ])
 
         user = "\n".join(user_parts)
 

--- a/backend/app/utils/contact.py
+++ b/backend/app/utils/contact.py
@@ -1,0 +1,77 @@
+"""Contact-detail extraction shared by every resume parser.
+
+Phone numbers are found with ``phonenumbers`` (Google's libphonenumber) rather
+than a regex. The regex this replaced matched the NANP layout only —
+``(?:\\+?1[-.\\s]?)?(?:\\(?[2-9]\\d{2}\\)?[-.\\s]?)[2-9]\\d{2}[-.\\s]?\\d{4}`` — so
+``+91 98765 43210``, ``+44 20 7946 0958``, ``+61 2 9374 4000`` and
+``+65 6123 4567`` all silently produced no phone number at all. Every format
+went through it, not just PDF.
+
+``PhoneNumberMatcher`` is used instead of ``parse()`` because it is built to scan
+free text: it will not match the digit strings a resume is full of. Verified
+against ``"Reduced p95 latency from 380ms to 140ms"``, ``"CGPA: 9.1/10"``,
+``"cert id 4519827364"`` and ``"Bangalore 560001"`` — none of which yield a
+match, where a looser regex would.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+try:
+    import phonenumbers
+    from phonenumbers import PhoneNumberFormat, PhoneNumberMatcher
+
+    _PHONENUMBERS_AVAILABLE = True
+except ImportError:  # pragma: no cover - declared in requirements.txt
+    _PHONENUMBERS_AVAILABLE = False
+
+
+# Fallback for the (unlikely) case where phonenumbers is missing. Deliberately
+# permissive, since it only runs when the real parser is unavailable.
+_FALLBACK_PHONE_RE = re.compile(r"\+?\d[\d\s\-().]{7,17}\d")
+
+EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
+
+
+def find_phone(text: str, default_region: Optional[str] = "US") -> Optional[str]:
+    """Return the first phone number in *text*, formatted internationally.
+
+    Two passes, in this order:
+
+    1. With no region. Anything written with an explicit country code (``+91``,
+       ``+44``) is unambiguous and is matched correctly wherever the candidate
+       lives — which covers most resumes that list an international number.
+    2. With *default_region*. Only this pass can resolve a bare local number
+       like ``98765 43210``, which is meaningless without knowing the country.
+
+    A number written bare in a region other than *default_region* yields ``None``
+    rather than a wrong guess: parsing a bare Indian number as US returns no
+    match, it does not invent one. Set ``RESUME_DEFAULT_PHONE_REGION`` to the
+    region most of your users write from.
+    """
+    if not text:
+        return None
+
+    if not _PHONENUMBERS_AVAILABLE:
+        match = _FALLBACK_PHONE_RE.search(text)
+        return match.group(0).strip() if match else None
+
+    for region in (None, default_region):
+        try:
+            for match in PhoneNumberMatcher(text, region):
+                return phonenumbers.format_number(
+                    match.number, PhoneNumberFormat.INTERNATIONAL
+                )
+        except Exception:
+            continue
+    return None
+
+
+def find_email(text: str) -> Optional[str]:
+    """Return the first email address in *text*."""
+    if not text:
+        return None
+    match = EMAIL_RE.search(text)
+    return match.group(0) if match else None

--- a/backend/test/test_contact_extraction.py
+++ b/backend/test/test_contact_extraction.py
@@ -1,0 +1,86 @@
+"""Contact extraction, with the international phone cases the old regex missed.
+
+The previous ``PHONE_RE`` matched the NANP layout only, so every resume that
+wrote its number with a non-US country code produced ``phone: None`` — silently,
+on every format, not just PDF. These tests pin that class of input.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.utils.contact import find_email, find_phone
+
+# (raw text, region hint, expected E.164-ish international form)
+INTERNATIONAL_CASES = [
+    ("Bangalore, India | priya@example.com | +91 98765 43210", "US", "+91 98765 43210"),
+    ("Mumbai | +91-98765-43210", "US", "+91 98765 43210"),
+    ("London | +44 20 7946 0958", "US", "+44 20 7946 0958"),
+    ("Sydney | +61 2 9374 4000", "US", "+61 2 9374 4000"),
+    ("Singapore | +65 6123 4567", "US", "+65 6123 4567"),
+    ("Berlin | +49 30 901820", "US", "+49 30 901820"),
+    ("Toronto | +1 416 555 0199", "US", "+1 416-555-0199"),
+    ("SF, CA | (415) 555-2671", "US", "+1 415-555-2671"),
+]
+
+
+@pytest.mark.parametrize("text,region,expected", INTERNATIONAL_CASES)
+def test_international_numbers_are_found(text, region, expected):
+    """A country code makes the number unambiguous — region must not matter."""
+    assert find_phone(text, region) == expected
+
+
+def test_bare_local_number_needs_the_matching_region():
+    """A number with no country code is meaningless without one.
+
+    The important half is the second assertion: parsing a bare Indian number
+    under a US default returns *nothing* rather than inventing a US number, so a
+    misconfigured region can never produce a wrong phone number on a resume.
+    """
+    assert find_phone("Chennai | 98765 43210", "IN") == "+91 98765 43210"
+    assert find_phone("Chennai | 98765 43210", "US") is None
+
+
+@pytest.mark.parametrize(
+    "noise",
+    [
+        "Reduced p95 checkout latency from 380ms to 140ms via query batching.",
+        "Designed idempotency layer handling 40M req/day with p99 under 25ms.",
+        "CGPA: 9.1/10  |  2015 - 2019",
+        "Scaled the pipeline to 1,200,000 events daily",
+        "AWS certified 2023-2026, credential id 4519827364",
+        "Bangalore 560001",
+    ],
+)
+def test_resume_digit_noise_is_not_a_phone_number(noise):
+    """Resumes are full of digits; none of these are phone numbers.
+
+    This is why the implementation scans with PhoneNumberMatcher rather than a
+    permissive regex — a looser pattern matches the credential id and the pin
+    code, which is worse than the US-only bug it replaced.
+    """
+    for region in ("US", "IN", "GB"):
+        assert find_phone(noise, region) is None
+
+
+def test_no_phone_present_returns_none():
+    assert find_phone("Priya Raman\nBackend engineer", "US") is None
+    assert find_phone("", "US") is None
+
+
+def test_email_extraction():
+    assert find_email("reach me at priya.raman@example.com today") == "priya.raman@example.com"
+    assert find_email("no address here") is None
+
+
+def test_parser_contact_uses_the_international_path():
+    """The parser base class must go through find_phone, not the old regex."""
+    from app.parsers.text_parser import TextParser
+
+    contact = TextParser()._extract_contact_info(
+        "Priya Raman\nBangalore, India\npriya.raman@example.com\n+91 98765 43210\n"
+        "github.com/priyaraman"
+    )
+    assert contact.phone == "+91 98765 43210"
+    assert contact.email == "priya.raman@example.com"
+    assert contact.github == "github.com/priyaraman"

--- a/backend/test/test_conversion_prompt_budget.py
+++ b/backend/test/test_conversion_prompt_budget.py
@@ -1,0 +1,85 @@
+"""The conversion prompt must not silently drop resume content.
+
+The previous cap was ``raw_text[:4000]`` with no log and no signal to the model.
+For a PDF that excerpt is the *entire* content the LLM receives — PDFParser fills
+only ``raw_text``, so the structured-sections block is empty — which meant a
+dense two-page resume was converted from a mid-sentence fragment and the user
+got back a LaTeX file quietly missing its last role.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.services.document_converter_service import (
+    RAW_TEXT_CHAR_BUDGET,
+    _clip_raw_text,
+    document_converter_service,
+)
+
+
+def _line_block(n_lines: int, filler: str = "Delivered a measurable improvement to the system.") -> str:
+    return "\n".join(f"{i:04d} {filler}" for i in range(n_lines))
+
+
+def test_a_realistic_two_page_resume_is_not_truncated():
+    """The old 4000-char cap cut exactly this size of document."""
+    two_pages = _line_block(90)  # ~4.6k chars, a dense two-page resume
+    assert len(two_pages) > 4000, "fixture must exceed the OLD cap to be meaningful"
+
+    clipped, dropped = _clip_raw_text(two_pages)
+    assert dropped == 0
+    assert clipped == two_pages
+
+
+def test_content_beyond_the_budget_is_reported_not_hidden():
+    oversized = _line_block(2000)
+    assert len(oversized) > RAW_TEXT_CHAR_BUDGET
+
+    clipped, dropped = _clip_raw_text(oversized)
+    assert dropped > 0
+    assert len(clipped) <= RAW_TEXT_CHAR_BUDGET
+    # Nothing is lost silently: what is kept plus what is reported is the whole input.
+    assert len(clipped) + dropped == len(oversized)
+
+
+def test_truncation_cuts_on_a_line_boundary():
+    """A mid-word cut invites the model to complete the fragment."""
+    oversized = _line_block(2000)
+    clipped, _ = _clip_raw_text(oversized)
+    assert not clipped.endswith(" ")
+    # The final retained line is whole.
+    assert oversized.startswith(clipped)
+    remainder = oversized[len(clipped):]
+    assert remainder.startswith("\n"), "cut landed mid-line"
+
+
+def test_truncation_is_logged(caplog):
+    with caplog.at_level(logging.WARNING):
+        _clip_raw_text(_line_block(2000))
+    assert any(
+        "exceeded the conversion prompt budget" in r.getMessage()
+        for r in caplog.records
+    ), "truncation must leave a trace an operator can find"
+
+
+def test_prompt_tells_the_model_when_content_was_omitted():
+    """Otherwise a mid-resume cut reads as the end, and the model tidies it up."""
+    structure = {"raw_text": _line_block(2000), "contact": {"name": "Priya Raman"}}
+    user = document_converter_service.build_conversion_prompt(structure, "pdf")[-1]["content"]
+    assert "characters were omitted" in user
+    assert "do not" in user.lower() and "invent" in user.lower()
+
+
+def test_prompt_has_no_omission_note_for_a_normal_resume():
+    structure = {"raw_text": _line_block(90), "contact": {"name": "Priya Raman"}}
+    user = document_converter_service.build_conversion_prompt(structure, "pdf")[-1]["content"]
+    assert "characters were omitted" not in user
+
+
+def test_full_two_page_resume_reaches_the_prompt_intact():
+    """End-to-end on the prompt builder, not just the helper."""
+    body = _line_block(90)
+    structure = {"raw_text": body, "contact": {"name": "Priya Raman"}}
+    user = document_converter_service.build_conversion_prompt(structure, "pdf")[-1]["content"]
+    assert body.splitlines()[-1] in user, "last line of the resume never reached the model"

--- a/backend/test/test_pdf_layout.py
+++ b/backend/test/test_pdf_layout.py
@@ -1,0 +1,204 @@
+"""Layout-aware PDF extraction.
+
+``page.extract_text()`` flattened a resume into space-joined lines, which ran a
+job title into its right-aligned date and turned a two-column skills block into
+one sentence. It also yielded no section information at all, so
+``section_hints`` came back empty and the LLM had to infer structure from a flat
+blob.
+
+PDFs here are built by hand rather than with a PDF library, so the suite needs no
+dependency that production does not already have.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.parsers.pdf_layout import (
+    CELL_GAP_PTS,
+    _looks_like_section_heading,
+    _split_cells,
+    extract_layout_text,
+)
+
+# ── minimal PDF writer ───────────────────────────────────────────────────────
+
+
+def make_pdf(items) -> bytes:
+    """Build a one-page PDF. *items* are (x, y, size, bold, text) tuples."""
+    ops = []
+    for x, y, size, bold, text in items:
+        font = "/F2" if bold else "/F1"
+        esc = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+        ops.append(f"BT {font} {size} Tf {x} {y} Td ({esc}) Tj ET")
+    stream = "\n".join(ops).encode("latin-1")
+    objs = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font "
+        b"<< /F1 5 0 R /F2 6 0 R >> >> /Contents 4 0 R >>",
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>",
+    ]
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for i, body in enumerate(objs, start=1):
+        offsets.append(len(out))
+        out += f"{i} 0 obj\n".encode() + body + b"\nendobj\n"
+    xref = len(out)
+    out += f"xref\n0 {len(objs) + 1}\n".encode() + b"0000000000 65535 f \n"
+    for off in offsets:
+        out += f"{off:010d} 00000 n \n".encode()
+    out += (
+        f"trailer\n<< /Size {len(objs) + 1} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n"
+    ).encode()
+    return bytes(out)
+
+
+RESUME = make_pdf([
+    (250, 750, 18, True, "Priya Raman"),
+    (170, 730, 9, False, "Bangalore, India | priya@example.com | +91 98765 43210"),
+    (60, 700, 11, True, "SUMMARY"),
+    (60, 682, 10, False, "Backend engineer with six years on payment systems."),
+    (60, 655, 11, True, "EXPERIENCE"),
+    (60, 636, 10, True, "Senior Software Engineer, Razorpay"),
+    (430, 636, 10, False, "Mar 2022 - Present"),
+    (72, 620, 9.5, False, "- Led the settlement ledger migration."),
+    (60, 590, 11, True, "SKILLS"),
+    (72, 572, 9.5, False, "Languages: Go, Python"),
+    (320, 572, 9.5, False, "Practices: Event sourcing"),
+])
+
+
+# ── cell splitting ───────────────────────────────────────────────────────────
+
+
+def _w(text, x0, x1, size=10.0, font="Helvetica"):
+    return {"text": text, "x0": x0, "x1": x1, "size": size, "fontname": font}
+
+
+def test_wide_gap_splits_cells():
+    """A right-aligned date is a separate cell, not the tail of the job title."""
+    cells = _split_cells([
+        _w("Engineer", 60, 110),
+        _w("Razorpay", 112, 160),
+        _w("Mar", 430, 452),   # far right — the date column
+        _w("2022", 454, 480),
+    ])
+    assert cells == ["Engineer Razorpay", "Mar 2022"]
+
+
+def test_ordinary_word_spacing_does_not_split():
+    cells = _split_cells([_w("Backend", 60, 110), _w("engineer", 114, 165)])
+    assert cells == ["Backend engineer"]
+
+
+def test_gap_threshold_boundary():
+    """Just under the threshold stays joined; just over splits."""
+    under = _split_cells([_w("a", 60, 100), _w("b", 100 + CELL_GAP_PTS - 1, 200)])
+    over = _split_cells([_w("a", 60, 100), _w("b", 100 + CELL_GAP_PTS + 1, 200)])
+    assert len(under) == 1
+    assert len(over) == 2
+
+
+def test_words_are_ordered_by_position_not_input_order():
+    cells = _split_cells([_w("second", 430, 470), _w("first", 60, 100)])
+    assert cells == ["first", "second"]
+
+
+# ── heading detection ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("text", ["SUMMARY", "EXPERIENCE", "EDUCATION", "SKILLS", "PROJECTS"])
+def test_known_section_names_are_headings(text):
+    assert _looks_like_section_heading(text, size=11.0, bold=True, body_size=9.5)
+
+
+def test_unknown_all_caps_short_line_is_a_heading():
+    """Real resumes invent section names; all-caps and short is the convention."""
+    assert _looks_like_section_heading("CORE COMPETENCIES", 11.0, True, 9.5)
+
+
+def test_bold_job_title_is_not_a_heading():
+    """The discriminator that matters — job titles are bold and larger too."""
+    assert not _looks_like_section_heading(
+        "Senior Software Engineer, Razorpay", size=10.0, bold=True, body_size=9.5
+    )
+
+
+def test_body_text_is_not_a_heading():
+    assert not _looks_like_section_heading(
+        "Backend engineer with six years on payment systems.", 9.5, False, 9.5
+    )
+
+
+def test_a_long_prominent_line_is_not_a_heading():
+    assert not _looks_like_section_heading(
+        "ACHIEVEMENTS AND AWARDS RECEIVED THROUGHOUT MY ENTIRE CAREER", 12.0, True, 9.5
+    )
+
+
+# ── end to end ───────────────────────────────────────────────────────────────
+
+
+def test_sections_are_detected_from_a_real_pdf():
+    result = extract_layout_text(RESUME)
+    assert result is not None
+    assert result.section_hints == ["SUMMARY", "EXPERIENCE", "SKILLS"]
+
+
+def test_right_aligned_date_is_separated_from_the_job_title():
+    text = extract_layout_text(RESUME).text
+    assert "Senior Software Engineer, Razorpay | Mar 2022 - Present" in text
+    assert "Razorpay Mar 2022" not in text, "title and date ran together"
+
+
+def test_two_column_block_is_not_run_into_one_line():
+    text = extract_layout_text(RESUME).text
+    assert "Languages: Go, Python | Practices: Event sourcing" in text
+    assert "Go, Python Practices" not in text, "columns were linearised"
+
+
+def test_headings_get_a_blank_line_before_them():
+    text = extract_layout_text(RESUME).text
+    assert "\n\nSUMMARY\n" in text
+    assert "\n\nEXPERIENCE\n" in text
+
+
+def test_no_positioned_words_returns_none_so_caller_can_fall_back():
+    """A scanned page must not look like a successful empty parse."""
+    assert extract_layout_text(make_pdf([])) is None
+
+
+# ── parser integration ───────────────────────────────────────────────────────
+
+
+def test_pdf_parser_populates_section_hints():
+    from app.parsers.pdf_parser import PDFParser
+
+    parsed = asyncio.run(PDFParser().parse(RESUME, "resume.pdf"))
+    assert parsed.metadata["section_hints"] == ["SUMMARY", "EXPERIENCE", "SKILLS"]
+
+
+def test_pdf_parser_still_extracts_contact_details():
+    from app.parsers.pdf_parser import PDFParser
+
+    parsed = asyncio.run(PDFParser().parse(RESUME, "resume.pdf"))
+    assert parsed.contact.email == "priya@example.com"
+    assert parsed.contact.phone == "+91 98765 43210"
+
+
+def test_parser_falls_back_when_layout_extraction_raises(monkeypatch):
+    """Layout is an enhancement; a failure in it must not fail the upload."""
+    import app.parsers.pdf_parser as pdf_parser_mod
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("layout exploded")
+
+    monkeypatch.setattr(pdf_parser_mod, "extract_layout_text", boom)
+    parsed = asyncio.run(pdf_parser_mod.PDFParser().parse(RESUME, "resume.pdf"))
+    assert "Priya Raman" in (parsed.raw_text or "")
+    assert parsed.metadata["section_hints"] == []


### PR DESCRIPTION
Fixes #1042, #1043 and #1044 — three bugs in the resume ingestion path, all found while evaluating whether to adopt `firecrawl/pdf-inspector`.

**The evaluation's conclusion was "no", and that is the interesting part.** pdf-inspector is genuinely good — 67× faster than pdfplumber on the same file, zero dependencies, MIT, manylinux wheels. But conversion is one `gpt-4o-mini` call taking seconds, so a 26 ms parse is under 1% of the job: we are LLM-bound, not parse-bound. Its Markdown output is also *worse* for this pipeline (it inlines section headers and merges the document tail into a single paragraph), and it does no OCR, so tesseract would stay regardless.

Its most valuable feature is position-aware extraction — and **pdfplumber already returns exactly that** (`x0`, `top`, `size`, `fontname`). We simply never asked for it. So the fix was never a new dependency; it was to stop discarding what we already had.

## What was wrong

**#1042 — phone extraction was US-only.** The regex matched the NANP layout only:

| Input | Match |
|---|---|
| `+91 98765 43210` | **none** |
| `+44 20 7946 0958` | **none** |
| `+61 2 9374 4000` | **none** |
| `+65 6123 4567` | **none** |
| `(415) 555-2671` | ok |

This ran in `_extract_contact_info`, so it hit **every** format — PDF, DOCX, HTML, text. For a product billing through Razorpay it dropped the phone number from essentially every Indian resume that wrote a country code.

**#1043 — resumes were silently truncated at 4000 characters.** No log, no warning, no signal to the model. And the cap was load-bearing in a way it did not look: because PDFs produced no structured sections (#1044), that excerpt was the *entire* content the LLM received. Measured on a realistic two-page resume: **6991 chars, so 43% was dropped**, including the last two roles outright.

**#1044 — PDF parsing extracted zero structure.** On a cleanly formatted resume: `experience: 0, education: 0, skills: 0, section_hints: []`. `extract_text()` flattens the page, so a right-aligned date arrived as `"Senior Software Engineer, Razorpay Mar 2022 - Present"` with nothing marking where the title ended, and a two-column skills block read as one sentence.

## The fixes

- **Phone** → `app/utils/contact.find_phone`, built on `phonenumbers`, already in `requirements.txt` for the Feature 64 contact formatter — **no new dependency**. It scans with `PhoneNumberMatcher` rather than a looser regex, because resumes are full of digit strings: `"p95 latency 380ms to 140ms"`, `"CGPA: 9.1/10"`, `"credential id 4519827364"`, `"Bangalore 560001"` all correctly yield nothing, where a merely-permissive pattern would have matched the last two — worse than the bug being fixed. Two passes: no region first (so any `+CC` number parses correctly wherever its owner lives), then `RESUME_DEFAULT_PHONE_REGION` for bare local numbers. A bare number from a different region yields `None` rather than a wrong guess, so the setting only ever adds coverage.

- **Truncation** → budget raised to 24k chars (~6k tokens; gpt-4o-mini has a 128k context, so 4000 was orders of magnitude below the real constraint). When the budget genuinely is exceeded, the cut lands on a line boundary, the drop is logged with both counts, and the prompt carries an explicit note of how much was omitted so the model does not read a mid-resume cut as the ending and invent a tidy conclusion.

- **Structure** → new `app/parsers/pdf_layout.py` rebuilds lines from pdfplumber's positional data, splits them into cells on gaps wider than ordinary word spacing, and marks headings by font prominence. Prominence alone is not sufficient — job titles are bold too — so a heading must also be short and either a known section name or all-caps. That discriminator is pinned by tests. **The layout pass is strictly additive**: if it yields nothing (scanned page) or raises, the original flat extraction runs unchanged, so an upload can never fail because of it.

## Verification

**Full backend suite: 2607 passed, 0 failed** (main baseline on the same machine: 2566). Ruff clean. 46 new tests across the three areas. The Modal deployment-parity guard from #998 still passes.

Beyond tests, all three were driven **through real HTTP against a running server** (live Postgres + Redis, real session). The decisive evidence is the payload the *server* produced for the conversion job, pulled back out of the Celery queue in Redis after a real `POST /formats/upload`:

```
contact.phone : +91 98765 43210     <- None before
section_hints : ['SUMMARY', 'EXPERIENCE', 'EDUCATION', 'SKILLS', 'PROJECTS']   <- [] before
columns split : True                 <- "Languages: Go, Python, Java, SQL | Practices: Event sourcing, DDD"
title | date  : True                 <- "Senior Software Engineer, Razorpay | Mar 2022 - Present"
```

And on the long resume: `extracted 6991 chars / old cap would have dropped 2991 (43%) / new: dropped 0`, with the final line of the resume confirmed to reach the model — and confirmed *not* to under the old cap.

Test PDFs are built by hand in the test file rather than with a PDF library, so the suite adds no dependency production does not already have.

## Worth a reviewer's attention

- **`raw_text` changes shape for PDFs.** Cells are now joined with `" | "` and headings get a blank line before them. Nothing in the suite depended on the old shape, but anything downstream reading `raw_text` positionally would notice.
- **`RESUME_DEFAULT_PHONE_REGION` defaults to `US`**, which preserves today's behaviour. Given the user base, **`IN` is probably the right production value** — it is the only way a bare `98765 43210` (no country code) resolves. Numbers written with `+91` work regardless.
- **`CELL_GAP_PTS = 24.0`** is the one tuned constant. It is comfortably above inter-word spacing at 9–12pt body text and comfortably below a resume gutter, but an unusually tight two-column layout could fall on the wrong side of it. Boundary behaviour is tested both ways.
- I have **not** attempted to populate `experience`/`education` objects. Those remain empty and the LLM still infers them — but now from text with correct reading order and explicit section markers, rather than a flat blob. That felt like the right stopping point; full structured extraction is a much larger change with a much larger error surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
