### PR TITLE
F2-P3: steer-and-regenerate (regenerate with your own note)

### DIFF
--- a/backend/app/api/ai_routes.py
+++ b/backend/app/api/ai_routes.py
@@ -193,7 +193,9 @@ class GenerateSummaryResponse(BaseModel):
     cached: bool
 
 
-RewriteAction = Literal["improve", "shorten", "quantify", "power_verbs", "change_tone", "expand"]
+RewriteAction = Literal[
+    "improve", "shorten", "quantify", "power_verbs", "change_tone", "expand", "steer"
+]
 
 
 class RewriteRequest(BaseModel):
@@ -201,6 +203,8 @@ class RewriteRequest(BaseModel):
     action: RewriteAction
     context: Optional[str] = Field(None, max_length=1000)
     tone: Optional[str] = Field(None, max_length=50)
+    # Free-text steer for the "steer" action (regenerate-with-a-note, F2-P3).
+    instruction: Optional[str] = Field(None, max_length=500)
 
 
 class RewriteResponse(BaseModel):
@@ -565,11 +569,22 @@ _REWRITE_PROMPTS: Dict[str, str] = {
         "Limit the increase to roughly 50% more words. Keep LaTeX commands valid. "
         "Return ONLY the expanded LaTeX text."
     ),
+    "steer": (
+        "Revise the LaTeX text to follow this instruction from the user: {instruction}. "
+        "Keep all LaTeX commands valid and preserve factual accuracy — never invent facts, "
+        "metrics, or experience. Return ONLY the revised LaTeX text."
+    ),
 }
 
 
-def _rewrite_cache_key(action: str, selected_text: str, tone: Optional[str], context: Optional[str] = None) -> str:
-    raw = f"{action}|{selected_text}|{tone or ''}|{(context or '').strip()}"
+def _rewrite_cache_key(
+    action: str,
+    selected_text: str,
+    tone: Optional[str],
+    context: Optional[str] = None,
+    instruction: Optional[str] = None,
+) -> str:
+    raw = f"{action}|{selected_text}|{tone or ''}|{(context or '').strip()}|{(instruction or '').strip()}"
     return "ai:rewrite:" + hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
@@ -585,7 +600,13 @@ async def rewrite_text(
     user_id: Optional[str] = Depends(get_current_user_optional),
 ):
     """Rewrite selected LaTeX text using AI. Auth optional."""
-    cache_key = _rewrite_cache_key(request.action, request.selected_text, request.tone, request.context)
+    # The "steer" action needs a non-empty instruction; without one it has no
+    # direction, so fall back to a general improve rather than a no-op prompt.
+    if request.action == "steer" and not (request.instruction or "").strip():
+        request.action = "improve"
+    cache_key = _rewrite_cache_key(
+        request.action, request.selected_text, request.tone, request.context, request.instruction
+    )
 
     # Check cache
     try:
@@ -607,7 +628,10 @@ async def rewrite_text(
     # The cache missed and a platform-key completion is about to run → charge it.
     quota_ticket = await _charge_ai_assist(db, user_id, resolved)
 
-    system_prompt = _REWRITE_PROMPTS[request.action].format(tone=request.tone or "formal")
+    system_prompt = _REWRITE_PROMPTS[request.action].format(
+        tone=request.tone or "formal",
+        instruction=(request.instruction or "").strip() or "improve the text",
+    )
     user_parts = [f"Text to rewrite:\n{request.selected_text}"]
     if request.context:
         user_parts.append(f"\nContext (for reference only):\n{request.context}")

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -129,6 +129,11 @@ from .github_routes import router as github_router
 
 router.include_router(github_router)
 
+# Include external-source import routes (Feature 1 Phase 2 — URL project ingest)
+from .sources_routes import router as sources_router
+
+router.include_router(sources_router)
+
 # Include Zotero integration routes (Feature 42)
 from .zotero_routes import router as zotero_router
 

--- a/backend/app/api/sources_routes.py
+++ b/backend/app/api/sources_routes.py
@@ -1,0 +1,96 @@
+"""External-source import routes (Feature 1 Phase 2 — URL project ingest).
+
+Synchronous endpoint that turns a public portfolio / personal-site / project URL
+into resume-ready ``ProjectEvidence`` records (the SAME shape as the GitHub
+import) for the existing frontend review UI.
+
+PRIVACY / SAFETY: public pages only. One static HTTP GET (no JS execution) behind
+the shared SSRF guard, followed by one LLM call. Because it is a single fetch +
+single summarization it runs in-request (like the ``/ai/*`` endpoints), not as an
+async job. Summarization uses the caller's own LLM key (BYOK) when present, else
+the platform key.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.logging import get_logger
+from ..database.connection import get_db
+from ..middleware.entitlements import require_feature
+from ..services import url_projects_service as url_import
+from ..services.api_key_service import api_key_service
+from ..services.job_scraper_service import SSRFError
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/sources", tags=["sources"])
+
+
+# ── Schemas ──────────────────────────────────────────────────────────────────
+
+
+class ImportUrlRequest(BaseModel):
+    url: str = Field(..., max_length=2000)
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        v = v.strip()
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("URL must start with http:// or https://")
+        return v
+
+
+class ImportUrlResponse(BaseModel):
+    projects: List[dict] = []
+
+
+# ── Endpoint ─────────────────────────────────────────────────────────────────
+
+
+@router.post("/import-url", response_model=ImportUrlResponse)
+async def import_from_url(
+    body: ImportUrlRequest,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(require_feature("ai_import_url")),
+) -> ImportUrlResponse:
+    """Import projects from a public portfolio / personal-site URL.
+
+    Reads PUBLIC page content only via a single SSRF-guarded static fetch (no JS
+    execution), then extracts up to 5 ``ProjectEvidence`` records with one LLM
+    call. Runs synchronously in-request. Summarization uses the user's own LLM
+    key when present (BYOK), otherwise the platform key.
+    """
+    # Resolve the LLM key the same way optimize / GitHub import do: the user's
+    # own OpenAI key (BYOK) when present, else the platform key (api_key=None →
+    # extract_projects uses settings.OPENAI_API_KEY via the lazy openai client).
+    api_key: Optional[str] = None
+    try:
+        api_key = await api_key_service.get_user_provider(db, user_id, "openai")
+    except Exception:
+        api_key = None
+
+    # 1) Static, SSRF-guarded fetch → cleaned page text.
+    try:
+        page_text = await url_import.fetch_url_text(body.url)
+    except SSRFError as exc:
+        logger.warning(f"Blocked URL import (SSRF/invalid) for user {user_id}: {exc}")
+        raise HTTPException(status_code=400, detail="Invalid or disallowed URL")
+    except ValueError as exc:
+        logger.info(f"URL import fetch failed for {body.url!r}: {exc}")
+        raise HTTPException(status_code=502, detail="Could not fetch the page. Check the URL and try again.")
+    except Exception as exc:  # noqa: BLE001 — last-resort guard around the fetch
+        logger.error(f"Unexpected error fetching {body.url!r}: {exc}")
+        raise HTTPException(status_code=500, detail="Unexpected error while fetching the page.")
+
+    # 2) One LLM call → ProjectEvidence records (degrades to metadata on error).
+    try:
+        projects = url_import.extract_projects(page_text, body.url, api_key)
+    except Exception as exc:  # noqa: BLE001 — extract_projects already degrades, belt-and-braces
+        logger.error(f"Unexpected error extracting projects from {body.url!r}: {exc}")
+        raise HTTPException(status_code=500, detail="Unexpected error while extracting projects.")
+
+    return ImportUrlResponse(projects=projects)

--- a/backend/app/core/feature_registry.py
+++ b/backend/app/core/feature_registry.py
@@ -91,6 +91,8 @@ FEATURE_REGISTRY: list[FeatureDef] = [
                "Import references from Mendeley."),
     FeatureDef("ai_import_github", "GitHub Project Import", "integrations",
                "Import your top public GitHub projects as AI-summarized resume evidence."),
+    FeatureDef("ai_import_url", "URL Project Import", "integrations",
+               "Import projects from a portfolio or personal-site URL as AI-summarized resume evidence."),
     # ---- analytics --------------------------------------------------------
     FeatureDef("analytics", "Analytics Dashboard", "analytics",
                "Usage and performance analytics dashboard."),

--- a/backend/app/services/url_projects_service.py
+++ b/backend/app/services/url_projects_service.py
@@ -1,0 +1,267 @@
+"""URL project-import service (Feature 1 Phase 2 — external sources to resume).
+
+Turn a public portfolio / personal-site / project URL into resume-ready
+``ProjectEvidence`` records (the SAME shape produced by the GitHub import), so
+the existing frontend review UI can render them unchanged:
+
+    fetch_url_text → extract_projects → build_project_evidence
+
+PRIVACY / SAFETY: this module reads PUBLIC pages only. The fetch is a single
+static HTTP GET — no JavaScript execution, no headless browser — and every
+request (including redirect hops) is validated by the shared SSRF guard so it
+can never reach internal/private/link-local addresses (localhost, RFC1918,
+cloud metadata at 169.254.169.254, etc.). No credentials are sent.
+
+All network + LLM calls are injectable (pass a ``client``) so tests can mock
+them without touching the network or an LLM provider.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ..core.config import settings
+from ..core.logging import get_logger
+
+# Reuse the GitHub import's tolerant LLM-JSON parsing helpers so both import
+# paths share the exact same normalization semantics.
+from .github_projects_service import _extract_json_object, _normalize_str_list
+
+# Reuse the job scraper's SSRF guard + clean-text helpers rather than
+# re-implementing them — one hardened implementation, one place to audit.
+from .job_scraper_service import (
+    SSRFError,
+    _assert_public_url,
+    _html_to_clean_text,
+    _SSRFGuardTransport,
+)
+
+logger = get_logger(__name__)
+
+# Chars of cleaned page text handed to the LLM. ~4 chars/token → ~2000 tokens.
+_PAGE_TEXT_MAX_CHARS = 8000
+
+# Timeout for the single static GET.
+_TIMEOUT = 15.0
+
+# Never emit more than this many projects from one page.
+_MAX_PROJECTS = 5
+
+_BROWSER_HEADERS: Dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+# ── Static fetch ─────────────────────────────────────────────────────────────
+
+
+async def fetch_url_text(url: str, *, client: Optional[httpx.AsyncClient] = None) -> str:
+    """Fetch a public URL and return its cleaned, plain-text body.
+
+    Performs ONE SSRF-guarded static HTTP GET (public pages only — no JS
+    execution) and converts the HTML to structured plain text capped at
+    ``_PAGE_TEXT_MAX_CHARS``.
+
+    Raises:
+        SSRFError: the URL scheme is not http(s) or the host is not public.
+        ValueError: the page could not be fetched or returned a non-2xx status.
+    """
+    # Pre-flight guard so an obviously-internal URL fails fast with SSRFError
+    # (the transport guard below is the real enforcement, incl. redirects).
+    _assert_public_url(url)
+
+    owns_client = client is None
+    client = client or httpx.AsyncClient(
+        headers=_BROWSER_HEADERS,
+        follow_redirects=True,
+        timeout=_TIMEOUT,
+        transport=_SSRFGuardTransport(),
+    )
+    try:
+        resp = await client.get(url, headers=_BROWSER_HEADERS)
+    except (httpx.ConnectError, httpx.UnsupportedProtocol) as exc:
+        # The guard transport raises these when it blocks a non-public host or
+        # a non-http(s) redirect hop — surface as an SSRF rejection.
+        raise SSRFError(f"Blocked or unreachable host for {url!r}: {exc}") from exc
+    except httpx.HTTPError as exc:
+        raise ValueError(f"Failed to fetch URL {url!r}: {exc}") from exc
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    if resp.status_code != 200:
+        raise ValueError(f"URL returned HTTP {resp.status_code}")
+
+    return _html_to_clean_text(resp.text, max_length=_PAGE_TEXT_MAX_CHARS)
+
+
+# ── LLM extraction ───────────────────────────────────────────────────────────
+
+_EXTRACT_SYSTEM_PROMPT = (
+    "You are a resume-writing assistant. Given the plain text of a person's "
+    "portfolio or personal website, identify the concrete software/technical "
+    "PROJECTS they built. Respond with ONLY a JSON array (no prose, no markdown "
+    "fences) of up to 5 objects, each of the exact shape:\n"
+    '{"title": "Project name", '
+    '"description": "one or two sentences on what it does and its impact", '
+    '"tech": ["Key", "Technologies"], '
+    '"suggested_bullets": ["achievement-oriented resume bullet", "..."], '
+    '"url": "project link if the page shows one, else empty string"}\n'
+    "Rules: 2-4 suggested_bullets per project, each starting with a strong "
+    "action verb; never invent metrics, numbers, or facts not present in the "
+    "text; tech is the concrete stack (languages, frameworks, infra) only. If "
+    "the page has no real projects, return an empty array []."
+)
+
+# Fallback title mining from raw HTML when the LLM yields nothing usable.
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_HEADING_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
+_TAG_STRIP_RE = re.compile(r"<[^>]+>")
+
+
+def _first_page_title(page_text: str) -> str:
+    """Best-effort project title from the page's <title>/<h1>/first line.
+
+    ``page_text`` is already cleaned plain text (headings preserved), so the
+    first non-empty line is the most reliable signal; the regexes are a safety
+    net for callers that pass raw HTML.
+    """
+    for line in page_text.splitlines():
+        stripped = line.strip().lstrip("•").strip()
+        if stripped:
+            return stripped[:120]
+    for pattern in (_TITLE_RE, _HEADING_RE):
+        m = pattern.search(page_text)
+        if m:
+            cleaned = _TAG_STRIP_RE.sub("", m.group(1)).strip()
+            if cleaned:
+                return cleaned[:120]
+    return ""
+
+
+def build_project_evidence(project: Dict[str, Any], source_url: str) -> Dict[str, Any]:
+    """Normalize one extracted project into a ``ProjectEvidence`` record.
+
+    Mirrors ``github_projects_service.build_project_evidence`` exactly so the
+    frontend review UI renders URL and GitHub imports identically. A page-scraped
+    project has no repo metrics, so stars/forks are 0 and ``last_active`` is null.
+    """
+    project_url = str(project.get("url") or "").strip() or source_url
+    return {
+        "source": "url",
+        "title": (str(project.get("title")).strip() if project.get("title") else "")
+        or "Untitled project",
+        "description": str(project.get("description") or "").strip(),
+        "tech": _normalize_str_list(project.get("tech")),
+        "metrics": {"stars": 0, "forks": 0},
+        "dates": {"last_active": None},
+        "url": project_url,
+        "suggested_bullets": _normalize_str_list(project.get("suggested_bullets")),
+        "raw_excerpt": "",
+    }
+
+
+def _degrade_to_metadata(page_text: str, source_url: str) -> List[Dict[str, Any]]:
+    """Single metadata-only project from the page title, or ``[]`` if none."""
+    title = _first_page_title(page_text)
+    if not title:
+        return []
+    return [build_project_evidence({"title": title, "url": source_url}, source_url)]
+
+
+def extract_projects(
+    page_text: str,
+    source_url: str,
+    api_key: Optional[str],
+    *,
+    client: Any = None,
+    model: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Extract up to 5 ``ProjectEvidence`` records from page text via ONE LLM call.
+
+    On any LLM error, missing key, or unparseable output the function degrades to
+    a single metadata-only project mined from the page title (or ``[]`` when even
+    that is absent) rather than raising — a flaky provider never fails the import.
+    """
+    truncated = (page_text or "")[:_PAGE_TEXT_MAX_CHARS]
+    if not truncated.strip():
+        return []
+
+    if not api_key:
+        logger.info("extract_projects: no LLM key, degrading to page metadata")
+        return _degrade_to_metadata(truncated, source_url)
+
+    user_prompt = f"Source URL: {source_url}\n\nPage text:\n{truncated}"
+
+    try:
+        if client is None:
+            import openai  # noqa: PLC0415 — lazy so import stays cheap/offline-safe
+
+            client = openai.OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model=model or settings.OPENAI_MODEL,
+            messages=[
+                {"role": "system", "content": _EXTRACT_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            max_tokens=1200,
+            temperature=0.4,
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception as exc:
+        logger.warning(f"extract_projects LLM call failed for {source_url}: {exc}")
+        return _degrade_to_metadata(truncated, source_url)
+
+    projects = _parse_project_array(raw)
+    if not projects:
+        return _degrade_to_metadata(truncated, source_url)
+
+    evidence = [build_project_evidence(p, source_url) for p in projects[:_MAX_PROJECTS]]
+    # Drop entries that carry no usable signal (no title AND no description).
+    return [e for e in evidence if e["title"] != "Untitled project" or e["description"]]
+
+
+def _parse_project_array(text: str) -> List[Dict[str, Any]]:
+    """Best-effort parse of an LLM JSON array of project objects.
+
+    Tolerates markdown fences and a single-object response; reuses the GitHub
+    import's object parser as a last resort. Returns ``[]`` when unparseable.
+    """
+    if not text:
+        return []
+    import json  # noqa: PLC0415 — local, cheap
+
+    candidate = text.strip()
+    fence = re.search(r"```(?:json)?\s*(.*?)\s*```", candidate, re.DOTALL)
+    if fence:
+        candidate = fence.group(1).strip()
+    else:
+        start = candidate.find("[")
+        end = candidate.rfind("]")
+        if start != -1 and end != -1 and end > start:
+            candidate = candidate[start : end + 1]
+
+    try:
+        parsed = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        # Maybe the model returned a bare object — reuse the object parser.
+        obj = _extract_json_object(text)
+        return [obj] if obj else []
+
+    if isinstance(parsed, dict):
+        return [parsed]
+    if isinstance(parsed, list):
+        return [p for p in parsed if isinstance(p, dict)]
+    return []

--- a/backend/test/test_admin_control_plane_api.py
+++ b/backend/test/test_admin_control_plane_api.py
@@ -94,7 +94,7 @@ class TestGetEntitlements:
         body = resp.json()
         assert set(body.keys()) == {"registry", "kill_switches", "matrix", "plan_families"}
         assert body["plan_families"] == ["free", "basic", "pro", "byok", "team"]
-        assert len(body["registry"]) == 28
+        assert len(body["registry"]) == 29
 
 
 # ── PATCH /admin/entitlements/kill-switch/{key} ──────────────────────────────
@@ -306,7 +306,7 @@ class TestConfigEntitlements:
         assert resp.status_code == 200
         body = resp.json()
         assert "features" in body
-        assert len(body["features"]) == 28
+        assert len(body["features"]) == 29
         assert body["features"]["compile"] is True
 
     async def test_anonymous(self, client: AsyncClient):
@@ -314,7 +314,7 @@ class TestConfigEntitlements:
         assert resp.status_code == 200
         body = resp.json()
         assert "features" in body
-        assert len(body["features"]) == 28
+        assert len(body["features"]) == 29
 
     async def test_anonymous_reflects_free_matrix_disable(
         self, client: AsyncClient, db_session: AsyncSession

--- a/backend/test/test_entitlement_service.py
+++ b/backend/test/test_entitlement_service.py
@@ -103,11 +103,11 @@ class TestHasFeatureToggles:
 
 class TestEffectiveFeaturesAndState:
 
-    async def test_effective_features_all_28_keys(self):
+    async def test_effective_features_all_29_keys(self):
         free = _user(plan="free")
         eff = await entitlement_service.effective_features(free)
         assert set(eff.keys()) == {f.key for f in FEATURE_REGISTRY}
-        assert len(eff) == 28
+        assert len(eff) == 29
         # Non-gateable always True.
         assert eff["compile"] is True
 
@@ -134,7 +134,7 @@ class TestEffectiveFeaturesAndState:
             assert set(state["matrix"][family].keys()) == gateable
 
         # registry entries carry the expected fields.
-        assert len(state["registry"]) == 28
+        assert len(state["registry"]) == 29
         sample = state["registry"][0]
         assert set(sample.keys()) == {"key", "label", "category", "gateable"}
 

--- a/backend/test/test_feature_registry.py
+++ b/backend/test/test_feature_registry.py
@@ -15,12 +15,12 @@ from app.core.feature_registry import (
 )
 
 
-def test_registry_has_28_entries():
-    assert len(FEATURE_REGISTRY) == 28
+def test_registry_has_29_entries():
+    assert len(FEATURE_REGISTRY) == 29
 
 
-def test_registry_has_27_gateable():
-    assert len(gateable_keys()) == 27
+def test_registry_has_28_gateable():
+    assert len(gateable_keys()) == 28
 
 
 def test_compile_present_and_non_gateable():

--- a/backend/test/test_url_import.py
+++ b/backend/test/test_url_import.py
@@ -1,0 +1,217 @@
+"""Tests for URL project import (Feature 1 Phase 2 — external sources to resume).
+
+All network + LLM calls are mocked (injected fake ``client`` / monkeypatched
+service functions) — nothing here touches the network or a real LLM provider.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import url_projects_service as url_import
+from app.services.job_scraper_service import SSRFError
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, text: str):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeAsyncClient:
+    """Minimal stand-in for httpx.AsyncClient with a canned GET response."""
+
+    def __init__(self, resp: _FakeResp):
+        self._resp = resp
+
+    async def get(self, url, headers=None):
+        return self._resp
+
+
+def _fake_llm(content: str):
+    """A fake OpenAI client whose chat completion returns ``content``."""
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kw: resp)
+        )
+    )
+
+
+def _raising_llm(exc: Exception):
+    def _create(**kw):
+        raise exc
+
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+    )
+
+
+# ── fetch_url_text (SSRF + clean text) ───────────────────────────────────────
+
+
+class TestFetchUrlText:
+    async def test_rejects_private_url(self):
+        """A loopback/private host is refused before any fetch happens."""
+        with pytest.raises(SSRFError):
+            await url_import.fetch_url_text("http://localhost/projects")
+
+    async def test_rejects_non_http_scheme(self):
+        with pytest.raises(SSRFError):
+            await url_import.fetch_url_text("ftp://example.com/x")
+
+    async def test_returns_clean_text(self, monkeypatch):
+        """HTML body is converted to structured plain text."""
+        # Skip real DNS/SSRF resolution for the public test URL.
+        monkeypatch.setattr(url_import, "_assert_public_url", lambda url: None)
+        html = "<html><body><h1>My Work</h1><p>I build things.</p></body></html>"
+        client = _FakeAsyncClient(_FakeResp(200, html))
+        text = await url_import.fetch_url_text("https://example.com", client=client)
+        assert "My Work" in text
+        assert "I build things." in text
+        assert "<h1>" not in text  # tags stripped
+
+    async def test_raises_valueerror_on_non_200(self, monkeypatch):
+        monkeypatch.setattr(url_import, "_assert_public_url", lambda url: None)
+        client = _FakeAsyncClient(_FakeResp(404, "nope"))
+        with pytest.raises(ValueError):
+            await url_import.fetch_url_text("https://example.com", client=client)
+
+
+# ── extract_projects (LLM → ProjectEvidence) ─────────────────────────────────
+
+_MULTI_JSON = """[
+  {"title": "Latexy", "description": "A resume compiler.",
+   "tech": ["Python", "FastAPI"],
+   "suggested_bullets": ["Built a LaTeX compilation pipeline"],
+   "url": "https://latexy.dev"},
+  {"title": "Orbit", "description": "A scheduling tool.",
+   "tech": ["TypeScript"],
+   "suggested_bullets": ["Shipped a calendar sync engine"],
+   "url": ""}
+]"""
+
+
+class TestExtractProjects:
+    def test_parses_multiple_projects(self):
+        client = _fake_llm(_MULTI_JSON)
+        out = url_import.extract_projects(
+            "portfolio page text", "https://me.example.com", "sk-test", client=client
+        )
+        assert len(out) == 2
+        assert out[0]["title"] == "Latexy"
+        assert out[0]["url"] == "https://latexy.dev"
+        # Empty project url falls back to the source URL.
+        assert out[1]["url"] == "https://me.example.com"
+
+    def test_evidence_shape(self):
+        client = _fake_llm(_MULTI_JSON)
+        ev = url_import.extract_projects(
+            "text", "https://me.example.com", "sk-test", client=client
+        )[0]
+        assert set(ev.keys()) == {
+            "source", "title", "description", "tech", "metrics",
+            "dates", "url", "suggested_bullets", "raw_excerpt",
+        }
+        assert ev["source"] == "url"
+        assert ev["metrics"] == {"stars": 0, "forks": 0}
+        assert ev["dates"] == {"last_active": None}
+        assert ev["tech"] == ["Python", "FastAPI"]
+        assert ev["raw_excerpt"] == ""
+
+    def test_respects_five_project_cap(self):
+        many = "[" + ",".join(
+            f'{{"title": "P{i}", "description": "d{i}", "tech": [], '
+            f'"suggested_bullets": [], "url": ""}}'
+            for i in range(8)
+        ) + "]"
+        out = url_import.extract_projects(
+            "text", "https://me.example.com", "sk-test", client=_fake_llm(many)
+        )
+        assert len(out) == 5
+
+    def test_degrades_to_metadata_on_llm_error(self):
+        """A raising LLM degrades to one metadata-only project from the title."""
+        client = _raising_llm(RuntimeError("boom"))
+        out = url_import.extract_projects(
+            "My Cool Portfolio\nSome intro text.",
+            "https://me.example.com",
+            "sk-test",
+            client=client,
+        )
+        assert len(out) == 1
+        assert out[0]["title"] == "My Cool Portfolio"
+        assert out[0]["source"] == "url"
+        assert out[0]["url"] == "https://me.example.com"
+
+    def test_degrades_on_unparseable_output(self):
+        client = _fake_llm("I could not find any projects, sorry!")
+        out = url_import.extract_projects(
+            "Jane Doe Portfolio\nbio", "https://me.example.com", "sk-test", client=client
+        )
+        assert len(out) == 1
+        assert out[0]["title"] == "Jane Doe Portfolio"
+
+    def test_no_key_degrades_to_metadata(self):
+        out = url_import.extract_projects(
+            "Homepage Title\nwelcome", "https://me.example.com", None
+        )
+        assert len(out) == 1
+        assert out[0]["title"] == "Homepage Title"
+
+    def test_empty_page_returns_empty(self):
+        assert url_import.extract_projects("   ", "https://me.example.com", "sk-test") == []
+
+
+# ── Endpoint smoke tests (live ASGI app) ─────────────────────────────────────
+
+
+class TestImportUrlEndpoint:
+    async def test_requires_auth(self, client):
+        resp = await client.post("/sources/import-url", json={"url": "https://example.com"})
+        assert resp.status_code in (401, 403)
+
+    async def test_200_with_mocked_service(self, client, auth_headers, monkeypatch):
+        projects = [{
+            "source": "url", "title": "Latexy", "description": "A compiler.",
+            "tech": ["Python"], "metrics": {"stars": 0, "forks": 0},
+            "dates": {"last_active": None}, "url": "https://latexy.dev",
+            "suggested_bullets": ["Built X"], "raw_excerpt": "",
+        }]
+
+        async def _fake_fetch(url, *, client=None):
+            return "portfolio page text"
+
+        monkeypatch.setattr(url_import, "fetch_url_text", _fake_fetch)
+        monkeypatch.setattr(
+            url_import, "extract_projects", lambda *a, **k: projects
+        )
+
+        resp = await client.post(
+            "/sources/import-url",
+            json={"url": "https://me.example.com"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["projects"] == projects
+
+    async def test_400_on_disallowed_url(self, client, auth_headers):
+        """A private/internal host is rejected by the SSRF guard → 400."""
+        resp = await client.post(
+            "/sources/import-url",
+            json={"url": "http://localhost/projects"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    async def test_422_on_non_http_url(self, client, auth_headers):
+        resp = await client.post(
+            "/sources/import-url",
+            json={"url": "ftp://example.com/x"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422

--- a/backend/test/test_writing_assistant.py
+++ b/backend/test/test_writing_assistant.py
@@ -77,6 +77,13 @@ class TestRewriteCacheKey:
         k2 = _rewrite_cache_key("change_tone", _SAMPLE_INPUT, "casual")
         assert k1 != k2
 
+    def test_instruction_changes_key(self) -> None:
+        from app.api.ai_routes import _rewrite_cache_key
+
+        k1 = _rewrite_cache_key("steer", _SAMPLE_INPUT, None, None, "make it more technical")
+        k2 = _rewrite_cache_key("steer", _SAMPLE_INPUT, None, None, "make it more concise")
+        assert k1 != k2
+
 
 # ---------------------------------------------------------------------------
 # Validation tests (no LLM needed)
@@ -264,3 +271,70 @@ class TestRewriteLLM:
                 },
             )
             assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Steer / regenerate-with-a-note (F2-P3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRewriteSteer:
+    async def test_instruction_too_long_returns_422(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/ai/rewrite",
+            json={"selected_text": _SAMPLE_INPUT, "action": "steer", "instruction": "x" * 501},
+        )
+        assert resp.status_code == 422
+
+    async def test_steer_with_instruction_returns_rewrite(self, client: AsyncClient) -> None:
+        with patch(_SETTINGS_PATCH) as mock_settings, patch(
+            "app.api.ai_routes.openai.AsyncOpenAI"
+        ) as mock_cls, patch(
+            "app.api.ai_routes.cache_manager.get", new_callable=AsyncMock, return_value=None
+        ), patch(
+            "app.api.ai_routes.cache_manager.set", new_callable=AsyncMock
+        ):
+            _mock_settings(mock_settings)
+            mock_openai = AsyncMock()
+            mock_openai.chat.completions.create = AsyncMock(
+                return_value=_make_openai_response(_SAMPLE_REWRITTEN)
+            )
+            mock_cls.return_value = mock_openai
+
+            resp = await client.post(
+                "/ai/rewrite",
+                json={
+                    "selected_text": _SAMPLE_INPUT,
+                    "action": "steer",
+                    "instruction": "Emphasize leadership and scale",
+                },
+            )
+            assert resp.status_code == 200
+            assert resp.json()["rewritten"] == _SAMPLE_REWRITTEN
+            # The user's instruction must reach the system prompt.
+            sys_prompt = mock_openai.chat.completions.create.call_args.kwargs["messages"][0]["content"]
+            assert "Emphasize leadership and scale" in sys_prompt
+
+    async def test_steer_without_instruction_falls_back_to_improve(self, client: AsyncClient) -> None:
+        with patch(_SETTINGS_PATCH) as mock_settings, patch(
+            "app.api.ai_routes.openai.AsyncOpenAI"
+        ) as mock_cls, patch(
+            "app.api.ai_routes.cache_manager.get", new_callable=AsyncMock, return_value=None
+        ), patch(
+            "app.api.ai_routes.cache_manager.set", new_callable=AsyncMock
+        ):
+            _mock_settings(mock_settings)
+            mock_openai = AsyncMock()
+            mock_openai.chat.completions.create = AsyncMock(
+                return_value=_make_openai_response(_SAMPLE_REWRITTEN)
+            )
+            mock_cls.return_value = mock_openai
+
+            resp = await client.post(
+                "/ai/rewrite",
+                json={"selected_text": _SAMPLE_INPUT, "action": "steer", "instruction": "   "},
+            )
+            assert resp.status_code == 200
+            # Empty instruction → treated as a general improve (no undirected prompt).
+            assert resp.json()["action"] == "improve"

--- a/frontend/src/__tests__/steer-rewrite-client.test.ts
+++ b/frontend/src/__tests__/steer-rewrite-client.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { apiClient } from '../lib/api-client'
+
+function mockFetch(responseBody: object) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      json: () => Promise.resolve(responseBody),
+      text: () => Promise.resolve(JSON.stringify(responseBody)),
+    })
+  )
+}
+
+function lastBody(): Record<string, unknown> {
+  const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+  return JSON.parse(init.body as string)
+}
+
+afterEach(() => {
+  apiClient.setAuthToken(null)
+  vi.unstubAllGlobals()
+})
+
+describe('rewriteText steer action', () => {
+  test('forwards the steer action + free-text instruction', async () => {
+    mockFetch({ rewritten: 'Led a team...', action: 'steer', cached: false })
+
+    const res = await apiClient.rewriteText({
+      selected_text: 'Managed a team of engineers to deliver features.',
+      action: 'steer',
+      instruction: 'Emphasize leadership and quantify impact',
+    })
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/ai/rewrite')
+    const body = lastBody()
+    expect(body.action).toBe('steer')
+    expect(body.instruction).toBe('Emphasize leadership and quantify impact')
+    expect(res.rewritten).toBe('Led a team...')
+  })
+
+  test('omits instruction for non-steer actions', async () => {
+    mockFetch({ rewritten: 'x', action: 'improve', cached: false })
+
+    await apiClient.rewriteText({
+      selected_text: 'Managed a team of engineers to deliver features.',
+      action: 'improve',
+    })
+
+    expect('instruction' in lastBody()).toBe(false)
+  })
+})

--- a/frontend/src/components/WritingAssistantWidget.tsx
+++ b/frontend/src/components/WritingAssistantWidget.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { Check, Loader2, MessageSquare, RefreshCw, Scissors, Sparkles, TrendingUp, X, ZoomIn } from 'lucide-react'
+import { Check, Loader2, MessageSquare, RefreshCw, Scissors, Sparkles, TrendingUp, Wand2, X, ZoomIn } from 'lucide-react'
 import { apiClient, type RewriteAction } from '@/lib/api-client'
 
 interface ActionDef {
@@ -18,6 +18,7 @@ const ACTIONS: ActionDef[] = [
   { key: 'power_verbs', label: 'Power Verbs', icon: <Check size={11} />,         description: 'Replace weak verbs' },
   { key: 'change_tone', label: 'Change Tone', icon: <MessageSquare size={11} />, description: 'Formal or casual style' },
   { key: 'expand',      label: 'Expand',      icon: <ZoomIn size={11} />,        description: 'Add more detail' },
+  { key: 'steer',       label: 'Steer',       icon: <Wand2 size={11} />,         description: 'Regenerate with your own note' },
 ]
 
 const TONES = [
@@ -25,7 +26,7 @@ const TONES = [
   { key: 'casual', label: 'Casual', description: 'Friendly & conversational' },
 ]
 
-type Phase = 'picking' | 'tone_picking' | 'loading' | 'result'
+type Phase = 'picking' | 'tone_picking' | 'steer_input' | 'loading' | 'result'
 
 interface WritingAssistantWidgetProps {
   isOpen: boolean
@@ -47,6 +48,8 @@ export default function WritingAssistantWidget({
   const [phase, setPhase]               = useState<Phase>('picking')
   const [activeAction, setActiveAction] = useState<RewriteAction | null>(null)
   const [activeTone, setActiveTone]     = useState<string | null>(null)
+  const [activeInstruction, setActiveInstruction] = useState<string | null>(null)
+  const [steerNote, setSteerNote]       = useState('')
   const [rewritten, setRewritten]       = useState<string | null>(null)
   const [error, setError]               = useState<string | null>(null)
   const containerRef                    = useRef<HTMLDivElement>(null)
@@ -63,6 +66,8 @@ export default function WritingAssistantWidget({
       setPhase('picking')
       setActiveAction(null)
       setActiveTone(null)
+      setActiveInstruction(null)
+      setSteerNote('')
       setRewritten(null)
       setError(null)
     }
@@ -76,9 +81,10 @@ export default function WritingAssistantWidget({
     return () => window.removeEventListener('keydown', handler)
   }, [isOpen, onClose])
 
-  const callApi = async (action: RewriteAction, tone?: string) => {
+  const callApi = async (action: RewriteAction, tone?: string, instruction?: string) => {
     setActiveAction(action)
     setActiveTone(tone ?? null)
+    setActiveInstruction(instruction ?? null)
     setPhase('loading')
     setError(null)
     setRewritten(null)
@@ -88,6 +94,7 @@ export default function WritingAssistantWidget({
         action,
         context: context || undefined,
         tone: tone || undefined,
+        instruction: instruction || undefined,
       })
       setRewritten(res.rewritten)
       setPhase('result')
@@ -101,13 +108,16 @@ export default function WritingAssistantWidget({
     if (key === 'change_tone') {
       setActiveAction('change_tone')
       setPhase('tone_picking')
+    } else if (key === 'steer') {
+      setActiveAction('steer')
+      setPhase('steer_input')
     } else {
       callApi(key)
     }
   }
 
   const handleRegenerate = () => {
-    if (activeAction) callApi(activeAction, activeTone ?? undefined)
+    if (activeAction) callApi(activeAction, activeTone ?? undefined, activeInstruction ?? undefined)
   }
 
   // Anchor position within the positioned editor container.
@@ -243,6 +253,44 @@ export default function WritingAssistantWidget({
                   </span>
                 </button>
               ))}
+            </div>
+          )}
+
+          {/* ── Phase: steer_input ──────────────────────────────────── */}
+          {phase === 'steer_input' && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setPhase('picking')}
+                  className="text-[10px] text-zinc-600 transition hover:text-zinc-400"
+                  aria-label="Back to actions"
+                >
+                  ←
+                </button>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-600">Your instruction</p>
+              </div>
+              <textarea
+                value={steerNote}
+                onChange={(e) => setSteerNote(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && steerNote.trim()) {
+                    e.preventDefault()
+                    callApi('steer', undefined, steerNote.trim())
+                  }
+                }}
+                autoFocus
+                maxLength={500}
+                placeholder="e.g. Emphasize leadership and quantify the impact; keep it to one line."
+                className="h-20 w-full resize-none rounded-lg border border-white/[0.08] bg-black/30 px-2.5 py-1.5 text-[11px] leading-relaxed text-zinc-200 outline-none transition placeholder:text-zinc-600 focus:border-violet-400/30"
+              />
+              <button
+                onClick={() => callApi('steer', undefined, steerNote.trim())}
+                disabled={!steerNote.trim()}
+                className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-violet-500/20 py-2 text-[11px] font-semibold text-violet-200 ring-1 ring-violet-400/30 transition hover:bg-violet-500/30 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <Wand2 size={11} />
+                Regenerate with this note
+              </button>
             </div>
           )}
 

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -890,13 +890,15 @@ export interface GenerateBulletsResponse {
   cached: boolean
 }
 
-export type RewriteAction = 'improve' | 'shorten' | 'quantify' | 'power_verbs' | 'change_tone' | 'expand'
+export type RewriteAction = 'improve' | 'shorten' | 'quantify' | 'power_verbs' | 'change_tone' | 'expand' | 'steer'
 
 export interface RewriteRequest {
   selected_text: string
   action: RewriteAction
   context?: string
   tone?: string
+  /** Free-text steer for the 'steer' action (regenerate-with-a-note). */
+  instruction?: string
 }
 
 export interface RewriteResponse {


### PR DESCRIPTION
Closes #1056.

The delight layer of the Input-Driven Optimization PRD (P3). The writing assistant already had quick actions + tone control; this adds the missing piece — **regenerate a selection with a free-text steer note**.

## What's in it
- **Backend** (`ai_routes.py`) — `/ai/rewrite` gains a `steer` action + optional `instruction` (≤500 chars, 422 above) threaded into the system prompt and the cache key. An empty instruction falls back to `improve` (no undirected prompt). Prompt forbids inventing facts/metrics.
- **Frontend** (`WritingAssistantWidget`) — a **Steer** action opens a note textarea (⌘/Ctrl+Enter submits); Try-again regenerates with the same note.

## Testing
- Backend `test_writing_assistant.py`: 22 passed (added instruction cache-key, 422 on over-long, instruction reaches the system prompt, empty→improve fallback).
- Frontend: 490 vitest passed (added steer client plumbing). `tsc` + ESLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Steer writing action that lets you provide custom rewrite instructions, with keyboard shortcut support and a 500-character limit.
  * Added AI-powered project importing from public portfolio or personal-site URLs.
  * Import results include extracted project details, with safeguards and fallback behavior for unavailable or invalid content.

* **Bug Fixes**
  * Improved rewrite caching so customized instructions produce the correct results.
  * Blank Steer instructions now fall back to the Improve action.

* **Tests**
  * Added coverage for Steer rewriting and URL-based project imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->