### PR TITLE
F1 Phase 2+3: URL + LinkedIn (compliant) source import backend

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -207,6 +207,11 @@ from .optimize_routes import router as optimize_review_router
 
 router.include_router(optimize_review_router)
 
+# Include external-source import routes (Feature 1 Phase 3 — LinkedIn/resume)
+from .sources_routes import router as sources_router
+
+router.include_router(sources_router)
+
 
 def _check_cors_origins_on_startup() -> None:
     """CONFIG-002: Warn if CORS origins include localhost in a production-like environment."""

--- a/backend/app/api/sources_routes.py
+++ b/backend/app/api/sources_routes.py
@@ -1,0 +1,188 @@
+"""External-source import routes (Feature 1 — external sources to resume).
+
+Turns external sources into resume-ready ``ProjectEvidence`` records (the SAME
+shape as the GitHub import) for the existing frontend review UI:
+
+  * POST /sources/import-url      — Phase 2: a public portfolio / personal-site
+    URL. One SSRF-guarded static fetch (no JS execution) + one LLM call, all
+    in-request (like the ``/ai/*`` endpoints). Public pages only.
+  * POST /sources/import-linkedin — Phase 3: a user-uploaded LinkedIn data-export
+    ZIP or resume file. Parsed locally on the uploaded bytes.
+
+COMPLIANCE CONSTRAINT (LinkedIn): the LinkedIn import NEVER scrapes LinkedIn,
+NEVER calls any LinkedIn URL/API, and NEVER buys LinkedIn data. It parses ONLY a
+file the USER uploads themselves — their official LinkedIn **data export** ZIP
+(from LinkedIn → Settings → "Get a copy of your data") OR their own resume file
+(PDF/DOCX). See ``linkedin_import_service`` for the constraint in full.
+
+LLM summarization (URL path) uses the caller's own key (BYOK) when present, else
+the platform key.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.logging import get_logger
+from ..database.connection import get_db
+from ..middleware.entitlements import require_feature
+from ..services import linkedin_import_service
+from ..services import url_projects_service as url_import
+from ..services.api_key_service import api_key_service
+from ..services.job_scraper_service import SSRFError
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/sources", tags=["sources"])
+
+
+# ── URL import (Phase 2) ─────────────────────────────────────────────────────
+
+
+class ImportUrlRequest(BaseModel):
+    url: str = Field(..., max_length=2000)
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        v = v.strip()
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("URL must start with http:// or https://")
+        return v
+
+
+class ImportUrlResponse(BaseModel):
+    projects: List[dict] = []
+
+
+@router.post("/import-url", response_model=ImportUrlResponse)
+async def import_from_url(
+    body: ImportUrlRequest,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(require_feature("ai_import_url")),
+) -> ImportUrlResponse:
+    """Import projects from a public portfolio / personal-site URL.
+
+    Reads PUBLIC page content only via a single SSRF-guarded static fetch (no JS
+    execution), then extracts up to 5 ``ProjectEvidence`` records with one LLM
+    call. Runs synchronously in-request. Summarization uses the user's own LLM
+    key when present (BYOK), otherwise the platform key.
+    """
+    # Resolve the LLM key the same way optimize / GitHub import do: the user's
+    # own OpenAI key (BYOK) when present, else the platform key (api_key=None →
+    # extract_projects uses settings.OPENAI_API_KEY via the lazy openai client).
+    api_key: Optional[str] = None
+    try:
+        api_key = await api_key_service.get_user_provider(db, user_id, "openai")
+    except Exception:
+        api_key = None
+
+    # 1) Static, SSRF-guarded fetch → cleaned page text.
+    try:
+        page_text = await url_import.fetch_url_text(body.url)
+    except SSRFError as exc:
+        logger.warning(f"Blocked URL import (SSRF/invalid) for user {user_id}: {exc}")
+        raise HTTPException(status_code=400, detail="Invalid or disallowed URL")
+    except ValueError as exc:
+        logger.info(f"URL import fetch failed for {body.url!r}: {exc}")
+        raise HTTPException(status_code=502, detail="Could not fetch the page. Check the URL and try again.")
+    except Exception as exc:  # noqa: BLE001 — last-resort guard around the fetch
+        logger.error(f"Unexpected error fetching {body.url!r}: {exc}")
+        raise HTTPException(status_code=500, detail="Unexpected error while fetching the page.")
+
+    # 2) One LLM call → ProjectEvidence records (degrades to metadata on error).
+    try:
+        projects = url_import.extract_projects(page_text, body.url, api_key)
+    except Exception as exc:  # noqa: BLE001 — extract_projects already degrades, belt-and-braces
+        logger.error(f"Unexpected error extracting projects from {body.url!r}: {exc}")
+        raise HTTPException(status_code=500, detail="Unexpected error while extracting projects.")
+
+    return ImportUrlResponse(projects=projects)
+
+
+# ── LinkedIn / resume-file import (Phase 3) ──────────────────────────────────
+
+# Reject uploads larger than this before reading them into memory (defence in
+# depth on top of the service's own zip-bomb caps). LinkedIn exports and resumes
+# are comfortably under this.
+_MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
+
+_ZIP_CONTENT_TYPES = {
+    "application/zip",
+    "application/x-zip-compressed",
+    "application/x-zip",
+    "multipart/x-zip",
+}
+
+
+class LinkedInImportResponse(BaseModel):
+    """Candidate ProjectEvidence records parsed from the uploaded file."""
+
+    projects: List[dict] = []
+
+
+def _looks_like_zip(filename: str, content_type: str, head: bytes) -> bool:
+    """Best-effort ZIP sniff by extension, content-type, or magic bytes."""
+    if filename.lower().endswith(".zip"):
+        return True
+    if (content_type or "").lower().split(";")[0].strip() in _ZIP_CONTENT_TYPES:
+        return True
+    # ZIP local-file-header magic ("PK\x03\x04"). A DOCX is also a ZIP, but DOCX
+    # is routed to the resume parser by its .docx extension check above, so this
+    # only fires for genuine LinkedIn export archives.
+    return head[:4] == b"PK\x03\x04" and not filename.lower().endswith(
+        (".docx", ".doc")
+    )
+
+
+@router.post("/import-linkedin", response_model=LinkedInImportResponse)
+async def import_linkedin(
+    file: UploadFile = File(...),
+    user_id: str = Depends(require_feature("ai_import_linkedin")),
+) -> LinkedInImportResponse:
+    """Import ProjectEvidence from a user-uploaded LinkedIn export ZIP or resume.
+
+    COMPLIANCE: the ONLY input is the file the user uploads themselves — their
+    own LinkedIn data export (``.zip``) or their own resume (``.pdf``/``.docx``).
+    Nothing in this handler contacts LinkedIn.
+
+    - ``.zip`` (LinkedIn export)  → ``parse_linkedin_export``
+    - anything else (resume file) → ``parse_resume_file``
+
+    Returns ``{projects: [ProjectEvidence]}``. A bad/unparseable file yields 422;
+    an oversized upload yields 413.
+    """
+    del user_id  # gating only; the parse is stateless
+
+    filename = file.filename or "upload"
+    content_type = file.content_type or ""
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=422, detail="Uploaded file is empty.")
+    if len(content) > _MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large. Maximum size: {_MAX_UPLOAD_BYTES} bytes.",
+        )
+
+    try:
+        if _looks_like_zip(filename, content_type, content):
+            projects = linkedin_import_service.parse_linkedin_export(content)
+        else:
+            projects = await linkedin_import_service.parse_resume_file(content, filename)
+    except ValueError as exc:
+        # Malformed ZIP / unsupported or unparseable resume → client error.
+        raise HTTPException(status_code=422, detail=str(exc))
+    except Exception as exc:  # unexpected → 500, but never leak internals
+        logger.error("sources/import-linkedin failed for %s: %s", filename, exc)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to import from the uploaded file. Please try again.",
+        )
+
+    return LinkedInImportResponse(projects=projects)

--- a/backend/app/core/feature_registry.py
+++ b/backend/app/core/feature_registry.py
@@ -91,6 +91,10 @@ FEATURE_REGISTRY: list[FeatureDef] = [
                "Import references from Mendeley."),
     FeatureDef("ai_import_github", "GitHub Project Import", "integrations",
                "Import your top public GitHub projects as AI-summarized resume evidence."),
+    FeatureDef("ai_import_url", "URL Project Import", "integrations",
+               "Import projects from a portfolio or personal-site URL as AI-summarized resume evidence."),
+    FeatureDef("ai_import_linkedin", "LinkedIn Export Import", "integrations",
+               "Import projects and experience from a user-uploaded LinkedIn data export or resume file."),
     # ---- analytics --------------------------------------------------------
     FeatureDef("analytics", "Analytics Dashboard", "analytics",
                "Usage and performance analytics dashboard."),

--- a/backend/app/services/linkedin_import_service.py
+++ b/backend/app/services/linkedin_import_service.py
@@ -1,0 +1,397 @@
+"""LinkedIn COMPLIANT import service (Feature 1 Phase 3 — external sources to resume).
+
+COMPLIANCE CONSTRAINT (read before touching this module):
+    This module NEVER scrapes LinkedIn, NEVER calls any LinkedIn URL or API, and
+    NEVER buys or fetches LinkedIn data. The ONLY supported input is a file the
+    USER uploads themselves — either
+
+      1. their official LinkedIn **data export** (a ZIP of CSV files the user
+         downloads from LinkedIn → Settings → "Get a copy of your data"), or
+      2. their own resume file (PDF/DOCX).
+
+    Every function here operates purely on in-memory ``bytes`` the caller already
+    holds. There is ZERO outbound network to LinkedIn (or anywhere else) in this
+    module, by design and by construction. Do not add one.
+
+The parsed output matches the shared ``ProjectEvidence`` dict shape used by the
+GitHub importer (``github_projects_service.build_project_evidence``) so the same
+frontend review UI renders LinkedIn-sourced evidence (``source="linkedin"``):
+
+    {source, title, description, tech[], metrics{}, dates{last_active},
+     url, suggested_bullets[], raw_excerpt}
+
+All ZIP handling is defensive against malformed archives and zip bombs: entry
+count, per-member uncompressed size, and total uncompressed bytes read are all
+capped; non-CSV members are ignored.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+import zipfile
+from typing import Any, Dict, List, Optional
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ── Defensive caps (zip-bomb / DoS guards) ────────────────────────────────────
+
+# Never inspect more than this many members in an uploaded ZIP.
+_MAX_ZIP_ENTRIES = 200
+# Skip any single member whose DECLARED uncompressed size exceeds this, and stop
+# reading a member once this many bytes have actually been read.
+_MAX_MEMBER_BYTES = 5 * 1024 * 1024  # 5 MB
+# Hard ceiling on TOTAL uncompressed bytes read across all members. Guards against
+# a zip bomb of many individually-small-but-collectively-huge members.
+_MAX_TOTAL_UNCOMPRESSED = 20 * 1024 * 1024  # 20 MB
+# Cap rows parsed per CSV so a giant CSV cannot exhaust memory/CPU.
+_MAX_ROWS_PER_CSV = 1000
+# Truncate any single field to this many characters.
+_MAX_FIELD_CHARS = 20_000
+# Cap the number of evidence records returned regardless of source.
+_MAX_EVIDENCE = 100
+# Cap suggested bullets per evidence record.
+_MAX_BULLETS = 8
+
+# CSV files we care about (matched case-insensitively against the member name).
+_PROJECTS_CSV = "projects.csv"
+_POSITIONS_CSV = "positions.csv"
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+# ── Small helpers ─────────────────────────────────────────────────────────────
+
+
+def _clip(value: Any) -> str:
+    """Coerce a CSV value to a stripped, length-capped string."""
+    if value is None:
+        return ""
+    return str(value).strip()[:_MAX_FIELD_CHARS]
+
+
+def _lc_row(row: Dict[str, Any]) -> Dict[str, str]:
+    """Return a row keyed by lower-cased/stripped header → clipped string value."""
+    out: Dict[str, str] = {}
+    for key, val in row.items():
+        if key is None:
+            continue
+        out[str(key).strip().lower()] = _clip(val)
+    return out
+
+
+def _get(row_lc: Dict[str, str], *names: str) -> str:
+    """First non-empty value among the given (case-insensitive) column names."""
+    for name in names:
+        val = row_lc.get(name.lower())
+        if val:
+            return val
+    return ""
+
+
+def _split_bullets(description: str) -> List[str]:
+    """Turn a free-text description into sentence-ish resume bullets.
+
+    Splits on newlines first (LinkedIn descriptions are often newline-delimited),
+    then on sentence boundaries. Falls back to the whole description as a single
+    bullet. Never invents content — this is pure segmentation.
+    """
+    description = (description or "").strip()
+    if not description:
+        return []
+
+    # Prefer explicit line breaks / bullet glyphs the user already authored.
+    lines = [
+        re.sub(r"^[\-•\*▪●\s]+", "", ln).strip()
+        for ln in re.split(r"[\r\n]+", description)
+    ]
+    lines = [ln for ln in lines if ln]
+
+    if len(lines) > 1:
+        bullets = lines
+    else:
+        # Single blob — split into sentences.
+        single = lines[0] if lines else description
+        sentences = [s.strip() for s in _SENTENCE_SPLIT_RE.split(single) if s.strip()]
+        bullets = sentences or [single]
+
+    return bullets[:_MAX_BULLETS]
+
+
+def _build_evidence(
+    *,
+    title: str,
+    description: str,
+    suggested_bullets: List[str],
+    tech: Optional[List[str]] = None,
+    url: Optional[str] = None,
+    last_active: Optional[str] = None,
+    raw_excerpt: str = "",
+) -> Dict[str, Any]:
+    """Assemble a ``ProjectEvidence`` dict for a LinkedIn-sourced record.
+
+    Mirrors ``github_projects_service.build_project_evidence`` exactly, with
+    ``source="linkedin"``. LinkedIn has no stars/forks, so ``metrics`` is an
+    empty dict (the same key the GitHub path fills).
+    """
+    return {
+        "source": "linkedin",
+        "title": (title or "").strip(),
+        "description": (description or "").strip(),
+        "tech": tech or [],
+        "metrics": {},
+        "dates": {"last_active": last_active or None},
+        "url": (url or None),
+        "suggested_bullets": suggested_bullets or [],
+        "raw_excerpt": (raw_excerpt or "")[:2000],
+    }
+
+
+# ── LinkedIn data-export (ZIP of CSVs) parsing ────────────────────────────────
+
+
+def _row_to_project_evidence(row_lc: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    """Map one ``Projects.csv`` row → ProjectEvidence (None if unusable)."""
+    title = _get(row_lc, "title", "name", "project name")
+    description = _get(row_lc, "description", "summary")
+    if not title and not description:
+        return None
+    url = _get(row_lc, "url", "link")
+    started = _get(row_lc, "started on", "start date", "started")
+    finished = _get(row_lc, "finished on", "end date", "finished")
+    return _build_evidence(
+        title=title or "Project",
+        description=description,
+        suggested_bullets=_split_bullets(description) if description else [],
+        tech=[],
+        url=url,
+        last_active=finished or started,
+        raw_excerpt=description,
+    )
+
+
+def _row_to_position_evidence(row_lc: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    """Map one ``Positions.csv`` row → ProjectEvidence (None if unusable)."""
+    role = _get(row_lc, "title", "position", "role")
+    company = _get(row_lc, "company name", "company", "organization")
+    description = _get(row_lc, "description", "summary")
+    if not role and not company and not description:
+        return None
+    if role and company:
+        title = f"{role} at {company}"
+    else:
+        title = role or company or "Experience"
+    started = _get(row_lc, "started on", "start date", "started")
+    finished = _get(row_lc, "finished on", "end date", "finished")
+    return _build_evidence(
+        title=title,
+        description=description,
+        suggested_bullets=_split_bullets(description) if description else [],
+        tech=[],
+        url=None,
+        last_active=finished or started,
+        raw_excerpt=description,
+    )
+
+
+def _read_member_text(zf: zipfile.ZipFile, info: zipfile.ZipInfo) -> Optional[str]:
+    """Safely read+decode a single ZIP member, honoring the size caps.
+
+    Returns None if the member is too large or cannot be decoded. The read is
+    bounded to ``_MAX_MEMBER_BYTES`` regardless of the declared size (a lying
+    header cannot make us read more).
+    """
+    # Refuse members whose declared uncompressed size already blows the cap.
+    if info.file_size and info.file_size > _MAX_MEMBER_BYTES:
+        logger.warning(
+            "linkedin_import: skipping oversized member %s (%d bytes declared)",
+            info.filename,
+            info.file_size,
+        )
+        return None
+    try:
+        with zf.open(info, "r") as fh:
+            raw = fh.read(_MAX_MEMBER_BYTES + 1)
+    except (zipfile.BadZipFile, OSError, RuntimeError) as exc:
+        logger.warning("linkedin_import: failed reading %s: %s", info.filename, exc)
+        return None
+    if len(raw) > _MAX_MEMBER_BYTES:
+        logger.warning("linkedin_import: member %s exceeded read cap", info.filename)
+        return None
+    # utf-8-sig strips a BOM if present; replace undecodable bytes rather than fail.
+    return raw.decode("utf-8-sig", errors="replace")
+
+
+def _parse_csv_rows(text: str) -> List[Dict[str, str]]:
+    """Parse CSV text into a list of lower-cased-key rows, capped in count."""
+    rows: List[Dict[str, str]] = []
+    reader = csv.DictReader(io.StringIO(text))
+    for i, raw_row in enumerate(reader):
+        if i >= _MAX_ROWS_PER_CSV:
+            logger.warning("linkedin_import: row cap reached, truncating CSV")
+            break
+        rows.append(_lc_row(raw_row))
+    return rows
+
+
+def parse_linkedin_export(zip_bytes: bytes) -> List[Dict[str, Any]]:
+    """Parse a user-uploaded LinkedIn data-export ZIP into ProjectEvidence dicts.
+
+    COMPLIANCE: ``zip_bytes`` must be the user's OWN LinkedIn export (downloaded
+    by them from LinkedIn's data-export tool). Nothing here contacts LinkedIn.
+
+    Finds ``Projects.csv`` and ``Positions.csv`` case-insensitively anywhere in
+    the archive, parses them defensively, and maps each row to a ProjectEvidence
+    record (``source="linkedin"``). Missing files and malformed rows are
+    tolerated — the function returns whatever it could extract (possibly empty),
+    and only raises ``ValueError`` when the bytes are not a valid ZIP at all.
+    """
+    if not zip_bytes:
+        raise ValueError("Empty upload: no LinkedIn export data provided.")
+
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        raise ValueError("Uploaded file is not a valid ZIP archive.") from exc
+
+    evidence: List[Dict[str, Any]] = []
+    total_read = 0
+
+    try:
+        infos = zf.infolist()[:_MAX_ZIP_ENTRIES]
+        for info in infos:
+            if len(evidence) >= _MAX_EVIDENCE:
+                break
+            if info.is_dir():
+                continue
+            base = info.filename.rsplit("/", 1)[-1].lower()
+            if base not in (_PROJECTS_CSV, _POSITIONS_CSV):
+                continue  # ignore non-CSV / irrelevant members
+            if total_read >= _MAX_TOTAL_UNCOMPRESSED:
+                logger.warning("linkedin_import: total uncompressed cap reached")
+                break
+
+            text = _read_member_text(zf, info)
+            if text is None:
+                continue
+            total_read += len(text)
+
+            try:
+                rows = _parse_csv_rows(text)
+            except (csv.Error, ValueError) as exc:
+                logger.warning("linkedin_import: CSV parse error in %s: %s", base, exc)
+                continue
+
+            mapper = (
+                _row_to_project_evidence
+                if base == _PROJECTS_CSV
+                else _row_to_position_evidence
+            )
+            for row in rows:
+                if len(evidence) >= _MAX_EVIDENCE:
+                    break
+                try:
+                    record = mapper(row)
+                except Exception as exc:  # one bad row never fails the whole import
+                    logger.warning("linkedin_import: bad row skipped: %s", exc)
+                    continue
+                if record:
+                    evidence.append(record)
+    finally:
+        zf.close()
+
+    return evidence
+
+
+# ── Resume-file (PDF/DOCX) parsing ────────────────────────────────────────────
+
+
+def _parsed_resume_to_evidence(parsed: Any) -> List[Dict[str, Any]]:
+    """Map a ``ParsedResume`` (experience + projects) → ProjectEvidence dicts."""
+    evidence: List[Dict[str, Any]] = []
+
+    for proj in getattr(parsed, "projects", None) or []:
+        if len(evidence) >= _MAX_EVIDENCE:
+            break
+        description = (getattr(proj, "description", "") or "").strip()
+        name = (getattr(proj, "name", "") or "").strip()
+        if not name and not description:
+            continue
+        end = getattr(proj, "end_date", None)
+        start = getattr(proj, "start_date", None)
+        evidence.append(
+            _build_evidence(
+                title=name or "Project",
+                description=description,
+                suggested_bullets=_split_bullets(description) if description else [],
+                tech=list(getattr(proj, "technologies", None) or []),
+                url=getattr(proj, "url", None),
+                last_active=end or start,
+                raw_excerpt=description,
+            )
+        )
+
+    for exp in getattr(parsed, "experience", None) or []:
+        if len(evidence) >= _MAX_EVIDENCE:
+            break
+        role = (getattr(exp, "title", "") or "").strip()
+        company = (getattr(exp, "company", "") or "").strip()
+        desc_lines = [
+            str(d).strip() for d in (getattr(exp, "description", None) or []) if str(d).strip()
+        ]
+        if not role and not company and not desc_lines:
+            continue
+        if role and company:
+            title = f"{role} at {company}"
+        else:
+            title = role or company or "Experience"
+        description = " ".join(desc_lines)
+        end = getattr(exp, "end_date", None)
+        start = getattr(exp, "start_date", None)
+        evidence.append(
+            _build_evidence(
+                title=title,
+                description=description,
+                suggested_bullets=desc_lines[:_MAX_BULLETS],
+                tech=list(getattr(exp, "technologies", None) or []),
+                url=None,
+                last_active=end or start,
+                raw_excerpt=description,
+            )
+        )
+
+    return evidence[:_MAX_EVIDENCE]
+
+
+async def parse_resume_file(file_bytes: bytes, filename: str) -> List[Dict[str, Any]]:
+    """Parse a user-uploaded resume file (PDF/DOCX/...) into ProjectEvidence dicts.
+
+    COMPLIANCE: this operates ONLY on the bytes the user uploaded — their own
+    resume. No network, no LinkedIn. Uses the existing ``ParserFactory`` to turn
+    the file into a ``ParsedResume``, then best-effort maps its experience and
+    project sections to ProjectEvidence records (``source="linkedin"`` because
+    the entry point is the LinkedIn-import flow).
+
+    Raises ``ValueError`` if the file format is unsupported or unparseable.
+    """
+    if not file_bytes:
+        raise ValueError("Empty upload: no resume file provided.")
+
+    # Local import keeps module import cheap and avoids a heavy parser import at
+    # startup for callers that only use the ZIP path.
+    from ..parsers.parser_factory import parser_factory  # noqa: PLC0415
+
+    parser = parser_factory.get_parser_for_file(filename, content=file_bytes)
+    if parser is None:
+        raise ValueError(f"Unsupported resume file format: {filename!r}")
+
+    try:
+        parsed = await parser.parse(file_bytes, filename)
+    except Exception as exc:  # normalize parser failures to a 4xx-friendly error
+        logger.warning("linkedin_import: resume parse failed for %s: %s", filename, exc)
+        raise ValueError(f"Could not parse resume file: {exc}") from exc
+
+    return _parsed_resume_to_evidence(parsed)

--- a/backend/app/services/url_projects_service.py
+++ b/backend/app/services/url_projects_service.py
@@ -1,0 +1,267 @@
+"""URL project-import service (Feature 1 Phase 2 — external sources to resume).
+
+Turn a public portfolio / personal-site / project URL into resume-ready
+``ProjectEvidence`` records (the SAME shape produced by the GitHub import), so
+the existing frontend review UI can render them unchanged:
+
+    fetch_url_text → extract_projects → build_project_evidence
+
+PRIVACY / SAFETY: this module reads PUBLIC pages only. The fetch is a single
+static HTTP GET — no JavaScript execution, no headless browser — and every
+request (including redirect hops) is validated by the shared SSRF guard so it
+can never reach internal/private/link-local addresses (localhost, RFC1918,
+cloud metadata at 169.254.169.254, etc.). No credentials are sent.
+
+All network + LLM calls are injectable (pass a ``client``) so tests can mock
+them without touching the network or an LLM provider.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ..core.config import settings
+from ..core.logging import get_logger
+
+# Reuse the GitHub import's tolerant LLM-JSON parsing helpers so both import
+# paths share the exact same normalization semantics.
+from .github_projects_service import _extract_json_object, _normalize_str_list
+
+# Reuse the job scraper's SSRF guard + clean-text helpers rather than
+# re-implementing them — one hardened implementation, one place to audit.
+from .job_scraper_service import (
+    SSRFError,
+    _assert_public_url,
+    _html_to_clean_text,
+    _SSRFGuardTransport,
+)
+
+logger = get_logger(__name__)
+
+# Chars of cleaned page text handed to the LLM. ~4 chars/token → ~2000 tokens.
+_PAGE_TEXT_MAX_CHARS = 8000
+
+# Timeout for the single static GET.
+_TIMEOUT = 15.0
+
+# Never emit more than this many projects from one page.
+_MAX_PROJECTS = 5
+
+_BROWSER_HEADERS: Dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+# ── Static fetch ─────────────────────────────────────────────────────────────
+
+
+async def fetch_url_text(url: str, *, client: Optional[httpx.AsyncClient] = None) -> str:
+    """Fetch a public URL and return its cleaned, plain-text body.
+
+    Performs ONE SSRF-guarded static HTTP GET (public pages only — no JS
+    execution) and converts the HTML to structured plain text capped at
+    ``_PAGE_TEXT_MAX_CHARS``.
+
+    Raises:
+        SSRFError: the URL scheme is not http(s) or the host is not public.
+        ValueError: the page could not be fetched or returned a non-2xx status.
+    """
+    # Pre-flight guard so an obviously-internal URL fails fast with SSRFError
+    # (the transport guard below is the real enforcement, incl. redirects).
+    _assert_public_url(url)
+
+    owns_client = client is None
+    client = client or httpx.AsyncClient(
+        headers=_BROWSER_HEADERS,
+        follow_redirects=True,
+        timeout=_TIMEOUT,
+        transport=_SSRFGuardTransport(),
+    )
+    try:
+        resp = await client.get(url, headers=_BROWSER_HEADERS)
+    except (httpx.ConnectError, httpx.UnsupportedProtocol) as exc:
+        # The guard transport raises these when it blocks a non-public host or
+        # a non-http(s) redirect hop — surface as an SSRF rejection.
+        raise SSRFError(f"Blocked or unreachable host for {url!r}: {exc}") from exc
+    except httpx.HTTPError as exc:
+        raise ValueError(f"Failed to fetch URL {url!r}: {exc}") from exc
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    if resp.status_code != 200:
+        raise ValueError(f"URL returned HTTP {resp.status_code}")
+
+    return _html_to_clean_text(resp.text, max_length=_PAGE_TEXT_MAX_CHARS)
+
+
+# ── LLM extraction ───────────────────────────────────────────────────────────
+
+_EXTRACT_SYSTEM_PROMPT = (
+    "You are a resume-writing assistant. Given the plain text of a person's "
+    "portfolio or personal website, identify the concrete software/technical "
+    "PROJECTS they built. Respond with ONLY a JSON array (no prose, no markdown "
+    "fences) of up to 5 objects, each of the exact shape:\n"
+    '{"title": "Project name", '
+    '"description": "one or two sentences on what it does and its impact", '
+    '"tech": ["Key", "Technologies"], '
+    '"suggested_bullets": ["achievement-oriented resume bullet", "..."], '
+    '"url": "project link if the page shows one, else empty string"}\n'
+    "Rules: 2-4 suggested_bullets per project, each starting with a strong "
+    "action verb; never invent metrics, numbers, or facts not present in the "
+    "text; tech is the concrete stack (languages, frameworks, infra) only. If "
+    "the page has no real projects, return an empty array []."
+)
+
+# Fallback title mining from raw HTML when the LLM yields nothing usable.
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_HEADING_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
+_TAG_STRIP_RE = re.compile(r"<[^>]+>")
+
+
+def _first_page_title(page_text: str) -> str:
+    """Best-effort project title from the page's <title>/<h1>/first line.
+
+    ``page_text`` is already cleaned plain text (headings preserved), so the
+    first non-empty line is the most reliable signal; the regexes are a safety
+    net for callers that pass raw HTML.
+    """
+    for line in page_text.splitlines():
+        stripped = line.strip().lstrip("•").strip()
+        if stripped:
+            return stripped[:120]
+    for pattern in (_TITLE_RE, _HEADING_RE):
+        m = pattern.search(page_text)
+        if m:
+            cleaned = _TAG_STRIP_RE.sub("", m.group(1)).strip()
+            if cleaned:
+                return cleaned[:120]
+    return ""
+
+
+def build_project_evidence(project: Dict[str, Any], source_url: str) -> Dict[str, Any]:
+    """Normalize one extracted project into a ``ProjectEvidence`` record.
+
+    Mirrors ``github_projects_service.build_project_evidence`` exactly so the
+    frontend review UI renders URL and GitHub imports identically. A page-scraped
+    project has no repo metrics, so stars/forks are 0 and ``last_active`` is null.
+    """
+    project_url = str(project.get("url") or "").strip() or source_url
+    return {
+        "source": "url",
+        "title": (str(project.get("title")).strip() if project.get("title") else "")
+        or "Untitled project",
+        "description": str(project.get("description") or "").strip(),
+        "tech": _normalize_str_list(project.get("tech")),
+        "metrics": {"stars": 0, "forks": 0},
+        "dates": {"last_active": None},
+        "url": project_url,
+        "suggested_bullets": _normalize_str_list(project.get("suggested_bullets")),
+        "raw_excerpt": "",
+    }
+
+
+def _degrade_to_metadata(page_text: str, source_url: str) -> List[Dict[str, Any]]:
+    """Single metadata-only project from the page title, or ``[]`` if none."""
+    title = _first_page_title(page_text)
+    if not title:
+        return []
+    return [build_project_evidence({"title": title, "url": source_url}, source_url)]
+
+
+def extract_projects(
+    page_text: str,
+    source_url: str,
+    api_key: Optional[str],
+    *,
+    client: Any = None,
+    model: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Extract up to 5 ``ProjectEvidence`` records from page text via ONE LLM call.
+
+    On any LLM error, missing key, or unparseable output the function degrades to
+    a single metadata-only project mined from the page title (or ``[]`` when even
+    that is absent) rather than raising — a flaky provider never fails the import.
+    """
+    truncated = (page_text or "")[:_PAGE_TEXT_MAX_CHARS]
+    if not truncated.strip():
+        return []
+
+    if not api_key:
+        logger.info("extract_projects: no LLM key, degrading to page metadata")
+        return _degrade_to_metadata(truncated, source_url)
+
+    user_prompt = f"Source URL: {source_url}\n\nPage text:\n{truncated}"
+
+    try:
+        if client is None:
+            import openai  # noqa: PLC0415 — lazy so import stays cheap/offline-safe
+
+            client = openai.OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model=model or settings.OPENAI_MODEL,
+            messages=[
+                {"role": "system", "content": _EXTRACT_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            max_tokens=1200,
+            temperature=0.4,
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception as exc:
+        logger.warning(f"extract_projects LLM call failed for {source_url}: {exc}")
+        return _degrade_to_metadata(truncated, source_url)
+
+    projects = _parse_project_array(raw)
+    if not projects:
+        return _degrade_to_metadata(truncated, source_url)
+
+    evidence = [build_project_evidence(p, source_url) for p in projects[:_MAX_PROJECTS]]
+    # Drop entries that carry no usable signal (no title AND no description).
+    return [e for e in evidence if e["title"] != "Untitled project" or e["description"]]
+
+
+def _parse_project_array(text: str) -> List[Dict[str, Any]]:
+    """Best-effort parse of an LLM JSON array of project objects.
+
+    Tolerates markdown fences and a single-object response; reuses the GitHub
+    import's object parser as a last resort. Returns ``[]`` when unparseable.
+    """
+    if not text:
+        return []
+    import json  # noqa: PLC0415 — local, cheap
+
+    candidate = text.strip()
+    fence = re.search(r"```(?:json)?\s*(.*?)\s*```", candidate, re.DOTALL)
+    if fence:
+        candidate = fence.group(1).strip()
+    else:
+        start = candidate.find("[")
+        end = candidate.rfind("]")
+        if start != -1 and end != -1 and end > start:
+            candidate = candidate[start : end + 1]
+
+    try:
+        parsed = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        # Maybe the model returned a bare object — reuse the object parser.
+        obj = _extract_json_object(text)
+        return [obj] if obj else []
+
+    if isinstance(parsed, dict):
+        return [parsed]
+    if isinstance(parsed, list):
+        return [p for p in parsed if isinstance(p, dict)]
+    return []

--- a/backend/test/test_admin_control_plane_api.py
+++ b/backend/test/test_admin_control_plane_api.py
@@ -94,7 +94,7 @@ class TestGetEntitlements:
         body = resp.json()
         assert set(body.keys()) == {"registry", "kill_switches", "matrix", "plan_families"}
         assert body["plan_families"] == ["free", "basic", "pro", "byok", "team"]
-        assert len(body["registry"]) == 28
+        assert len(body["registry"]) == 30
 
 
 # ── PATCH /admin/entitlements/kill-switch/{key} ──────────────────────────────
@@ -306,7 +306,7 @@ class TestConfigEntitlements:
         assert resp.status_code == 200
         body = resp.json()
         assert "features" in body
-        assert len(body["features"]) == 28
+        assert len(body["features"]) == 30
         assert body["features"]["compile"] is True
 
     async def test_anonymous(self, client: AsyncClient):
@@ -314,7 +314,7 @@ class TestConfigEntitlements:
         assert resp.status_code == 200
         body = resp.json()
         assert "features" in body
-        assert len(body["features"]) == 28
+        assert len(body["features"]) == 30
 
     async def test_anonymous_reflects_free_matrix_disable(
         self, client: AsyncClient, db_session: AsyncSession

--- a/backend/test/test_entitlement_service.py
+++ b/backend/test/test_entitlement_service.py
@@ -107,7 +107,7 @@ class TestEffectiveFeaturesAndState:
         free = _user(plan="free")
         eff = await entitlement_service.effective_features(free)
         assert set(eff.keys()) == {f.key for f in FEATURE_REGISTRY}
-        assert len(eff) == 28
+        assert len(eff) == 30
         # Non-gateable always True.
         assert eff["compile"] is True
 
@@ -134,7 +134,7 @@ class TestEffectiveFeaturesAndState:
             assert set(state["matrix"][family].keys()) == gateable
 
         # registry entries carry the expected fields.
-        assert len(state["registry"]) == 28
+        assert len(state["registry"]) == 30
         sample = state["registry"][0]
         assert set(sample.keys()) == {"key", "label", "category", "gateable"}
 

--- a/backend/test/test_feature_registry.py
+++ b/backend/test/test_feature_registry.py
@@ -15,12 +15,12 @@ from app.core.feature_registry import (
 )
 
 
-def test_registry_has_28_entries():
-    assert len(FEATURE_REGISTRY) == 28
+def test_registry_has_30_entries():
+    assert len(FEATURE_REGISTRY) == 30
 
 
-def test_registry_has_27_gateable():
-    assert len(gateable_keys()) == 27
+def test_registry_has_29_gateable():
+    assert len(gateable_keys()) == 29
 
 
 def test_compile_present_and_non_gateable():

--- a/backend/test/test_linkedin_import.py
+++ b/backend/test/test_linkedin_import.py
@@ -230,3 +230,236 @@ class TestConverterWorkerSourceHint:
             )
 
         mock_build.assert_called_once_with(STRUCTURE, "pdf", source_hint="linkedin", source_platform=None)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LinkedIn COMPLIANT export/resume import (Feature 1 Phase 3)
+#
+# These tests exercise the DATA-EXPORT parser (a user-uploaded LinkedIn export
+# ZIP or resume file → ProjectEvidence). This is a distinct feature from the
+# Feature-16 document-converter tests above and shares only the file name.
+#
+# COMPLIANCE: every test operates on in-memory bytes only. NO test performs (or
+# permits) any network I/O to LinkedIn — one test actively blocks sockets to
+# prove the parser is fully offline.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import io as _io
+import zipfile as _zipfile
+
+from app.parsers.base_parser import Experience, ParsedResume, Project
+from app.services import linkedin_import_service as lin
+
+
+def _make_export_zip(files: dict) -> bytes:
+    """Build an in-memory LinkedIn-export-style ZIP from {name: csv_text}."""
+    buf = _io.BytesIO()
+    with _zipfile.ZipFile(buf, "w", _zipfile.ZIP_DEFLATED) as zf:
+        for name, text in files.items():
+            zf.writestr(name, text)
+    return buf.getvalue()
+
+
+_PROJECTS_CSV = (
+    "Title,Description,Url,Started On,Finished On\r\n"
+    'Latexy,"Resume compiler in the cloud.\nCut latency 40%.",'
+    "https://example.com/latexy,Jan 2024,Dec 2024\r\n"
+)
+_POSITIONS_CSV = (
+    "Company Name,Title,Description,Started On,Finished On\r\n"
+    "Acme Corp,Senior Engineer,Owned backend systems. Led a team of 5.,"
+    "Jan 2020,Present\r\n"
+)
+
+
+class TestParseLinkedInExport:
+    def test_projects_csv_maps_to_project_evidence(self):
+        zip_bytes = _make_export_zip({"Projects.csv": _PROJECTS_CSV})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+        ev = out[0]
+        assert ev["source"] == "linkedin"
+        assert ev["title"] == "Latexy"
+        assert "Resume compiler" in ev["description"]
+        assert ev["url"] == "https://example.com/latexy"
+        assert ev["dates"]["last_active"] == "Dec 2024"
+        assert ev["metrics"] == {}
+        assert ev["tech"] == []
+        # Newline-delimited description → multiple bullets
+        assert len(ev["suggested_bullets"]) == 2
+
+    def test_positions_csv_maps_title_at_company(self):
+        zip_bytes = _make_export_zip({"Positions.csv": _POSITIONS_CSV})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+        ev = out[0]
+        assert ev["source"] == "linkedin"
+        assert ev["title"] == "Senior Engineer at Acme Corp"
+        assert ev["dates"]["last_active"] == "Present"
+        assert ev["suggested_bullets"]  # sentence-split description
+
+    def test_both_files_combined(self):
+        zip_bytes = _make_export_zip(
+            {"Projects.csv": _PROJECTS_CSV, "Positions.csv": _POSITIONS_CSV}
+        )
+        out = lin.parse_linkedin_export(zip_bytes)
+        titles = {e["title"] for e in out}
+        assert "Latexy" in titles
+        assert "Senior Engineer at Acme Corp" in titles
+
+    def test_case_insensitive_filename_and_headers(self):
+        csv_text = "TITLE,description\r\nMyProj,Did a thing.\r\n"
+        zip_bytes = _make_export_zip({"data/PROJECTS.CSV": csv_text})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+        assert out[0]["title"] == "MyProj"
+
+    def test_missing_relevant_files_tolerated(self):
+        zip_bytes = _make_export_zip(
+            {"Profile.csv": "First Name,Last Name\r\nAlice,Lee\r\n"}
+        )
+        assert lin.parse_linkedin_export(zip_bytes) == []
+
+    def test_malformed_csv_tolerated(self):
+        # Ragged rows / stray quotes must not raise.
+        bad = 'Title,Description\r\n"unterminated,thing\r\nok,fine\r\n'
+        zip_bytes = _make_export_zip({"Projects.csv": bad})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert isinstance(out, list)  # tolerated, whatever it could extract
+
+    def test_bom_encoded_csv(self):
+        text = "﻿Title,Description\r\nBOMProj,Handled BOM.\r\n"
+        zip_bytes = _make_export_zip({"Projects.csv": text})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+        assert out[0]["title"] == "BOMProj"
+
+    def test_not_a_zip_raises_value_error(self):
+        with pytest.raises(ValueError):
+            lin.parse_linkedin_export(b"this is not a zip file")
+
+    def test_empty_bytes_raises_value_error(self):
+        with pytest.raises(ValueError):
+            lin.parse_linkedin_export(b"")
+
+    def test_non_csv_members_ignored(self):
+        zip_bytes = _make_export_zip(
+            {
+                "Projects.csv": _PROJECTS_CSV,
+                "photo.jpg": "\x00\x01\x02binary",
+                "README.txt": "hello",
+            }
+        )
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1  # only the CSV contributed
+
+    def test_no_network_used_sockets_blocked(self, monkeypatch):
+        """Prove the parser is fully offline: block sockets, parsing still works."""
+        import socket
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("network access attempted during LinkedIn parse")
+
+        monkeypatch.setattr(socket, "socket", _boom)
+        zip_bytes = _make_export_zip({"Projects.csv": _PROJECTS_CSV})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+
+
+class TestParseResumeFile:
+    async def test_resume_file_maps_experience_and_projects(self):
+        canned = ParsedResume(
+            experience=[
+                Experience(
+                    title="Staff Engineer",
+                    company="Globex",
+                    start_date="2021",
+                    end_date="2024",
+                    description=["Shipped X", "Scaled Y to 1M users"],
+                    technologies=["Go", "Kafka"],
+                )
+            ],
+            projects=[
+                Project(
+                    name="OpenTool",
+                    description="An open-source tool. Widely adopted.",
+                    technologies=["Rust"],
+                    url="https://example.com/opentool",
+                    end_date="2023",
+                )
+            ],
+        )
+
+        class _FakeParser:
+            async def parse(self, content, filename=""):
+                return canned
+
+        with patch(
+            "app.parsers.parser_factory.parser_factory.get_parser_for_file",
+            return_value=_FakeParser(),
+        ):
+            out = await lin.parse_resume_file(b"%PDF-1.4 fake", "resume.pdf")
+
+        titles = {e["title"] for e in out}
+        assert "Staff Engineer at Globex" in titles
+        assert "OpenTool" in titles
+        for e in out:
+            assert e["source"] == "linkedin"
+        proj = next(e for e in out if e["title"] == "OpenTool")
+        assert proj["tech"] == ["Rust"]
+        assert proj["url"] == "https://example.com/opentool"
+        exp = next(e for e in out if e["title"] == "Staff Engineer at Globex")
+        assert exp["suggested_bullets"] == ["Shipped X", "Scaled Y to 1M users"]
+
+    async def test_unsupported_format_raises(self):
+        with patch(
+            "app.parsers.parser_factory.parser_factory.get_parser_for_file",
+            return_value=None,
+        ):
+            with pytest.raises(ValueError):
+                await lin.parse_resume_file(b"junk", "weird.xyz")
+
+    async def test_empty_resume_bytes_raises(self):
+        with pytest.raises(ValueError):
+            await lin.parse_resume_file(b"", "resume.pdf")
+
+
+@pytest.mark.asyncio
+class TestSourcesImportEndpoint:
+    async def test_import_zip_returns_projects(self, client: AsyncClient, auth_headers):
+        zip_bytes = _make_export_zip({"Projects.csv": _PROJECTS_CSV})
+        resp = await client.post(
+            "/sources/import-linkedin",
+            files={"file": ("export.zip", zip_bytes, "application/zip")},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["projects"]) == 1
+        assert body["projects"][0]["source"] == "linkedin"
+        assert body["projects"][0]["title"] == "Latexy"
+
+    async def test_import_bad_zip_returns_422(self, client: AsyncClient, auth_headers):
+        resp = await client.post(
+            "/sources/import-linkedin",
+            files={"file": ("export.zip", b"definitely not a zip", "application/zip")},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_import_oversized_returns_413(self, client: AsyncClient, auth_headers):
+        big = b"\x00" * (10 * 1024 * 1024 + 1)
+        resp = await client.post(
+            "/sources/import-linkedin",
+            files={"file": ("big.zip", big, "application/zip")},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 413
+
+    async def test_import_requires_auth(self, client: AsyncClient):
+        zip_bytes = _make_export_zip({"Projects.csv": _PROJECTS_CSV})
+        resp = await client.post(
+            "/sources/import-linkedin",
+            files={"file": ("export.zip", zip_bytes, "application/zip")},
+        )
+        assert resp.status_code in (401, 403)

--- a/backend/test/test_url_import.py
+++ b/backend/test/test_url_import.py
@@ -1,0 +1,217 @@
+"""Tests for URL project import (Feature 1 Phase 2 — external sources to resume).
+
+All network + LLM calls are mocked (injected fake ``client`` / monkeypatched
+service functions) — nothing here touches the network or a real LLM provider.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import url_projects_service as url_import
+from app.services.job_scraper_service import SSRFError
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, text: str):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeAsyncClient:
+    """Minimal stand-in for httpx.AsyncClient with a canned GET response."""
+
+    def __init__(self, resp: _FakeResp):
+        self._resp = resp
+
+    async def get(self, url, headers=None):
+        return self._resp
+
+
+def _fake_llm(content: str):
+    """A fake OpenAI client whose chat completion returns ``content``."""
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kw: resp)
+        )
+    )
+
+
+def _raising_llm(exc: Exception):
+    def _create(**kw):
+        raise exc
+
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+    )
+
+
+# ── fetch_url_text (SSRF + clean text) ───────────────────────────────────────
+
+
+class TestFetchUrlText:
+    async def test_rejects_private_url(self):
+        """A loopback/private host is refused before any fetch happens."""
+        with pytest.raises(SSRFError):
+            await url_import.fetch_url_text("http://localhost/projects")
+
+    async def test_rejects_non_http_scheme(self):
+        with pytest.raises(SSRFError):
+            await url_import.fetch_url_text("ftp://example.com/x")
+
+    async def test_returns_clean_text(self, monkeypatch):
+        """HTML body is converted to structured plain text."""
+        # Skip real DNS/SSRF resolution for the public test URL.
+        monkeypatch.setattr(url_import, "_assert_public_url", lambda url: None)
+        html = "<html><body><h1>My Work</h1><p>I build things.</p></body></html>"
+        client = _FakeAsyncClient(_FakeResp(200, html))
+        text = await url_import.fetch_url_text("https://example.com", client=client)
+        assert "My Work" in text
+        assert "I build things." in text
+        assert "<h1>" not in text  # tags stripped
+
+    async def test_raises_valueerror_on_non_200(self, monkeypatch):
+        monkeypatch.setattr(url_import, "_assert_public_url", lambda url: None)
+        client = _FakeAsyncClient(_FakeResp(404, "nope"))
+        with pytest.raises(ValueError):
+            await url_import.fetch_url_text("https://example.com", client=client)
+
+
+# ── extract_projects (LLM → ProjectEvidence) ─────────────────────────────────
+
+_MULTI_JSON = """[
+  {"title": "Latexy", "description": "A resume compiler.",
+   "tech": ["Python", "FastAPI"],
+   "suggested_bullets": ["Built a LaTeX compilation pipeline"],
+   "url": "https://latexy.dev"},
+  {"title": "Orbit", "description": "A scheduling tool.",
+   "tech": ["TypeScript"],
+   "suggested_bullets": ["Shipped a calendar sync engine"],
+   "url": ""}
+]"""
+
+
+class TestExtractProjects:
+    def test_parses_multiple_projects(self):
+        client = _fake_llm(_MULTI_JSON)
+        out = url_import.extract_projects(
+            "portfolio page text", "https://me.example.com", "sk-test", client=client
+        )
+        assert len(out) == 2
+        assert out[0]["title"] == "Latexy"
+        assert out[0]["url"] == "https://latexy.dev"
+        # Empty project url falls back to the source URL.
+        assert out[1]["url"] == "https://me.example.com"
+
+    def test_evidence_shape(self):
+        client = _fake_llm(_MULTI_JSON)
+        ev = url_import.extract_projects(
+            "text", "https://me.example.com", "sk-test", client=client
+        )[0]
+        assert set(ev.keys()) == {
+            "source", "title", "description", "tech", "metrics",
+            "dates", "url", "suggested_bullets", "raw_excerpt",
+        }
+        assert ev["source"] == "url"
+        assert ev["metrics"] == {"stars": 0, "forks": 0}
+        assert ev["dates"] == {"last_active": None}
+        assert ev["tech"] == ["Python", "FastAPI"]
+        assert ev["raw_excerpt"] == ""
+
+    def test_respects_five_project_cap(self):
+        many = "[" + ",".join(
+            f'{{"title": "P{i}", "description": "d{i}", "tech": [], '
+            f'"suggested_bullets": [], "url": ""}}'
+            for i in range(8)
+        ) + "]"
+        out = url_import.extract_projects(
+            "text", "https://me.example.com", "sk-test", client=_fake_llm(many)
+        )
+        assert len(out) == 5
+
+    def test_degrades_to_metadata_on_llm_error(self):
+        """A raising LLM degrades to one metadata-only project from the title."""
+        client = _raising_llm(RuntimeError("boom"))
+        out = url_import.extract_projects(
+            "My Cool Portfolio\nSome intro text.",
+            "https://me.example.com",
+            "sk-test",
+            client=client,
+        )
+        assert len(out) == 1
+        assert out[0]["title"] == "My Cool Portfolio"
+        assert out[0]["source"] == "url"
+        assert out[0]["url"] == "https://me.example.com"
+
+    def test_degrades_on_unparseable_output(self):
+        client = _fake_llm("I could not find any projects, sorry!")
+        out = url_import.extract_projects(
+            "Jane Doe Portfolio\nbio", "https://me.example.com", "sk-test", client=client
+        )
+        assert len(out) == 1
+        assert out[0]["title"] == "Jane Doe Portfolio"
+
+    def test_no_key_degrades_to_metadata(self):
+        out = url_import.extract_projects(
+            "Homepage Title\nwelcome", "https://me.example.com", None
+        )
+        assert len(out) == 1
+        assert out[0]["title"] == "Homepage Title"
+
+    def test_empty_page_returns_empty(self):
+        assert url_import.extract_projects("   ", "https://me.example.com", "sk-test") == []
+
+
+# ── Endpoint smoke tests (live ASGI app) ─────────────────────────────────────
+
+
+class TestImportUrlEndpoint:
+    async def test_requires_auth(self, client):
+        resp = await client.post("/sources/import-url", json={"url": "https://example.com"})
+        assert resp.status_code in (401, 403)
+
+    async def test_200_with_mocked_service(self, client, auth_headers, monkeypatch):
+        projects = [{
+            "source": "url", "title": "Latexy", "description": "A compiler.",
+            "tech": ["Python"], "metrics": {"stars": 0, "forks": 0},
+            "dates": {"last_active": None}, "url": "https://latexy.dev",
+            "suggested_bullets": ["Built X"], "raw_excerpt": "",
+        }]
+
+        async def _fake_fetch(url, *, client=None):
+            return "portfolio page text"
+
+        monkeypatch.setattr(url_import, "fetch_url_text", _fake_fetch)
+        monkeypatch.setattr(
+            url_import, "extract_projects", lambda *a, **k: projects
+        )
+
+        resp = await client.post(
+            "/sources/import-url",
+            json={"url": "https://me.example.com"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["projects"] == projects
+
+    async def test_400_on_disallowed_url(self, client, auth_headers):
+        """A private/internal host is rejected by the SSRF guard → 400."""
+        resp = await client.post(
+            "/sources/import-url",
+            json={"url": "http://localhost/projects"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    async def test_422_on_non_http_url(self, client, auth_headers):
+        resp = await client.post(
+            "/sources/import-url",
+            json={"url": "ftp://example.com/x"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
Closes #1058.

Two more external-source importers feeding the **same `ProjectEvidence` review UI** as the GitHub import (External-Sources-to-Resume PRD, Phases 2 & 3). Both synchronous (in-request, no async worker), gated, and route through user review.

## URL ingest (Phase 2)
- **`url_projects_service.py`** — one SSRF-guarded static fetch (reuses `job_scraper_service`'s `_assert_public_url` + `_SSRFGuardTransport` + `_html_to_clean_text`, no JS execution, ~8k-char cap) + one LLM call → up to 5 `ProjectEvidence`; degrades to page-title metadata on error.
- **`POST /sources/import-url`** → `{projects}`. Gate `ai_import_url`. Non-http→422, SSRF/blocked→400, fetch failure→502.

## LinkedIn (Phase 3 — COMPLIANT ONLY)
- **Never scrapes LinkedIn / never touches the network.** Parses ONLY a user-uploaded LinkedIn **data-export ZIP** or their **resume file**. **`linkedin_import_service.py`** — in-memory ZIP parse (Projects.csv/Positions.csv, case-insensitive, BOM-safe) with zip-bomb guards (entry/size/row/field/total caps), or ParserFactory resume parse → `ProjectEvidence` (`source="linkedin"`).
- **`POST /sources/import-linkedin`** (multipart) → `{projects}`. Gate `ai_import_linkedin`. >10MB→413, empty/bad→422.

## Shared
- One `sources_routes.py` router (both endpoints), registered once in `routes.py`.
- `feature_registry`: +`ai_import_url` +`ai_import_linkedin` → **30 entries / 29 gateable**; count assertions updated across registry/entitlement/admin tests.

## Testing
- `test_url_import.py` (15) + `test_linkedin_import.py` (LinkedIn-import section, incl. a socket-blocked offline proof) + registry/entitlement/admin/parity suites — all green locally. `ruff` clean. Modal parity green (both endpoints are in-request, no worker function needed).