### PR TITLE
F1 Phase 3: LinkedIn (compliant) import backend

### DIFF
--- a/backend/app/api/sources_routes.py
+++ b/backend/app/api/sources_routes.py
@@ -1,25 +1,36 @@
-"""External-source import routes (Feature 1 Phase 2 — URL project ingest).
+"""External-source import routes (Feature 1 — external sources to resume).
 
-Synchronous endpoint that turns a public portfolio / personal-site / project URL
-into resume-ready ``ProjectEvidence`` records (the SAME shape as the GitHub
-import) for the existing frontend review UI.
+Turns external sources into resume-ready ``ProjectEvidence`` records (the SAME
+shape as the GitHub import) for the existing frontend review UI:
 
-PRIVACY / SAFETY: public pages only. One static HTTP GET (no JS execution) behind
-the shared SSRF guard, followed by one LLM call. Because it is a single fetch +
-single summarization it runs in-request (like the ``/ai/*`` endpoints), not as an
-async job. Summarization uses the caller's own LLM key (BYOK) when present, else
+  * POST /sources/import-url      — Phase 2: a public portfolio / personal-site
+    URL. One SSRF-guarded static fetch (no JS execution) + one LLM call, all
+    in-request (like the ``/ai/*`` endpoints). Public pages only.
+  * POST /sources/import-linkedin — Phase 3: a user-uploaded LinkedIn data-export
+    ZIP or resume file. Parsed locally on the uploaded bytes.
+
+COMPLIANCE CONSTRAINT (LinkedIn): the LinkedIn import NEVER scrapes LinkedIn,
+NEVER calls any LinkedIn URL/API, and NEVER buys LinkedIn data. It parses ONLY a
+file the USER uploads themselves — their official LinkedIn **data export** ZIP
+(from LinkedIn → Settings → "Get a copy of your data") OR their own resume file
+(PDF/DOCX). See ``linkedin_import_service`` for the constraint in full.
+
+LLM summarization (URL path) uses the caller's own key (BYOK) when present, else
 the platform key.
 """
 
+from __future__ import annotations
+
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.logging import get_logger
 from ..database.connection import get_db
 from ..middleware.entitlements import require_feature
+from ..services import linkedin_import_service
 from ..services import url_projects_service as url_import
 from ..services.api_key_service import api_key_service
 from ..services.job_scraper_service import SSRFError
@@ -29,7 +40,7 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/sources", tags=["sources"])
 
 
-# ── Schemas ──────────────────────────────────────────────────────────────────
+# ── URL import (Phase 2) ─────────────────────────────────────────────────────
 
 
 class ImportUrlRequest(BaseModel):
@@ -46,9 +57,6 @@ class ImportUrlRequest(BaseModel):
 
 class ImportUrlResponse(BaseModel):
     projects: List[dict] = []
-
-
-# ── Endpoint ─────────────────────────────────────────────────────────────────
 
 
 @router.post("/import-url", response_model=ImportUrlResponse)
@@ -94,3 +102,87 @@ async def import_from_url(
         raise HTTPException(status_code=500, detail="Unexpected error while extracting projects.")
 
     return ImportUrlResponse(projects=projects)
+
+
+# ── LinkedIn / resume-file import (Phase 3) ──────────────────────────────────
+
+# Reject uploads larger than this before reading them into memory (defence in
+# depth on top of the service's own zip-bomb caps). LinkedIn exports and resumes
+# are comfortably under this.
+_MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
+
+_ZIP_CONTENT_TYPES = {
+    "application/zip",
+    "application/x-zip-compressed",
+    "application/x-zip",
+    "multipart/x-zip",
+}
+
+
+class LinkedInImportResponse(BaseModel):
+    """Candidate ProjectEvidence records parsed from the uploaded file."""
+
+    projects: List[dict] = []
+
+
+def _looks_like_zip(filename: str, content_type: str, head: bytes) -> bool:
+    """Best-effort ZIP sniff by extension, content-type, or magic bytes."""
+    if filename.lower().endswith(".zip"):
+        return True
+    if (content_type or "").lower().split(";")[0].strip() in _ZIP_CONTENT_TYPES:
+        return True
+    # ZIP local-file-header magic ("PK\x03\x04"). A DOCX is also a ZIP, but DOCX
+    # is routed to the resume parser by its .docx extension check above, so this
+    # only fires for genuine LinkedIn export archives.
+    return head[:4] == b"PK\x03\x04" and not filename.lower().endswith(
+        (".docx", ".doc")
+    )
+
+
+@router.post("/import-linkedin", response_model=LinkedInImportResponse)
+async def import_linkedin(
+    file: UploadFile = File(...),
+    user_id: str = Depends(require_feature("ai_import_linkedin")),
+) -> LinkedInImportResponse:
+    """Import ProjectEvidence from a user-uploaded LinkedIn export ZIP or resume.
+
+    COMPLIANCE: the ONLY input is the file the user uploads themselves — their
+    own LinkedIn data export (``.zip``) or their own resume (``.pdf``/``.docx``).
+    Nothing in this handler contacts LinkedIn.
+
+    - ``.zip`` (LinkedIn export)  → ``parse_linkedin_export``
+    - anything else (resume file) → ``parse_resume_file``
+
+    Returns ``{projects: [ProjectEvidence]}``. A bad/unparseable file yields 422;
+    an oversized upload yields 413.
+    """
+    del user_id  # gating only; the parse is stateless
+
+    filename = file.filename or "upload"
+    content_type = file.content_type or ""
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=422, detail="Uploaded file is empty.")
+    if len(content) > _MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large. Maximum size: {_MAX_UPLOAD_BYTES} bytes.",
+        )
+
+    try:
+        if _looks_like_zip(filename, content_type, content):
+            projects = linkedin_import_service.parse_linkedin_export(content)
+        else:
+            projects = await linkedin_import_service.parse_resume_file(content, filename)
+    except ValueError as exc:
+        # Malformed ZIP / unsupported or unparseable resume → client error.
+        raise HTTPException(status_code=422, detail=str(exc))
+    except Exception as exc:  # unexpected → 500, but never leak internals
+        logger.error("sources/import-linkedin failed for %s: %s", filename, exc)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to import from the uploaded file. Please try again.",
+        )
+
+    return LinkedInImportResponse(projects=projects)

--- a/backend/app/core/feature_registry.py
+++ b/backend/app/core/feature_registry.py
@@ -93,6 +93,8 @@ FEATURE_REGISTRY: list[FeatureDef] = [
                "Import your top public GitHub projects as AI-summarized resume evidence."),
     FeatureDef("ai_import_url", "URL Project Import", "integrations",
                "Import projects from a portfolio or personal-site URL as AI-summarized resume evidence."),
+    FeatureDef("ai_import_linkedin", "LinkedIn Export Import", "integrations",
+               "Import projects and experience from a user-uploaded LinkedIn data export or resume file."),
     # ---- analytics --------------------------------------------------------
     FeatureDef("analytics", "Analytics Dashboard", "analytics",
                "Usage and performance analytics dashboard."),

--- a/backend/app/services/linkedin_import_service.py
+++ b/backend/app/services/linkedin_import_service.py
@@ -1,0 +1,397 @@
+"""LinkedIn COMPLIANT import service (Feature 1 Phase 3 — external sources to resume).
+
+COMPLIANCE CONSTRAINT (read before touching this module):
+    This module NEVER scrapes LinkedIn, NEVER calls any LinkedIn URL or API, and
+    NEVER buys or fetches LinkedIn data. The ONLY supported input is a file the
+    USER uploads themselves — either
+
+      1. their official LinkedIn **data export** (a ZIP of CSV files the user
+         downloads from LinkedIn → Settings → "Get a copy of your data"), or
+      2. their own resume file (PDF/DOCX).
+
+    Every function here operates purely on in-memory ``bytes`` the caller already
+    holds. There is ZERO outbound network to LinkedIn (or anywhere else) in this
+    module, by design and by construction. Do not add one.
+
+The parsed output matches the shared ``ProjectEvidence`` dict shape used by the
+GitHub importer (``github_projects_service.build_project_evidence``) so the same
+frontend review UI renders LinkedIn-sourced evidence (``source="linkedin"``):
+
+    {source, title, description, tech[], metrics{}, dates{last_active},
+     url, suggested_bullets[], raw_excerpt}
+
+All ZIP handling is defensive against malformed archives and zip bombs: entry
+count, per-member uncompressed size, and total uncompressed bytes read are all
+capped; non-CSV members are ignored.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+import zipfile
+from typing import Any, Dict, List, Optional
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ── Defensive caps (zip-bomb / DoS guards) ────────────────────────────────────
+
+# Never inspect more than this many members in an uploaded ZIP.
+_MAX_ZIP_ENTRIES = 200
+# Skip any single member whose DECLARED uncompressed size exceeds this, and stop
+# reading a member once this many bytes have actually been read.
+_MAX_MEMBER_BYTES = 5 * 1024 * 1024  # 5 MB
+# Hard ceiling on TOTAL uncompressed bytes read across all members. Guards against
+# a zip bomb of many individually-small-but-collectively-huge members.
+_MAX_TOTAL_UNCOMPRESSED = 20 * 1024 * 1024  # 20 MB
+# Cap rows parsed per CSV so a giant CSV cannot exhaust memory/CPU.
+_MAX_ROWS_PER_CSV = 1000
+# Truncate any single field to this many characters.
+_MAX_FIELD_CHARS = 20_000
+# Cap the number of evidence records returned regardless of source.
+_MAX_EVIDENCE = 100
+# Cap suggested bullets per evidence record.
+_MAX_BULLETS = 8
+
+# CSV files we care about (matched case-insensitively against the member name).
+_PROJECTS_CSV = "projects.csv"
+_POSITIONS_CSV = "positions.csv"
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+# ── Small helpers ─────────────────────────────────────────────────────────────
+
+
+def _clip(value: Any) -> str:
+    """Coerce a CSV value to a stripped, length-capped string."""
+    if value is None:
+        return ""
+    return str(value).strip()[:_MAX_FIELD_CHARS]
+
+
+def _lc_row(row: Dict[str, Any]) -> Dict[str, str]:
+    """Return a row keyed by lower-cased/stripped header → clipped string value."""
+    out: Dict[str, str] = {}
+    for key, val in row.items():
+        if key is None:
+            continue
+        out[str(key).strip().lower()] = _clip(val)
+    return out
+
+
+def _get(row_lc: Dict[str, str], *names: str) -> str:
+    """First non-empty value among the given (case-insensitive) column names."""
+    for name in names:
+        val = row_lc.get(name.lower())
+        if val:
+            return val
+    return ""
+
+
+def _split_bullets(description: str) -> List[str]:
+    """Turn a free-text description into sentence-ish resume bullets.
+
+    Splits on newlines first (LinkedIn descriptions are often newline-delimited),
+    then on sentence boundaries. Falls back to the whole description as a single
+    bullet. Never invents content — this is pure segmentation.
+    """
+    description = (description or "").strip()
+    if not description:
+        return []
+
+    # Prefer explicit line breaks / bullet glyphs the user already authored.
+    lines = [
+        re.sub(r"^[\-•\*▪●\s]+", "", ln).strip()
+        for ln in re.split(r"[\r\n]+", description)
+    ]
+    lines = [ln for ln in lines if ln]
+
+    if len(lines) > 1:
+        bullets = lines
+    else:
+        # Single blob — split into sentences.
+        single = lines[0] if lines else description
+        sentences = [s.strip() for s in _SENTENCE_SPLIT_RE.split(single) if s.strip()]
+        bullets = sentences or [single]
+
+    return bullets[:_MAX_BULLETS]
+
+
+def _build_evidence(
+    *,
+    title: str,
+    description: str,
+    suggested_bullets: List[str],
+    tech: Optional[List[str]] = None,
+    url: Optional[str] = None,
+    last_active: Optional[str] = None,
+    raw_excerpt: str = "",
+) -> Dict[str, Any]:
+    """Assemble a ``ProjectEvidence`` dict for a LinkedIn-sourced record.
+
+    Mirrors ``github_projects_service.build_project_evidence`` exactly, with
+    ``source="linkedin"``. LinkedIn has no stars/forks, so ``metrics`` is an
+    empty dict (the same key the GitHub path fills).
+    """
+    return {
+        "source": "linkedin",
+        "title": (title or "").strip(),
+        "description": (description or "").strip(),
+        "tech": tech or [],
+        "metrics": {},
+        "dates": {"last_active": last_active or None},
+        "url": (url or None),
+        "suggested_bullets": suggested_bullets or [],
+        "raw_excerpt": (raw_excerpt or "")[:2000],
+    }
+
+
+# ── LinkedIn data-export (ZIP of CSVs) parsing ────────────────────────────────
+
+
+def _row_to_project_evidence(row_lc: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    """Map one ``Projects.csv`` row → ProjectEvidence (None if unusable)."""
+    title = _get(row_lc, "title", "name", "project name")
+    description = _get(row_lc, "description", "summary")
+    if not title and not description:
+        return None
+    url = _get(row_lc, "url", "link")
+    started = _get(row_lc, "started on", "start date", "started")
+    finished = _get(row_lc, "finished on", "end date", "finished")
+    return _build_evidence(
+        title=title or "Project",
+        description=description,
+        suggested_bullets=_split_bullets(description) if description else [],
+        tech=[],
+        url=url,
+        last_active=finished or started,
+        raw_excerpt=description,
+    )
+
+
+def _row_to_position_evidence(row_lc: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    """Map one ``Positions.csv`` row → ProjectEvidence (None if unusable)."""
+    role = _get(row_lc, "title", "position", "role")
+    company = _get(row_lc, "company name", "company", "organization")
+    description = _get(row_lc, "description", "summary")
+    if not role and not company and not description:
+        return None
+    if role and company:
+        title = f"{role} at {company}"
+    else:
+        title = role or company or "Experience"
+    started = _get(row_lc, "started on", "start date", "started")
+    finished = _get(row_lc, "finished on", "end date", "finished")
+    return _build_evidence(
+        title=title,
+        description=description,
+        suggested_bullets=_split_bullets(description) if description else [],
+        tech=[],
+        url=None,
+        last_active=finished or started,
+        raw_excerpt=description,
+    )
+
+
+def _read_member_text(zf: zipfile.ZipFile, info: zipfile.ZipInfo) -> Optional[str]:
+    """Safely read+decode a single ZIP member, honoring the size caps.
+
+    Returns None if the member is too large or cannot be decoded. The read is
+    bounded to ``_MAX_MEMBER_BYTES`` regardless of the declared size (a lying
+    header cannot make us read more).
+    """
+    # Refuse members whose declared uncompressed size already blows the cap.
+    if info.file_size and info.file_size > _MAX_MEMBER_BYTES:
+        logger.warning(
+            "linkedin_import: skipping oversized member %s (%d bytes declared)",
+            info.filename,
+            info.file_size,
+        )
+        return None
+    try:
+        with zf.open(info, "r") as fh:
+            raw = fh.read(_MAX_MEMBER_BYTES + 1)
+    except (zipfile.BadZipFile, OSError, RuntimeError) as exc:
+        logger.warning("linkedin_import: failed reading %s: %s", info.filename, exc)
+        return None
+    if len(raw) > _MAX_MEMBER_BYTES:
+        logger.warning("linkedin_import: member %s exceeded read cap", info.filename)
+        return None
+    # utf-8-sig strips a BOM if present; replace undecodable bytes rather than fail.
+    return raw.decode("utf-8-sig", errors="replace")
+
+
+def _parse_csv_rows(text: str) -> List[Dict[str, str]]:
+    """Parse CSV text into a list of lower-cased-key rows, capped in count."""
+    rows: List[Dict[str, str]] = []
+    reader = csv.DictReader(io.StringIO(text))
+    for i, raw_row in enumerate(reader):
+        if i >= _MAX_ROWS_PER_CSV:
+            logger.warning("linkedin_import: row cap reached, truncating CSV")
+            break
+        rows.append(_lc_row(raw_row))
+    return rows
+
+
+def parse_linkedin_export(zip_bytes: bytes) -> List[Dict[str, Any]]:
+    """Parse a user-uploaded LinkedIn data-export ZIP into ProjectEvidence dicts.
+
+    COMPLIANCE: ``zip_bytes`` must be the user's OWN LinkedIn export (downloaded
+    by them from LinkedIn's data-export tool). Nothing here contacts LinkedIn.
+
+    Finds ``Projects.csv`` and ``Positions.csv`` case-insensitively anywhere in
+    the archive, parses them defensively, and maps each row to a ProjectEvidence
+    record (``source="linkedin"``). Missing files and malformed rows are
+    tolerated — the function returns whatever it could extract (possibly empty),
+    and only raises ``ValueError`` when the bytes are not a valid ZIP at all.
+    """
+    if not zip_bytes:
+        raise ValueError("Empty upload: no LinkedIn export data provided.")
+
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        raise ValueError("Uploaded file is not a valid ZIP archive.") from exc
+
+    evidence: List[Dict[str, Any]] = []
+    total_read = 0
+
+    try:
+        infos = zf.infolist()[:_MAX_ZIP_ENTRIES]
+        for info in infos:
+            if len(evidence) >= _MAX_EVIDENCE:
+                break
+            if info.is_dir():
+                continue
+            base = info.filename.rsplit("/", 1)[-1].lower()
+            if base not in (_PROJECTS_CSV, _POSITIONS_CSV):
+                continue  # ignore non-CSV / irrelevant members
+            if total_read >= _MAX_TOTAL_UNCOMPRESSED:
+                logger.warning("linkedin_import: total uncompressed cap reached")
+                break
+
+            text = _read_member_text(zf, info)
+            if text is None:
+                continue
+            total_read += len(text)
+
+            try:
+                rows = _parse_csv_rows(text)
+            except (csv.Error, ValueError) as exc:
+                logger.warning("linkedin_import: CSV parse error in %s: %s", base, exc)
+                continue
+
+            mapper = (
+                _row_to_project_evidence
+                if base == _PROJECTS_CSV
+                else _row_to_position_evidence
+            )
+            for row in rows:
+                if len(evidence) >= _MAX_EVIDENCE:
+                    break
+                try:
+                    record = mapper(row)
+                except Exception as exc:  # one bad row never fails the whole import
+                    logger.warning("linkedin_import: bad row skipped: %s", exc)
+                    continue
+                if record:
+                    evidence.append(record)
+    finally:
+        zf.close()
+
+    return evidence
+
+
+# ── Resume-file (PDF/DOCX) parsing ────────────────────────────────────────────
+
+
+def _parsed_resume_to_evidence(parsed: Any) -> List[Dict[str, Any]]:
+    """Map a ``ParsedResume`` (experience + projects) → ProjectEvidence dicts."""
+    evidence: List[Dict[str, Any]] = []
+
+    for proj in getattr(parsed, "projects", None) or []:
+        if len(evidence) >= _MAX_EVIDENCE:
+            break
+        description = (getattr(proj, "description", "") or "").strip()
+        name = (getattr(proj, "name", "") or "").strip()
+        if not name and not description:
+            continue
+        end = getattr(proj, "end_date", None)
+        start = getattr(proj, "start_date", None)
+        evidence.append(
+            _build_evidence(
+                title=name or "Project",
+                description=description,
+                suggested_bullets=_split_bullets(description) if description else [],
+                tech=list(getattr(proj, "technologies", None) or []),
+                url=getattr(proj, "url", None),
+                last_active=end or start,
+                raw_excerpt=description,
+            )
+        )
+
+    for exp in getattr(parsed, "experience", None) or []:
+        if len(evidence) >= _MAX_EVIDENCE:
+            break
+        role = (getattr(exp, "title", "") or "").strip()
+        company = (getattr(exp, "company", "") or "").strip()
+        desc_lines = [
+            str(d).strip() for d in (getattr(exp, "description", None) or []) if str(d).strip()
+        ]
+        if not role and not company and not desc_lines:
+            continue
+        if role and company:
+            title = f"{role} at {company}"
+        else:
+            title = role or company or "Experience"
+        description = " ".join(desc_lines)
+        end = getattr(exp, "end_date", None)
+        start = getattr(exp, "start_date", None)
+        evidence.append(
+            _build_evidence(
+                title=title,
+                description=description,
+                suggested_bullets=desc_lines[:_MAX_BULLETS],
+                tech=list(getattr(exp, "technologies", None) or []),
+                url=None,
+                last_active=end or start,
+                raw_excerpt=description,
+            )
+        )
+
+    return evidence[:_MAX_EVIDENCE]
+
+
+async def parse_resume_file(file_bytes: bytes, filename: str) -> List[Dict[str, Any]]:
+    """Parse a user-uploaded resume file (PDF/DOCX/...) into ProjectEvidence dicts.
+
+    COMPLIANCE: this operates ONLY on the bytes the user uploaded — their own
+    resume. No network, no LinkedIn. Uses the existing ``ParserFactory`` to turn
+    the file into a ``ParsedResume``, then best-effort maps its experience and
+    project sections to ProjectEvidence records (``source="linkedin"`` because
+    the entry point is the LinkedIn-import flow).
+
+    Raises ``ValueError`` if the file format is unsupported or unparseable.
+    """
+    if not file_bytes:
+        raise ValueError("Empty upload: no resume file provided.")
+
+    # Local import keeps module import cheap and avoids a heavy parser import at
+    # startup for callers that only use the ZIP path.
+    from ..parsers.parser_factory import parser_factory  # noqa: PLC0415
+
+    parser = parser_factory.get_parser_for_file(filename, content=file_bytes)
+    if parser is None:
+        raise ValueError(f"Unsupported resume file format: {filename!r}")
+
+    try:
+        parsed = await parser.parse(file_bytes, filename)
+    except Exception as exc:  # normalize parser failures to a 4xx-friendly error
+        logger.warning("linkedin_import: resume parse failed for %s: %s", filename, exc)
+        raise ValueError(f"Could not parse resume file: {exc}") from exc
+
+    return _parsed_resume_to_evidence(parsed)

--- a/backend/test/test_admin_control_plane_api.py
+++ b/backend/test/test_admin_control_plane_api.py
@@ -94,7 +94,7 @@ class TestGetEntitlements:
         body = resp.json()
         assert set(body.keys()) == {"registry", "kill_switches", "matrix", "plan_families"}
         assert body["plan_families"] == ["free", "basic", "pro", "byok", "team"]
-        assert len(body["registry"]) == 29
+        assert len(body["registry"]) == 30
 
 
 # ── PATCH /admin/entitlements/kill-switch/{key} ──────────────────────────────
@@ -306,7 +306,7 @@ class TestConfigEntitlements:
         assert resp.status_code == 200
         body = resp.json()
         assert "features" in body
-        assert len(body["features"]) == 29
+        assert len(body["features"]) == 30
         assert body["features"]["compile"] is True
 
     async def test_anonymous(self, client: AsyncClient):
@@ -314,7 +314,7 @@ class TestConfigEntitlements:
         assert resp.status_code == 200
         body = resp.json()
         assert "features" in body
-        assert len(body["features"]) == 29
+        assert len(body["features"]) == 30
 
     async def test_anonymous_reflects_free_matrix_disable(
         self, client: AsyncClient, db_session: AsyncSession

--- a/backend/test/test_entitlement_service.py
+++ b/backend/test/test_entitlement_service.py
@@ -103,11 +103,11 @@ class TestHasFeatureToggles:
 
 class TestEffectiveFeaturesAndState:
 
-    async def test_effective_features_all_29_keys(self):
+    async def test_effective_features_all_28_keys(self):
         free = _user(plan="free")
         eff = await entitlement_service.effective_features(free)
         assert set(eff.keys()) == {f.key for f in FEATURE_REGISTRY}
-        assert len(eff) == 29
+        assert len(eff) == 30
         # Non-gateable always True.
         assert eff["compile"] is True
 
@@ -134,7 +134,7 @@ class TestEffectiveFeaturesAndState:
             assert set(state["matrix"][family].keys()) == gateable
 
         # registry entries carry the expected fields.
-        assert len(state["registry"]) == 29
+        assert len(state["registry"]) == 30
         sample = state["registry"][0]
         assert set(sample.keys()) == {"key", "label", "category", "gateable"}
 

--- a/backend/test/test_feature_registry.py
+++ b/backend/test/test_feature_registry.py
@@ -15,12 +15,12 @@ from app.core.feature_registry import (
 )
 
 
-def test_registry_has_29_entries():
-    assert len(FEATURE_REGISTRY) == 29
+def test_registry_has_30_entries():
+    assert len(FEATURE_REGISTRY) == 30
 
 
-def test_registry_has_28_gateable():
-    assert len(gateable_keys()) == 28
+def test_registry_has_29_gateable():
+    assert len(gateable_keys()) == 29
 
 
 def test_compile_present_and_non_gateable():

--- a/backend/test/test_linkedin_import.py
+++ b/backend/test/test_linkedin_import.py
@@ -230,3 +230,236 @@ class TestConverterWorkerSourceHint:
             )
 
         mock_build.assert_called_once_with(STRUCTURE, "pdf", source_hint="linkedin", source_platform=None)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LinkedIn COMPLIANT export/resume import (Feature 1 Phase 3)
+#
+# These tests exercise the DATA-EXPORT parser (a user-uploaded LinkedIn export
+# ZIP or resume file → ProjectEvidence). This is a distinct feature from the
+# Feature-16 document-converter tests above and shares only the file name.
+#
+# COMPLIANCE: every test operates on in-memory bytes only. NO test performs (or
+# permits) any network I/O to LinkedIn — one test actively blocks sockets to
+# prove the parser is fully offline.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import io as _io
+import zipfile as _zipfile
+
+from app.parsers.base_parser import Experience, ParsedResume, Project
+from app.services import linkedin_import_service as lin
+
+
+def _make_export_zip(files: dict) -> bytes:
+    """Build an in-memory LinkedIn-export-style ZIP from {name: csv_text}."""
+    buf = _io.BytesIO()
+    with _zipfile.ZipFile(buf, "w", _zipfile.ZIP_DEFLATED) as zf:
+        for name, text in files.items():
+            zf.writestr(name, text)
+    return buf.getvalue()
+
+
+_PROJECTS_CSV = (
+    "Title,Description,Url,Started On,Finished On\r\n"
+    'Latexy,"Resume compiler in the cloud.\nCut latency 40%.",'
+    "https://example.com/latexy,Jan 2024,Dec 2024\r\n"
+)
+_POSITIONS_CSV = (
+    "Company Name,Title,Description,Started On,Finished On\r\n"
+    "Acme Corp,Senior Engineer,Owned backend systems. Led a team of 5.,"
+    "Jan 2020,Present\r\n"
+)
+
+
+class TestParseLinkedInExport:
+    def test_projects_csv_maps_to_project_evidence(self):
+        zip_bytes = _make_export_zip({"Projects.csv": _PROJECTS_CSV})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+        ev = out[0]
+        assert ev["source"] == "linkedin"
+        assert ev["title"] == "Latexy"
+        assert "Resume compiler" in ev["description"]
+        assert ev["url"] == "https://example.com/latexy"
+        assert ev["dates"]["last_active"] == "Dec 2024"
+        assert ev["metrics"] == {}
+        assert ev["tech"] == []
+        # Newline-delimited description → multiple bullets
+        assert len(ev["suggested_bullets"]) == 2
+
+    def test_positions_csv_maps_title_at_company(self):
+        zip_bytes = _make_export_zip({"Positions.csv": _POSITIONS_CSV})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+        ev = out[0]
+        assert ev["source"] == "linkedin"
+        assert ev["title"] == "Senior Engineer at Acme Corp"
+        assert ev["dates"]["last_active"] == "Present"
+        assert ev["suggested_bullets"]  # sentence-split description
+
+    def test_both_files_combined(self):
+        zip_bytes = _make_export_zip(
+            {"Projects.csv": _PROJECTS_CSV, "Positions.csv": _POSITIONS_CSV}
+        )
+        out = lin.parse_linkedin_export(zip_bytes)
+        titles = {e["title"] for e in out}
+        assert "Latexy" in titles
+        assert "Senior Engineer at Acme Corp" in titles
+
+    def test_case_insensitive_filename_and_headers(self):
+        csv_text = "TITLE,description\r\nMyProj,Did a thing.\r\n"
+        zip_bytes = _make_export_zip({"data/PROJECTS.CSV": csv_text})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+        assert out[0]["title"] == "MyProj"
+
+    def test_missing_relevant_files_tolerated(self):
+        zip_bytes = _make_export_zip(
+            {"Profile.csv": "First Name,Last Name\r\nAlice,Lee\r\n"}
+        )
+        assert lin.parse_linkedin_export(zip_bytes) == []
+
+    def test_malformed_csv_tolerated(self):
+        # Ragged rows / stray quotes must not raise.
+        bad = 'Title,Description\r\n"unterminated,thing\r\nok,fine\r\n'
+        zip_bytes = _make_export_zip({"Projects.csv": bad})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert isinstance(out, list)  # tolerated, whatever it could extract
+
+    def test_bom_encoded_csv(self):
+        text = "﻿Title,Description\r\nBOMProj,Handled BOM.\r\n"
+        zip_bytes = _make_export_zip({"Projects.csv": text})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+        assert out[0]["title"] == "BOMProj"
+
+    def test_not_a_zip_raises_value_error(self):
+        with pytest.raises(ValueError):
+            lin.parse_linkedin_export(b"this is not a zip file")
+
+    def test_empty_bytes_raises_value_error(self):
+        with pytest.raises(ValueError):
+            lin.parse_linkedin_export(b"")
+
+    def test_non_csv_members_ignored(self):
+        zip_bytes = _make_export_zip(
+            {
+                "Projects.csv": _PROJECTS_CSV,
+                "photo.jpg": "\x00\x01\x02binary",
+                "README.txt": "hello",
+            }
+        )
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1  # only the CSV contributed
+
+    def test_no_network_used_sockets_blocked(self, monkeypatch):
+        """Prove the parser is fully offline: block sockets, parsing still works."""
+        import socket
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("network access attempted during LinkedIn parse")
+
+        monkeypatch.setattr(socket, "socket", _boom)
+        zip_bytes = _make_export_zip({"Projects.csv": _PROJECTS_CSV})
+        out = lin.parse_linkedin_export(zip_bytes)
+        assert len(out) == 1
+
+
+class TestParseResumeFile:
+    async def test_resume_file_maps_experience_and_projects(self):
+        canned = ParsedResume(
+            experience=[
+                Experience(
+                    title="Staff Engineer",
+                    company="Globex",
+                    start_date="2021",
+                    end_date="2024",
+                    description=["Shipped X", "Scaled Y to 1M users"],
+                    technologies=["Go", "Kafka"],
+                )
+            ],
+            projects=[
+                Project(
+                    name="OpenTool",
+                    description="An open-source tool. Widely adopted.",
+                    technologies=["Rust"],
+                    url="https://example.com/opentool",
+                    end_date="2023",
+                )
+            ],
+        )
+
+        class _FakeParser:
+            async def parse(self, content, filename=""):
+                return canned
+
+        with patch(
+            "app.parsers.parser_factory.parser_factory.get_parser_for_file",
+            return_value=_FakeParser(),
+        ):
+            out = await lin.parse_resume_file(b"%PDF-1.4 fake", "resume.pdf")
+
+        titles = {e["title"] for e in out}
+        assert "Staff Engineer at Globex" in titles
+        assert "OpenTool" in titles
+        for e in out:
+            assert e["source"] == "linkedin"
+        proj = next(e for e in out if e["title"] == "OpenTool")
+        assert proj["tech"] == ["Rust"]
+        assert proj["url"] == "https://example.com/opentool"
+        exp = next(e for e in out if e["title"] == "Staff Engineer at Globex")
+        assert exp["suggested_bullets"] == ["Shipped X", "Scaled Y to 1M users"]
+
+    async def test_unsupported_format_raises(self):
+        with patch(
+            "app.parsers.parser_factory.parser_factory.get_parser_for_file",
+            return_value=None,
+        ):
+            with pytest.raises(ValueError):
+                await lin.parse_resume_file(b"junk", "weird.xyz")
+
+    async def test_empty_resume_bytes_raises(self):
+        with pytest.raises(ValueError):
+            await lin.parse_resume_file(b"", "resume.pdf")
+
+
+@pytest.mark.asyncio
+class TestSourcesImportEndpoint:
+    async def test_import_zip_returns_projects(self, client: AsyncClient, auth_headers):
+        zip_bytes = _make_export_zip({"Projects.csv": _PROJECTS_CSV})
+        resp = await client.post(
+            "/sources/import-linkedin",
+            files={"file": ("export.zip", zip_bytes, "application/zip")},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["projects"]) == 1
+        assert body["projects"][0]["source"] == "linkedin"
+        assert body["projects"][0]["title"] == "Latexy"
+
+    async def test_import_bad_zip_returns_422(self, client: AsyncClient, auth_headers):
+        resp = await client.post(
+            "/sources/import-linkedin",
+            files={"file": ("export.zip", b"definitely not a zip", "application/zip")},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_import_oversized_returns_413(self, client: AsyncClient, auth_headers):
+        big = b"\x00" * (10 * 1024 * 1024 + 1)
+        resp = await client.post(
+            "/sources/import-linkedin",
+            files={"file": ("big.zip", big, "application/zip")},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 413
+
+    async def test_import_requires_auth(self, client: AsyncClient):
+        zip_bytes = _make_export_zip({"Projects.csv": _PROJECTS_CSV})
+        resp = await client.post(
+            "/sources/import-linkedin",
+            files={"file": ("export.zip", zip_bytes, "application/zip")},
+        )
+        assert resp.status_code in (401, 403)


### PR DESCRIPTION
Closes #1060.

Adds the compliant LinkedIn importer on top of the URL importer already on main, feeding the **same `ProjectEvidence` review UI** as GitHub/URL.

**COMPLIANT ONLY** — never scrapes LinkedIn, never touches the network. Parses ONLY a file the user uploads themselves: their LinkedIn **data-export ZIP** or their **resume file**.

## What's in it
- **`linkedin_import_service.py`** — in-memory ZIP parse (Projects.csv / Positions.csv, case-insensitive, `utf-8-sig` BOM-safe) with zip-bomb guards (entry count, per-member size, total uncompressed, row/field/record/bullet caps), or ParserFactory resume parse → `ProjectEvidence` (`source="linkedin"`).
- **`POST /sources/import-linkedin`** — multipart upload added to the existing `/sources` router; ZIP/resume sniff by extension/content-type/magic; gate `ai_import_linkedin`; >10MB→413, empty/unparseable→422.
- **`feature_registry`** — +`ai_import_linkedin` → **30 entries / 29 gateable**; count assertions updated across registry/entitlement/admin tests.

## Testing
- `test_linkedin_import.py` LinkedIn section incl. a **socket-blocked offline proof**; full combined suite (url + linkedin + registry + entitlement + admin + parity) green locally. `ruff` clean. Synchronous endpoint — Modal parity green, no worker function.

> Note: the URL-import backend (Phase 2) already merged via #1057 due to branch interleaving during parallel builds; #1059 was closed in favor of this LinkedIn-only delta.