### PR TITLE
docs(config): document empty/localhost-default settings in .env.example (#980)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,7 +21,15 @@ DB_NAME=latexy
 
 # ── Redis ─────────────────────────────────────────────────────────────────────
 REDIS_URL=redis://localhost:6379/0
+# Cache + quota-meter Redis (defaults to localhost DB 1). Set this in every
+# deployed environment — the startup validator flags it, but a localhost value
+# silently sends caching and the plan quota meter to a Redis that isn't there.
+REDIS_CACHE_URL=redis://localhost:6379/1
 REDIS_PASSWORD=
+# Upstash Redis REST endpoint + token (empty default). Only needed if you use
+# Upstash's REST API path instead of the standard REDIS_URL connection.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
 
 # ── Celery ────────────────────────────────────────────────────────────────────
 CELERY_BROKER_URL=redis://localhost:6379/0
@@ -32,6 +40,9 @@ CELERY_RESULT_BACKEND=redis://localhost:6379/0
 BETTER_AUTH_SECRET=change-me-generate-with-openssl-rand-hex-32
 # URL of the frontend service (for Better Auth cross-origin validation)
 BETTER_AUTH_URL=http://localhost:5180
+# Public frontend base URL used to build share links (defaults to localhost).
+# Set this to your deployed frontend origin or share links point at localhost.
+FRONTEND_URL=http://localhost:5180
 # Legacy JWT secret (for existing tokens during migration)
 JWT_SECRET_KEY=change-me-generate-with-openssl-rand-hex-32
 JWT_ALGORITHM=HS256
@@ -81,11 +92,44 @@ MINIO_BUCKET=latexy
 # Comma-separated list of allowed origins (include your frontend URL)
 CORS_ORIGINS=http://localhost:5180,http://127.0.0.1:5180,http://localhost:3000
 
-# ── OAuth (optional social login) ─────────────────────────────────────────────
+# ── OAuth (optional social login + integrations) ──────────────────────────────
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+# OAuth callback URLs (default to localhost:8030). Set these to your deployed
+# backend origin, and register the same URL in the provider's app settings, or
+# the GitHub repo-sync / project-import and Dropbox flows redirect to localhost.
+GITHUB_OAUTH_REDIRECT_URI=http://localhost:8030/github/callback
+DROPBOX_REDIRECT_URI=http://localhost:8030/dropbox/callback
+
+# ── Admin access ──────────────────────────────────────────────────────────────
+# Who may reach /admin/* (empty by default → no admin users). ADMIN_EMAIL is a
+# single email; ADMIN_EMAILS is a comma-separated list; the effective set is
+# their union. ADMIN_SECRET_KEY guards the template/admin utility endpoints.
+ADMIN_EMAIL=
+ADMIN_EMAILS=
+ADMIN_SECRET_KEY=
+
+# ── GeoIP (optional) ──────────────────────────────────────────────────────────
+# URL template with an {ip} placeholder for GeoIP lookups. Empty = disabled.
+GEOIP_PROVIDER_URL=
+
+# ── Reference-manager & storage integrations (optional) ───────────────────────
+# All empty by default → the respective integration is disabled. Set the OAuth
+# credentials + a deployed https callback URL to enable each.
+ZOTERO_CLIENT_KEY=
+ZOTERO_CLIENT_SECRET=
+ZOTERO_REDIRECT_URI=
+MENDELEY_CLIENT_ID=
+MENDELEY_CLIENT_SECRET=
+MENDELEY_REDIRECT_URI=
+DROPBOX_APP_KEY=
+DROPBOX_APP_SECRET=
+
+# ── Spell/grammar check (optional) ────────────────────────────────────────────
+# If set, use a self-hosted LanguageTool server instead of the public API.
+LANGUAGETOOL_LOCAL_URL=
 
 # ── Payments (Razorpay) ───────────────────────────────────────────────────────
 # Billing mode:
@@ -96,10 +140,27 @@ BILLING_MODE=auto
 RAZORPAY_KEY_ID=
 RAZORPAY_KEY_SECRET=
 RAZORPAY_WEBHOOK_SECRET=
+# Razorpay subscription plan IDs (empty by default). Required for paid checkout
+# when BILLING_MODE is auto/required — each maps a plan tier to its dashboard plan.
+RAZORPAY_PLAN_BASIC_MONTHLY=
+RAZORPAY_PLAN_BASIC_ANNUAL=
+RAZORPAY_PLAN_PRO_MONTHLY=
+RAZORPAY_PLAN_PRO_ANNUAL=
+RAZORPAY_PLAN_BYOK_MONTHLY=
+RAZORPAY_PLAN_BYOK_ANNUAL=
+RAZORPAY_PLAN_STUDENT=
+RAZORPAY_PLAN_TEAM=
 # Razorpay applies subscription discounts through offers, so a percentage coupon
 # is only accepted at checkout when it is mapped to an offer created in the
 # Razorpay dashboard: {"LAUNCH20": "offer_XXXXXXXX"}
 RAZORPAY_COUPON_OFFERS=
+
+# ── Observability (optional — OpenTelemetry) ──────────────────────────────────
+# All empty by default (tracing disabled). Set OTEL_EXPORTER_MODE=otlp plus the
+# endpoint/headers to export traces to a collector (e.g. Grafana Tempo, Honeycomb).
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_HEADERS=
+OTEL_RESOURCE_ATTRIBUTES=
 
 # ── Job / Queue Settings ──────────────────────────────────────────────────────
 JOB_RESULT_TTL=86400

--- a/backend/test/test_env_example_documents_settings.py
+++ b/backend/test/test_env_example_documents_settings.py
@@ -1,0 +1,88 @@
+"""Guard: every risk-class setting is documented in .env.example (#980).
+
+The risk class is a config default that is **empty** or points at **localhost** —
+exactly the defaults that are silently wrong in a deployed environment (a boot
+assert fires, or a service quietly talks to a Redis/Minio/URL that isn't there).
+Genuinely-safe defaults (timeouts, pool sizes, feature flags) are not the concern.
+
+This test parses ``app/core/config.py`` for those settings and asserts each is
+present in ``.env.example``, so the deployed Modal secret has a source of truth
+and new empty/localhost settings can't be added without documenting them.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent
+_CONFIG = _BACKEND / "app" / "core" / "config.py"
+_ENV_EXAMPLE = _BACKEND / ".env.example"
+
+
+def _string_default(value: ast.expr | None) -> str | None:
+    """Extract a string default from an annotation value, or None if not a plain string.
+
+    Handles both ``NAME: str = "..."`` and ``NAME: str = Field(default="...")`` /
+    ``Field("...")``. Non-string defaults (Field(default_factory=...), numbers,
+    bools) return None and are ignored.
+    """
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return value.value
+    if isinstance(value, ast.Call) and getattr(value.func, "id", None) == "Field":
+        for kw in value.keywords:
+            if kw.arg == "default" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                return kw.value.value
+        for arg in value.args:  # Field's first positional is the default
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                return arg.value
+    return None
+
+
+def _is_risk_default(default: str) -> bool:
+    return default == "" or "localhost" in default or "127.0.0.1" in default
+
+
+def _risk_settings() -> dict[str, str]:
+    tree = ast.parse(_CONFIG.read_text())
+    settings_cls = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == "Settings"),
+        None,
+    )
+    assert settings_cls is not None, "Settings class not found in config.py"
+
+    risk: dict[str, str] = {}
+    for stmt in settings_cls.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            default = _string_default(stmt.value)
+            if default is not None and _is_risk_default(default):
+                risk[stmt.target.id] = default
+    return risk
+
+
+def _documented_keys() -> set[str]:
+    keys: set[str] = set()
+    for line in _ENV_EXAMPLE.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            keys.add(line.split("=", 1)[0].strip())
+    return keys
+
+
+def test_risk_class_settings_are_documented_in_env_example():
+    risk = _risk_settings()
+    documented = _documented_keys()
+    missing = sorted(k for k in risk if k not in documented)
+    assert not missing, (
+        "These settings default to empty-or-localhost but are undocumented in "
+        f".env.example (see #980): {missing}"
+    )
+
+
+def test_finds_a_meaningful_number_of_risk_settings():
+    # Sanity check the parser actually resolves defaults (guards against a silent
+    # parse change that would make the guard above vacuously pass).
+    risk = _risk_settings()
+    assert "REDIS_CACHE_URL" in risk
+    assert "DATABASE_URL" in risk
+    assert len(risk) >= 20


### PR DESCRIPTION
Closes #980.

Production (the Modal secret) had no source of truth for what must be set — the risk class being any config default that is **empty** or points at **localhost** (the ones that are silently wrong when deployed; #954/#956 both traced here). Genuinely-safe defaults (timeouts, pool sizes, feature flags) are out of scope.

## What's in it
- **`.env.example`** — documents the risk-class settings that were missing: `REDIS_CACHE_URL`, `FRONTEND_URL`, `UPSTASH_REDIS_REST_URL/TOKEN`, `GITHUB_OAUTH_REDIRECT_URI`, `DROPBOX_REDIRECT_URI`, `ADMIN_EMAIL/ADMIN_EMAILS/ADMIN_SECRET_KEY`, `GEOIP_PROVIDER_URL`, the 8 `RAZORPAY_PLAN_*` IDs, `OTEL_EXPORTER_OTLP_*`/`OTEL_RESOURCE_ATTRIBUTES`, the Zotero/Mendeley/Dropbox integration creds, and `LANGUAGETOOL_LOCAL_URL` — each with a note on the deployment consequence of leaving it at its default.
- **`test_env_example_documents_settings.py`** — a guard that parses `config.py` for every empty/localhost-defaulting setting and asserts each is documented in `.env.example`. Now covers **61** risk-class settings, so a new one can't be added without documenting it (kills the drift that caused this).

## Testing
- 2 tests pass; `ruff` clean. Docs-only + test — no runtime change.