### PR TITLE
Redesign Phase 2: marketing shell (Typeset)

### DIFF
--- a/frontend/src/app/developer/page.tsx
+++ b/frontend/src/app/developer/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
+import { KeyRound, Trash2 } from 'lucide-react'
 import { useSession } from '@/lib/auth-client'
 import {
   apiClient,
@@ -12,6 +13,19 @@ import {
 } from '@/lib/api-client'
 
 type ExampleTab = 'curl' | 'python' | 'node'
+
+const reveal = 'motion-safe:animate-[fade-in-up_.7s_cubic-bezier(.2,.7,.2,1)_both]'
+
+const primaryBtn =
+  'inline-flex items-center justify-center rounded-[var(--radius-md)] bg-accent px-5 py-2.5 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-accent-fg transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:opacity-50 motion-reduce:transition-none'
+
+const ghostBtn =
+  'inline-flex items-center justify-center rounded-[var(--radius-md)] border border-line-2 px-4 py-2.5 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-fg transition duration-150 hover:border-accent hover:text-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:opacity-50 motion-reduce:transition-none'
+
+const fieldInput =
+  'w-full rounded-[var(--radius-md)] border border-line-2 bg-surface px-3 py-2.5 font-body text-sm text-fg outline-none transition duration-150 placeholder:text-fg-3 focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none'
+
+const label = 'font-ui text-[0.62rem] uppercase tracking-[0.16em] text-fg-3'
 
 export default function DeveloperPage() {
   const { data: session, isPending } = useSession()
@@ -137,125 +151,158 @@ console.log(payload);`,
 
   if (isPending || !session) {
     return (
-      <div className="content-shell">
-        <div className="surface-panel edge-highlight p-6 sm:p-8 text-slate-300">
-          Loading developer portal...
+      <div className="mx-auto max-w-6xl px-5 py-16 sm:px-8">
+        <div className="border border-line bg-surface p-6 font-ui text-sm text-fg-3 sm:p-8">
+          Loading developer portal…
         </div>
       </div>
     )
   }
 
   return (
-    <div className="content-shell">
-      <div className="space-y-6">
-        <section className="surface-panel edge-highlight p-6 sm:p-8">
-          <h1 className="text-3xl font-bold text-white tracking-tight">Developer API</h1>
-          <p className="mt-2 max-w-2xl text-zinc-400">
-            Create stable API keys for compile, optimize, and ATS workflows. Keys are shown only once and are rate-limited by your current plan.
-          </p>
-        </section>
+    <div className="bg-bg text-fg">
+      {/* folio strip */}
+      <div className="border-b border-line">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-2 font-ui text-[0.62rem] uppercase tracking-[0.16em] text-fg-3 sm:px-8">
+          <span>№ 07 — Developer API</span>
+          <span className="hidden sm:inline">Bearer keys · rate-limited by plan</span>
+          <span>compile · optimize · ats</span>
+        </div>
+      </div>
 
-        <section className="surface-panel edge-highlight p-5 sm:p-6">
-          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <h2 className="text-lg font-semibold text-white">API keys</h2>
-              <p className="mt-1 text-sm text-slate-400">Maximum 5 active keys per account.</p>
-            </div>
+      {/* ── hero ── */}
+      <section className={`mx-auto max-w-6xl px-5 py-14 sm:px-8 lg:py-20 ${reveal}`}>
+        <span className={label}>The API</span>
+        <h1 className="mt-5 max-w-[18ch] text-balance font-display text-[clamp(2.4rem,6vw,4.4rem)] font-semibold leading-[0.98] tracking-[-0.025em] text-fg">
+          Compile, optimize, and score — <em className="italic text-accent">from your own stack.</em>
+        </h1>
+        <p className="mt-6 max-w-[52ch] font-body text-lg text-fg-2">
+          Create stable API keys for compile, optimize, and ATS workflows. Keys are shown only once and
+          are rate-limited by your current plan.
+        </p>
+      </section>
+
+      {/* ── § 1 · API keys ── */}
+      <section className="mx-auto max-w-6xl px-5 pb-14 sm:px-8">
+        <div className="mb-6 flex items-baseline gap-3 border-b border-line pb-4">
+          <span className="font-ui text-sm text-accent-strong">§ 1</span>
+          <h2 className="font-display text-[clamp(1.5rem,3vw,2.1rem)] font-semibold text-fg">API keys</h2>
+          <span className="ml-auto font-ui text-xs text-fg-3">Maximum 5 active keys per account</span>
+        </div>
+
+        {/* create */}
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row">
+          <label htmlFor="new-key-name" className="sr-only">
+            New key name
+          </label>
+          <input
+            id="new-key-name"
+            value={createName}
+            onChange={(event) => setCreateName(event.target.value)}
+            placeholder="Production integration"
+            className={fieldInput}
+          />
+          <button
+            onClick={handleCreateKey}
+            disabled={busyKeyId === 'new' || !createName.trim()}
+            className={`${primaryBtn} shrink-0`}
+          >
+            {busyKeyId === 'new' ? 'Creating…' : 'Create key'}
+          </button>
+        </div>
+
+        {createdKey && (
+          <div className="mb-6 rounded-[var(--radius-md)] border border-accent bg-accent-soft p-4">
+            <p className="flex items-center gap-2 font-ui text-xs uppercase tracking-[0.14em] text-accent-strong">
+              <KeyRound className="h-4 w-4" aria-hidden="true" />
+              Copy this key now — it will never be shown again
+            </p>
+            <code className="mt-3 block overflow-x-auto rounded-[var(--radius-sm)] bg-code-bg p-3 font-ui text-sm text-code-fg">
+              {createdKey.full_key}
+            </code>
           </div>
+        )}
 
-          <div className="mb-5 flex flex-col gap-3 sm:flex-row">
-            <input
-              value={createName}
-              onChange={(event) => setCreateName(event.target.value)}
-              placeholder="Production integration"
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none placeholder:text-slate-500"
-            />
-            <button
-              onClick={handleCreateKey}
-              disabled={busyKeyId === 'new' || !createName.trim()}
-              className="rounded-lg bg-orange-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-orange-200 disabled:opacity-60"
-            >
-              {busyKeyId === 'new' ? 'Creating...' : 'Create key'}
-            </button>
+        {loading ? (
+          <div className="border border-line bg-surface p-4 font-ui text-sm text-fg-3">Loading keys…</div>
+        ) : keys.length === 0 ? (
+          <div className="border border-line bg-surface p-4 font-ui text-sm text-fg-3">
+            No developer API keys yet.
           </div>
-
-          {createdKey && (
-            <div className="mb-5 rounded-xl border border-amber-300/30 bg-amber-300/10 p-4">
-              <p className="text-sm font-semibold text-amber-100">Copy this key now. It will never be shown again.</p>
-              <code className="mt-3 block overflow-x-auto rounded-lg bg-black/50 p-3 text-sm text-white">{createdKey.full_key}</code>
-            </div>
-          )}
-
-          {loading ? (
-            <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-slate-300">Loading keys...</div>
-          ) : (
-            <div className="space-y-3">
-              {keys.length === 0 ? (
-                <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-sm text-slate-400">
-                  No developer API keys yet.
-                </div>
-              ) : (
-                keys.map((key) => (
-                  <div key={key.id} className="rounded-xl border border-white/10 bg-slate-950/60 p-4">
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <div>
-                        <p className="text-sm font-semibold text-white">{key.key_prefix}</p>
-                        <p className="mt-1 text-xs text-slate-400">
-                          {key.request_count} requests • last used {key.last_used_at ? new Date(key.last_used_at).toLocaleString() : 'never'}
-                        </p>
-                      </div>
-                      <button
-                        onClick={() => handleRevoke(key.id)}
-                        disabled={busyKeyId === key.id}
-                        className="rounded-lg border border-rose-300/30 bg-rose-300/10 px-3 py-2 text-sm text-rose-100 hover:bg-rose-300/20 disabled:opacity-60"
-                      >
-                        Revoke
-                      </button>
-                    </div>
-                    <div className="mt-3 flex flex-col gap-3 sm:flex-row">
-                      <input
-                        value={renaming[key.id] ?? ''}
-                        onChange={(event) => setRenaming((current) => ({ ...current, [key.id]: event.target.value }))}
-                        className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none"
-                      />
-                      <button
-                        onClick={() => handleRename(key.id)}
-                        disabled={busyKeyId === key.id}
-                        className="rounded-lg border border-white/15 px-4 py-2 text-sm text-slate-100 hover:bg-white/10 disabled:opacity-60"
-                      >
-                        Rename
-                      </button>
-                    </div>
+        ) : (
+          <div className="overflow-hidden rounded-[var(--radius-lg)] border border-line">
+            {keys.map((key, i) => (
+              <div key={key.id} className={`bg-surface p-5 ${i > 0 ? 'border-t border-line' : ''}`}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="font-ui text-sm font-semibold text-fg">{key.key_prefix}</p>
+                    <p className="mt-1 font-ui text-xs text-fg-3">
+                      {key.request_count} requests · last used{' '}
+                      {key.last_used_at ? new Date(key.last_used_at).toLocaleString() : 'never'}
+                    </p>
                   </div>
-                ))
-              )}
-            </div>
-          )}
-        </section>
-
-        <section className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
-          <div className="surface-panel edge-highlight min-w-0 p-5 sm:p-6">
-            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <h2 className="text-lg font-semibold text-white">Usage</h2>
-                <p className="mt-1 text-sm text-slate-400">
-                  {usage ? `Current plan: ${usage.plan_id} • ${usage.daily_limit} requests/day` : 'Rate limit history'}
-                </p>
+                  <button
+                    onClick={() => handleRevoke(key.id)}
+                    disabled={busyKeyId === key.id}
+                    className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-line-2 px-3 py-2 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-err transition duration-150 hover:border-err focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:opacity-50 motion-reduce:transition-none"
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    Revoke
+                  </button>
+                </div>
+                <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                  <label htmlFor={`rename-${key.id}`} className="sr-only">
+                    Rename key
+                  </label>
+                  <input
+                    id={`rename-${key.id}`}
+                    value={renaming[key.id] ?? ''}
+                    onChange={(event) =>
+                      setRenaming((current) => ({ ...current, [key.id]: event.target.value }))
+                    }
+                    className={fieldInput}
+                  />
+                  <button
+                    onClick={() => handleRename(key.id)}
+                    disabled={busyKeyId === key.id}
+                    className={`${ghostBtn} shrink-0`}
+                  >
+                    Rename
+                  </button>
+                </div>
               </div>
-            </div>
+            ))}
+          </div>
+        )}
+      </section>
 
-            <div className="space-y-3">
+      {/* ── § 2 · usage + docs ── */}
+      <section className="mx-auto max-w-6xl px-5 pb-20 sm:px-8">
+        <div className="grid gap-8 xl:grid-cols-[1.2fr_1fr]">
+          {/* usage */}
+          <div className="min-w-0">
+            <div className="mb-6 flex items-baseline gap-3 border-b border-line pb-4">
+              <span className="font-ui text-sm text-accent-strong">§ 2</span>
+              <h2 className="font-display text-[clamp(1.5rem,3vw,2.1rem)] font-semibold text-fg">Usage</h2>
+            </div>
+            <p className="mb-5 font-ui text-xs text-fg-3">
+              {usage
+                ? `Current plan: ${usage.plan_id} · ${usage.daily_limit} requests/day`
+                : 'Rate limit history'}
+            </p>
+
+            <div className="space-y-4">
               {(usage?.history || []).map((point) => {
                 const max = Math.max(...(usage?.history.map((entry) => entry.count) || [1]), 1)
                 const width = `${Math.max((point.count / max) * 100, point.count > 0 ? 6 : 0)}%`
                 return (
                   <div key={point.date}>
-                    <div className="mb-1 flex items-center justify-between text-sm text-slate-300">
+                    <div className="mb-1.5 flex items-center justify-between font-ui text-xs text-fg-2">
                       <span>{point.date}</span>
-                      <span>{point.count}</span>
+                      <span className="text-fg">{point.count}</span>
                     </div>
-                    <div className="h-2 rounded-full bg-white/10">
-                      <div className="h-2 rounded-full bg-orange-300" style={{ width }} />
+                    <div className="h-2 rounded-[var(--radius-pill)] bg-surface-2">
+                      <div className="h-2 rounded-[var(--radius-pill)] bg-accent" style={{ width }} />
                     </div>
                   </div>
                 )
@@ -263,29 +310,59 @@ console.log(payload);`,
             </div>
           </div>
 
-          <div className="surface-panel edge-highlight min-w-0 p-5 sm:p-6">
-            <h2 className="text-lg font-semibold text-white">Documentation</h2>
-            <div className="mt-4 inline-flex rounded-xl border border-white/10 bg-slate-950/70 p-1">
+          {/* docs */}
+          <div className="min-w-0">
+            <div className="mb-6 flex items-baseline gap-3 border-b border-line pb-4">
+              <span className="font-ui text-sm text-accent-strong">§ 3</span>
+              <h2 className="font-display text-[clamp(1.5rem,3vw,2.1rem)] font-semibold text-fg">
+                Documentation
+              </h2>
+            </div>
+
+            <div
+              role="tablist"
+              aria-label="Code examples"
+              className="inline-flex gap-1 rounded-[var(--radius-md)] border border-line bg-surface p-1"
+            >
               {(['curl', 'python', 'node'] as ExampleTab[]).map((tab) => (
                 <button
                   key={tab}
+                  role="tab"
+                  aria-selected={activeTab === tab}
                   onClick={() => setActiveTab(tab)}
-                  className={`rounded-lg px-4 py-2 text-sm capitalize ${activeTab === tab ? 'bg-orange-300 text-slate-950' : 'text-slate-300'}`}
+                  className={`rounded-[var(--radius-sm)] px-4 py-2 font-ui text-xs uppercase tracking-[0.06em] transition duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none ${
+                    activeTab === tab
+                      ? 'bg-accent text-accent-fg'
+                      : 'text-fg-3 hover:text-fg'
+                  }`}
                 >
                   {tab}
                 </button>
               ))}
             </div>
-            <pre className="mt-4 max-w-full overflow-x-auto rounded-xl border border-white/10 bg-black/50 p-4 text-xs text-slate-200">
+
+            <pre className="mt-4 max-w-full overflow-x-auto rounded-[var(--radius-md)] border border-line bg-code-bg p-4 font-ui text-xs leading-relaxed text-code-fg">
               {codeExamples[activeTab]}
             </pre>
-            <div className="mt-4 space-y-2 text-sm text-slate-300">
-              <p className="break-words">Available endpoints: `POST /api/v1/compile`, `POST /api/v1/optimize`, `POST /api/v1/ats/score`, `GET /api/v1/jobs/{'{job_id}'}`.</p>
-              <p className="break-words">Interactive backend docs: {(process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8030')}/docs</p>
+
+            <div className="mt-5 space-y-2 border-t border-line pt-4 font-body text-sm text-fg-2">
+              <p className="break-words">
+                <span className={label}>Endpoints</span>{' '}
+                <code className="font-ui text-xs text-code-fg">POST /api/v1/compile</code>,{' '}
+                <code className="font-ui text-xs text-code-fg">POST /api/v1/optimize</code>,{' '}
+                <code className="font-ui text-xs text-code-fg">POST /api/v1/ats/score</code>,{' '}
+                <code className="font-ui text-xs text-code-fg">GET /api/v1/jobs/{'{job_id}'}</code>.
+              </p>
+              <p className="break-words">
+                <span className={label}>Interactive docs</span>{' '}
+                <span className="text-accent-strong">
+                  {(process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8030')}/docs
+                </span>
+              </p>
             </div>
           </div>
-        </section>
-      </div>
+        </div>
+      </section>
     </div>
   )
 }

--- a/frontend/src/app/faq/page.tsx
+++ b/frontend/src/app/faq/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { MotionItem, MotionReveal, MotionStagger } from '@/components/marketing/MotionPrimitives'
 
 const faqs = [
@@ -21,22 +22,60 @@ const faqs = [
 
 export default function FAQPage() {
   return (
-    <div className="content-shell py-12">
-      <MotionReveal>
-        <p className="overline">FAQ</p>
-        <h1 className="section-title mt-2 text-white">Clear answers for product, workflow, and reliability.</h1>
-      </MotionReveal>
+    <div className="bg-bg text-fg">
+      {/* ── masthead ── */}
+      <section className="mx-auto max-w-6xl px-5 py-16 sm:px-8 lg:py-24">
+        <MotionReveal>
+          <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">
+            Frequently asked
+          </p>
+          <h1 className="mt-5 max-w-[20ch] text-balance font-display text-[clamp(2.4rem,6vw,4.4rem)] font-semibold leading-[1.0] tracking-[-0.025em] text-fg">
+            Clear answers for product, workflow, and reliability.
+          </h1>
+          <p className="mt-6 max-w-[46ch] font-body text-lg text-fg-2">
+            The questions we hear most, answered plainly — no fine print, no fabricated numbers.
+          </p>
+        </MotionReveal>
+      </section>
 
-      <MotionStagger className="mt-8 grid gap-4 md:grid-cols-2">
-        {faqs.map((item) => (
-          <MotionItem key={item.q}>
-            <article className="surface-card edge-highlight p-5 transition duration-300 hover:-translate-y-1 hover:border-orange-200/30">
-              <h2 className="text-lg font-semibold text-white">{item.q}</h2>
-              <p className="mt-2 text-zinc-300">{item.a}</p>
-            </article>
-          </MotionItem>
-        ))}
-      </MotionStagger>
+      {/* ── the list, set as hairline-ruled entries ── */}
+      <section className="border-t border-line">
+        <MotionStagger className="mx-auto max-w-6xl px-5 sm:px-8">
+          {faqs.map((item, i) => (
+            <MotionItem key={item.q}>
+              <article className="grid gap-4 border-b border-line py-8 md:grid-cols-[auto_1fr] md:gap-10">
+                <span className="font-ui text-xs uppercase tracking-[0.16em] text-accent-strong md:pt-1.5">
+                  § {i + 1}
+                </span>
+                <div>
+                  <h2 className="text-balance font-display text-[clamp(1.35rem,2.4vw,1.85rem)] font-semibold leading-snug text-fg">
+                    {item.q}
+                  </h2>
+                  <p className="mt-3 max-w-[62ch] font-body text-base leading-relaxed text-fg-2">
+                    {item.a}
+                  </p>
+                </div>
+              </article>
+            </MotionItem>
+          ))}
+        </MotionStagger>
+      </section>
+
+      {/* ── closing prompt ── */}
+      <section className="mx-auto max-w-6xl px-5 py-20 text-center sm:px-8">
+        <h2 className="text-balance font-display text-[clamp(1.8rem,4.5vw,3rem)] font-semibold leading-[1.04] tracking-[-0.02em] text-fg">
+          Still have a question?
+        </h2>
+        <p className="mx-auto mt-5 max-w-[42ch] font-body text-fg-2">
+          The fastest answer is a compile. Bring your own key or use ours — three free runs, no card.
+        </p>
+        <Link
+          href="/try"
+          className="mt-8 inline-flex items-center rounded-[var(--radius-md)] bg-accent px-8 py-3.5 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-accent-fg transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+        >
+          Open the studio →
+        </Link>
+      </section>
     </div>
   )
 }

--- a/frontend/src/app/platform/page.tsx
+++ b/frontend/src/app/platform/page.tsx
@@ -1,72 +1,155 @@
 import Link from 'next/link'
-import { MotionItem, MotionReveal, MotionStagger } from '@/components/marketing/MotionPrimitives'
+import { FileText, GitBranch, Radio, KeyRound } from 'lucide-react'
+
+/**
+ * Platform page — "Typeset" re-skin.
+ * Server-rendered, token-driven, CSS-only motion. Honest copy; fabricated
+ * SLA/latency/volume numbers removed in favour of facts we can stand behind.
+ */
+
+const reveal = 'motion-safe:animate-[fade-in-up_.7s_cubic-bezier(.2,.7,.2,1)_both]'
 
 const capabilities = [
   {
+    n: '§ 1',
+    icon: FileText,
     title: 'AI Rewrite Pipeline',
-    copy: 'Context-aware rewrite of bullets with conservative, balanced, and aggressive modes.',
+    copy: 'Context-aware rewrite of bullets with conservative, balanced, and aggressive modes — you accept, reject, or edit each change.',
   },
   {
+    n: '§ 2',
+    icon: Radio,
     title: 'ATS Signal Engine',
-    copy: 'Keyword alignment, section structure confidence, and role-fit scoring.',
+    copy: 'Keyword alignment, section-structure confidence, and role-fit scoring — measured against the actual job description, not a vanity number.',
   },
   {
+    n: '§ 3',
+    icon: GitBranch,
     title: 'Live Job Streaming',
-    copy: 'Observe queue state, progress, and logs in real-time while runs execute.',
+    copy: 'Observe queue state, progress, and compile logs in real time over WebSocket while runs execute.',
   },
   {
+    n: '§ 4',
+    icon: KeyRound,
     title: 'BYOK Security',
-    copy: 'Encrypted provider key storage with controlled runtime decryption.',
+    copy: 'Encrypted provider-key storage with controlled runtime decryption — your key, your models, never logged.',
   },
+]
+
+const facts: [string, string][] = [
+  ['Compile speed', 'Sub-second'],
+  ['Model providers', 'OpenAI · Anthropic · Gemini · OpenRouter'],
+  ['Change review', 'Per-line accept / reject / edit'],
+  ['Engines', 'pdflatex · xelatex · lualatex'],
 ]
 
 export default function PlatformPage() {
   return (
-    <div className="content-shell py-12">
-      <MotionReveal>
-        <section className="grid gap-5 lg:grid-cols-[1.15fr_0.85fr]">
-          <div>
-            <p className="overline">Platform</p>
-            <h1 className="section-title mt-2 text-white">A full execution layer for resume operations.</h1>
-            <p className="mt-4 max-w-2xl text-zinc-300">
-              Latexy is built for job seekers and teams that need deterministic output, measurable ATS performance, and high iteration speed.
-            </p>
-            <div className="mt-6 flex flex-wrap gap-3">
-              <Link href="/try" className="btn-accent">Open Studio</Link>
-              <Link href="/dashboard" className="btn-ghost">View Dashboard</Link>
-            </div>
-          </div>
+    <div className="bg-bg text-fg">
+      {/* folio strip */}
+      <div className="border-b border-line">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-2 font-ui text-[0.62rem] uppercase tracking-[0.16em] text-fg-3 sm:px-8">
+          <span>№ 02 — The Platform</span>
+          <span className="hidden sm:inline">Execution layer for résumé operations</span>
+          <span>REST · WebSocket · Celery</span>
+        </div>
+      </div>
 
-          <div className="surface-card edge-highlight p-5">
-            <p className="overline">System Snapshot</p>
-            <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              {[
-                ['Compile SLA', '99.2%'],
-                ['Median Latency', '8.4s'],
-                ['Monthly Jobs', '150k+'],
-                ['Model Providers', '3'],
-              ].map(([k, v]) => (
-                <div key={k} className="rounded-lg border border-white/10 bg-black/40 p-3">
-                  <p className="text-xs text-zinc-500">{k}</p>
-                  <p className="mt-1 text-lg text-white">{v}</p>
+      {/* ── hero ── */}
+      <section className="mx-auto grid max-w-6xl gap-10 px-5 py-16 sm:px-8 lg:grid-cols-[1.15fr_.85fr] lg:items-center lg:py-24">
+        <div className={reveal}>
+          <span className="font-ui text-xs uppercase tracking-[0.18em] text-fg-3">Platform</span>
+          <h1 className="mt-5 font-display text-[clamp(2.4rem,6vw,4.6rem)] font-semibold leading-[1.0] tracking-[-0.025em] text-balance text-fg">
+            A full execution layer for <em className="italic text-accent">résumé operations.</em>
+          </h1>
+          <p className="mt-6 max-w-[46ch] font-body text-lg text-fg-2">
+            Latexy is built for job seekers and teams that need deterministic output, measurable ATS
+            performance, and high iteration speed.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Link
+              href="/try"
+              className="inline-flex items-center rounded-[var(--radius-md)] bg-accent px-6 py-3 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-accent-fg transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+            >
+              Open Studio →
+            </Link>
+            <Link
+              href="/dashboard"
+              className="inline-flex items-center rounded-[var(--radius-md)] border border-line-2 px-6 py-3 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-fg transition duration-150 hover:border-accent hover:text-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+            >
+              View Dashboard
+            </Link>
+          </div>
+        </div>
+
+        {/* system snapshot — honest facts */}
+        <div
+          className={`relative rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)] ${reveal} motion-safe:[animation-delay:.12s]`}
+        >
+          <div className="absolute -top-2.5 left-5 bg-surface px-2 font-ui text-[0.6rem] uppercase tracking-[0.14em] text-fg-3">
+            System Snapshot
+          </div>
+          <dl className="mt-2 divide-y divide-line">
+            {facts.map(([k, v]) => (
+              <div key={k} className="flex items-baseline justify-between gap-4 py-3 first:pt-1">
+                <dt className="font-ui text-[0.62rem] uppercase tracking-[0.16em] text-fg-3">{k}</dt>
+                <dd className="text-right font-body text-sm text-fg">{v}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      {/* ── trust strip ── */}
+      <div className="border-y border-line bg-surface-2">
+        <div className="mx-auto flex max-w-6xl flex-wrap gap-x-8 gap-y-2 px-5 py-3 font-ui text-xs text-fg-3 sm:px-8">
+          <span><span className="text-fg">Deterministic</span> compiles</span>
+          <span><span className="text-fg">Measurable</span> ATS performance</span>
+          <span><span className="text-accent-strong">BYOK</span> — your key, your models</span>
+          <span><span className="text-fg">Real-time</span> job streaming</span>
+        </div>
+      </div>
+
+      {/* ── capabilities ── */}
+      <section className="mx-auto max-w-6xl px-5 py-16 sm:px-8">
+        <div className="mb-8 flex items-baseline gap-3">
+          <span className="font-ui text-xs uppercase tracking-[0.18em] text-fg-3">Capabilities</span>
+          <span className="h-px flex-1 bg-line" />
+        </div>
+        <div className="grid gap-px overflow-hidden rounded-[var(--radius-lg)] border border-line bg-line md:grid-cols-2">
+          {capabilities.map((item) => {
+            const Icon = item.icon
+            return (
+              <article key={item.title} className="bg-surface p-6">
+                <div className="flex items-center gap-2">
+                  <span className="font-ui text-xs text-accent-strong">{item.n}</span>
+                  <Icon className="h-4 w-4 text-fg-3" aria-hidden="true" strokeWidth={1.5} />
                 </div>
-              ))}
-            </div>
-          </div>
-        </section>
-      </MotionReveal>
+                <h2 className="mt-4 font-display text-xl font-semibold text-fg">{item.title}</h2>
+                <p className="mt-2 font-body text-sm leading-relaxed text-fg-2">{item.copy}</p>
+              </article>
+            )
+          })}
+        </div>
+      </section>
 
-      <MotionStagger className="mt-8 grid gap-4 md:grid-cols-2">
-        {capabilities.map((item) => (
-          <MotionItem key={item.title}>
-            <article className="surface-card edge-highlight p-5 transition duration-300 hover:-translate-y-1 hover:border-orange-200/30">
-              <p className="overline">Capability</p>
-              <h2 className="mt-3 text-xl font-semibold text-white">{item.title}</h2>
-              <p className="mt-2 text-zinc-300">{item.copy}</p>
-            </article>
-          </MotionItem>
-        ))}
-      </MotionStagger>
+      {/* ── closing ── */}
+      <section className="border-t border-line">
+        <div className="mx-auto max-w-6xl px-5 py-20 text-center sm:px-8">
+          <h2 className="font-display text-[clamp(2rem,5vw,3.4rem)] font-semibold leading-[1.02] tracking-[-0.02em] text-balance text-fg">
+            Run résumés like <em className="italic text-accent">infrastructure.</em>
+          </h2>
+          <p className="mx-auto mt-5 max-w-[42ch] font-body text-fg-2">
+            Deterministic output, measurable performance, and iteration speed — from a single studio.
+          </p>
+          <Link
+            href="/try"
+            className="mt-8 inline-flex items-center rounded-[var(--radius-md)] bg-accent px-8 py-3.5 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-accent-fg transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+          >
+            Open the studio →
+          </Link>
+        </div>
+      </section>
     </div>
   )
 }

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -1,3 +1,118 @@
-import BillingPage from '@/app/billing/page'
+import Link from 'next/link'
+import { Check } from 'lucide-react'
 
-export default BillingPage
+/**
+ * Public pricing page — Typeset marketing (redesign, PRD 2026-08-03).
+ * Was a re-export of the authenticated /billing screen; now a standalone
+ * marketing surface. Live prices + checkout stay on /billing (API-driven), so
+ * this page sells the tiers by value and links there for current numbers.
+ */
+
+export const metadata = {
+  title: 'Pricing | Latexy',
+  description: 'Start free, then pick the plan that fits — or bring your own key.',
+}
+
+type Tier = {
+  id: string
+  name: string
+  tagline: string
+  features: string[]
+  cta: { label: string; href: string }
+  featured?: boolean
+}
+
+const tiers: Tier[] = [
+  {
+    id: 'free',
+    name: 'Free',
+    tagline: 'Try it on a real résumé.',
+    features: ['3 free compiles', 'Per-change accept / reject review', 'ATS score & recommendations', 'Import from GitHub, a URL, or LinkedIn'],
+    cta: { label: 'Start free →', href: '/try' },
+  },
+  {
+    id: 'basic',
+    name: 'Basic',
+    tagline: 'For an active job search.',
+    features: ['Everything in Free', 'More monthly compiles & optimizations', 'Cover letters', 'Version history & variants'],
+    cta: { label: 'Choose Basic', href: '/billing' },
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    tagline: 'The full toolchain.',
+    features: ['Everything in Basic', 'Higher limits & priority compiles', 'All AI tools (steer, batch-tailor, interview prep)', 'Deep ATS analysis'],
+    cta: { label: 'Go Pro', href: '/billing' },
+    featured: true,
+  },
+  {
+    id: 'byok',
+    name: 'BYOK',
+    tagline: 'Your key, your models.',
+    features: ['Bring your own OpenAI / Anthropic / Gemini key', 'Use the models you choose', 'Your usage billed to you', 'All Pro features'],
+    cta: { label: 'Use your key', href: '/billing' },
+  },
+]
+
+export default function PricingPage() {
+  return (
+    <div className="bg-bg text-fg">
+      <div className="border-b border-line">
+        <div className="mx-auto max-w-6xl px-5 py-2 font-ui text-[0.62rem] uppercase tracking-[0.16em] text-fg-3 sm:px-8">
+          Pricing — set once, tailor forever
+        </div>
+      </div>
+
+      <section className="mx-auto max-w-6xl px-5 py-16 sm:px-8">
+        <h1 className="max-w-[18ch] font-display text-[clamp(2.2rem,5.5vw,3.8rem)] font-semibold leading-[1.02] tracking-[-0.025em] text-fg text-balance">
+          Start free. Pay only when it&apos;s working for you.
+        </h1>
+        <p className="mt-5 max-w-[50ch] font-body text-lg text-fg-2">
+          Three free compiles, no card. Upgrade for higher limits and the full AI toolchain, or bring your own key.
+          Current prices and checkout live on your <Link href="/billing" className="text-accent-strong underline-offset-4 hover:underline">billing page</Link>.
+        </p>
+
+        <div className="mt-12 grid gap-px overflow-hidden rounded-[var(--radius-lg)] border border-line bg-line md:grid-cols-2 lg:grid-cols-4">
+          {tiers.map((t) => (
+            <div
+              key={t.id}
+              className={`flex flex-col bg-surface p-6 ${t.featured ? 'ring-1 ring-inset ring-accent' : ''}`}
+            >
+              <div className="flex items-baseline justify-between">
+                <h2 className="font-display text-xl font-semibold text-fg">{t.name}</h2>
+                {t.featured && (
+                  <span className="rounded-[var(--radius-sm)] border border-accent bg-accent-soft px-1.5 py-0.5 font-ui text-[0.6rem] uppercase tracking-[0.12em] text-accent-strong">
+                    Popular
+                  </span>
+                )}
+              </div>
+              <p className="mt-1 font-body text-sm text-fg-2">{t.tagline}</p>
+              <ul className="mt-5 flex-1 space-y-2.5">
+                {t.features.map((f) => (
+                  <li key={f} className="flex gap-2 font-body text-sm text-fg-2">
+                    <Check size={15} className="mt-0.5 shrink-0 text-accent-strong" aria-hidden />
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+              <Link
+                href={t.cta.href}
+                className={`mt-6 inline-flex items-center justify-center rounded-[var(--radius-md)] px-4 py-2.5 font-ui text-sm font-semibold transition duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none ${
+                  t.featured
+                    ? 'bg-accent text-accent-fg hover:brightness-110'
+                    : 'border border-line-2 text-fg hover:border-accent hover:text-accent-strong'
+                }`}
+              >
+                {t.cta.label}
+              </Link>
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-6 font-ui text-xs text-fg-3">
+          Student &amp; team plans available on the billing page. Prices shown there are always current.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/app/resources/page.tsx
+++ b/frontend/src/app/resources/page.tsx
@@ -1,26 +1,37 @@
 import Link from 'next/link'
-import { MotionItem, MotionReveal, MotionStagger } from '@/components/marketing/MotionPrimitives'
 
-const cards = [
+/**
+ * Resources — "Typeset" re-skin. Server-rendered, token-driven, CSS-only motion.
+ * Editorial list of resource entries set as an index with hairline rules and
+ * mono section marks. Content, links, and CTAs preserved from the original.
+ */
+
+const reveal = 'motion-safe:animate-[fade-in-up_.7s_cubic-bezier(.2,.7,.2,1)_both]'
+
+const resources = [
   {
+    n: '§ 1',
     title: 'Guides',
     text: 'Role-specific resume strategy, ATS optimization heuristics, and rewrite frameworks.',
     cta: 'Read Guides',
     href: '/faq',
   },
   {
+    n: '§ 2',
     title: 'Workflows',
     text: 'Operational checklists for weekly resume iteration and job-targeted adaptation.',
     cta: 'See Workflows',
     href: '/platform',
   },
   {
+    n: '§ 3',
     title: 'Templates',
     text: 'LaTeX-ready templates designed for ATS readability and strong visual hierarchy.',
     cta: 'Open Studio',
     href: '/try',
   },
   {
+    n: '§ 4',
     title: 'Best Practices',
     text: 'How to decide when to rewrite, when to trim, and how to benchmark score movement.',
     cta: 'Start Learning',
@@ -30,29 +41,73 @@ const cards = [
 
 export default function ResourcesPage() {
   return (
-    <div className="content-shell py-12">
-      <MotionReveal>
-        <p className="overline">Resources</p>
-        <h1 className="section-title mt-2 text-white">Everything needed to ship better resumes, faster.</h1>
-        <p className="mt-4 max-w-2xl text-zinc-300">
-          Practical resources focused on outcomes: stronger interviews, faster iteration, better scoring confidence.
-        </p>
-      </MotionReveal>
+    <div className="bg-bg text-fg">
+      {/* folio strip */}
+      <div className="border-b border-line">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-2 font-ui text-[0.62rem] uppercase tracking-[0.16em] text-fg-3 sm:px-8">
+          <span>№ 04 — The Resource Index</span>
+          <span className="hidden sm:inline">Guides · Workflows · Templates</span>
+          <span>Read → Compile</span>
+        </div>
+      </div>
 
-      <MotionStagger className="mt-8 grid gap-4 md:grid-cols-2">
-        {cards.map((item) => (
-          <MotionItem key={item.title}>
-            <article className="surface-card edge-highlight p-5 transition duration-300 hover:-translate-y-1 hover:border-orange-200/30">
-              <p className="overline">Resource</p>
-              <h2 className="mt-3 text-xl font-semibold text-white">{item.title}</h2>
-              <p className="mt-2 text-zinc-300">{item.text}</p>
-              <Link href={item.href} className="mt-4 inline-flex text-sm text-orange-200 hover:text-white">
-                {item.cta}
-              </Link>
-            </article>
-          </MotionItem>
-        ))}
-      </MotionStagger>
+      {/* ── header ── */}
+      <section className="mx-auto max-w-6xl px-5 py-16 sm:px-8 lg:py-24">
+        <div className={reveal}>
+          <span className="font-ui text-xs uppercase tracking-[0.18em] text-fg-3">Resources</span>
+          <h1 className="mt-5 max-w-[18ch] text-balance font-display text-[clamp(2.4rem,6vw,4.6rem)] font-semibold leading-[1] tracking-[-0.025em] text-fg">
+            Everything needed to ship <em className="italic text-accent">better resumes</em>, faster.
+          </h1>
+          <p className="mt-6 max-w-[46ch] font-body text-lg text-fg-2">
+            Practical resources focused on outcomes: stronger interviews, faster iteration, better
+            scoring confidence.
+          </p>
+        </div>
+      </section>
+
+      {/* ── resource index ── */}
+      <section className="border-t border-line">
+        <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <ul className="divide-y divide-line">
+            {resources.map((item) => (
+              <li key={item.title}>
+                <div className="grid gap-4 py-8 sm:grid-cols-[auto_1fr_auto] sm:items-baseline sm:gap-8">
+                  <span className="font-ui text-sm text-accent-strong">{item.n}</span>
+                  <div>
+                    <h2 className="font-display text-[clamp(1.4rem,3vw,2rem)] font-semibold tracking-[-0.01em] text-fg">
+                      {item.title}
+                    </h2>
+                    <p className="mt-2 max-w-[52ch] font-body text-base leading-relaxed text-fg-2">
+                      {item.text}
+                    </p>
+                  </div>
+                  <Link
+                    href={item.href}
+                    className="inline-flex min-h-[44px] items-center self-center font-ui text-xs font-semibold uppercase tracking-[0.14em] text-accent-strong transition duration-150 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+                  >
+                    {item.cta} →
+                  </Link>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* ── closing ── */}
+      <section className="border-t border-line">
+        <div className="mx-auto max-w-6xl px-5 py-20 text-center sm:px-8">
+          <h2 className="mx-auto max-w-[20ch] text-balance font-display text-[clamp(1.8rem,4.5vw,3rem)] font-semibold leading-[1.04] tracking-[-0.02em] text-fg">
+            Stop reading. Start <em className="italic text-accent">compiling.</em>
+          </h2>
+          <Link
+            href="/try"
+            className="mt-8 inline-flex items-center rounded-[var(--radius-md)] bg-accent px-8 py-3.5 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-accent-fg transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+          >
+            Open the studio →
+          </Link>
+        </div>
+      </section>
     </div>
   )
 }

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -109,110 +109,136 @@ export default function TemplatesPage() {
     handleUseTemplate(id)
   }, [handleUseTemplate])
 
+  const tabClass = (isActive: boolean) =>
+    `inline-flex min-h-[36px] items-center rounded-[var(--radius-pill)] border px-4 py-1.5 font-ui text-xs uppercase tracking-[0.08em] transition duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none ${
+      isActive
+        ? 'border-accent bg-accent-soft text-accent-strong'
+        : 'border-line text-fg-3 hover:border-line-2 hover:text-fg'
+    }`
+
   return (
     <>
-      <div className="content-shell space-y-7 pb-16">
-        {/* Header */}
-        <header className="pt-2">
-          <p className="overline">Library</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">
-            Resume Templates
-          </h1>
-          <p className="mt-1 text-sm text-zinc-400">
-            Browse 50+ professional LaTeX templates across industries. Preview, then use any template to start building.
-          </p>
-        </header>
-
-        {/* Search + count */}
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="relative w-full sm:max-w-xs">
-            <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-500" />
-            <input
-              type="text"
-              placeholder="Search templates…"
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-              className="w-full rounded-xl border border-white/10 bg-black/40 py-2 pl-9 pr-9 text-sm text-white outline-none transition placeholder:text-zinc-600 focus:border-orange-300/40"
-            />
-            {search && (
-              <button
-                onClick={() => setSearch('')}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300"
-              >
-                <X size={13} />
-              </button>
-            )}
+      <div className="bg-bg text-fg">
+        {/* folio strip */}
+        <div className="border-b border-line">
+          <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-2 font-ui text-[0.62rem] uppercase tracking-[0.16em] text-fg-3 sm:px-8">
+            <span>№ 02 — The Specimen Library</span>
+            <span className="hidden sm:inline">Set in Fraunces &amp; JetBrains Mono</span>
+            <span>pdflatex · xelatex · lualatex</span>
           </div>
-          <p className="text-xs text-zinc-500">
-            {filteredTemplates.length} template{filteredTemplates.length !== 1 ? 's' : ''}
-          </p>
         </div>
 
-        {/* Category tabs */}
-        <div className="flex flex-wrap gap-2">
-          <button
-            onClick={() => setActiveCategory('all')}
-            className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
-              activeCategory === 'all'
-                ? 'border-orange-300/40 bg-orange-300/10 text-orange-200'
-                : 'border-white/10 text-zinc-500 hover:border-white/20 hover:text-zinc-300'
-            }`}
-          >
-            All ({templates.length})
-          </button>
-          {sortedCategories.map(cat => (
+        <div className="mx-auto max-w-6xl px-5 py-12 sm:px-8 lg:py-16">
+          {/* Header */}
+          <header>
+            <p className="font-ui text-xs uppercase tracking-[0.18em] text-fg-3">Library</p>
+            <h1 className="mt-4 max-w-[18ch] text-balance font-display text-[clamp(2.4rem,6vw,4.4rem)] font-semibold leading-[0.98] tracking-[-0.025em] text-fg">
+              Résumé <em className="italic text-accent">specimens</em>, ready to set.
+            </h1>
+            <p className="mt-6 max-w-[52ch] font-body text-lg text-fg-2">
+              Browse professional LaTeX templates across industries. Preview any specimen, then
+              use it to start building.
+            </p>
+          </header>
+
+          {/* Search + count */}
+          <div className="mt-10 flex flex-col gap-4 border-t border-line pt-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="relative w-full sm:max-w-xs">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-fg-3" />
+              <label htmlFor="template-search" className="sr-only">Search templates</label>
+              <input
+                id="template-search"
+                type="text"
+                placeholder="Search templates…"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface py-2.5 pl-9 pr-10 font-body text-sm text-fg outline-none transition duration-150 placeholder:text-fg-3 focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+              />
+              {search && (
+                <button
+                  type="button"
+                  aria-label="Clear search"
+                  onClick={() => setSearch('')}
+                  className="absolute right-1.5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-[var(--radius-sm)] text-fg-3 transition duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent motion-reduce:transition-none"
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+            <p className="font-ui text-xs uppercase tracking-[0.12em] text-fg-3">
+              {filteredTemplates.length} template{filteredTemplates.length !== 1 ? 's' : ''}
+            </p>
+          </div>
+
+          {/* Category tabs */}
+          <div className="mt-5 flex flex-wrap gap-2">
             <button
-              key={cat.category}
-              onClick={() => setActiveCategory(cat.category)}
-              className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
-                activeCategory === cat.category
-                  ? 'border-orange-300/40 bg-orange-300/10 text-orange-200'
-                  : 'border-white/10 text-zinc-500 hover:border-white/20 hover:text-zinc-300'
-              }`}
+              type="button"
+              onClick={() => setActiveCategory('all')}
+              className={tabClass(activeCategory === 'all')}
             >
-              {cat.label} ({cat.count})
+              All ({templates.length})
             </button>
-          ))}
-        </div>
-
-        {/* Template grid */}
-        {loading ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {Array.from({ length: 12 }).map((_, i) => (
-              <div key={i} className="h-64 animate-pulse rounded-xl bg-white/5" />
+            {sortedCategories.map(cat => (
+              <button
+                key={cat.category}
+                type="button"
+                onClick={() => setActiveCategory(cat.category)}
+                className={tabClass(activeCategory === cat.category)}
+              >
+                {cat.label} ({cat.count})
+              </button>
             ))}
           </div>
-        ) : filteredTemplates.length === 0 ? (
-          <div className="flex flex-col items-center gap-2 py-16 text-center">
-            <p className="text-sm text-zinc-500">No templates found</p>
-            {search && (
-              <button onClick={() => setSearch('')} className="text-xs text-orange-300 hover:underline">
-                Clear search
-              </button>
-            )}
-          </div>
-        ) : (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {filteredTemplates.map(template => (
-              <div key={template.id} className="relative">
-                <TemplateCard
-                  template={template}
-                  onSelect={handleUseTemplate}
-                  onPreview={handlePreview}
-                  disabled={usingTemplateId !== null}
-                />
-                {usingTemplateId === template.id && (
-                  <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-black/60 backdrop-blur-sm">
-                    <div className="flex items-center gap-2 text-xs text-white">
-                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-600 border-t-orange-300" />
-                      Creating…
-                    </div>
-                  </div>
+
+          {/* Template grid */}
+          <div className="mt-10">
+            {loading ? (
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {Array.from({ length: 12 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-64 rounded-[var(--radius-lg)] border border-line bg-surface-2 motion-safe:animate-pulse"
+                  />
+                ))}
+              </div>
+            ) : filteredTemplates.length === 0 ? (
+              <div className="flex flex-col items-center gap-3 border-t border-line py-20 text-center">
+                <p className="font-body text-sm text-fg-2">No templates found</p>
+                {search && (
+                  <button
+                    type="button"
+                    onClick={() => setSearch('')}
+                    className="font-ui text-xs uppercase tracking-[0.08em] text-accent-strong transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+                  >
+                    Clear search
+                  </button>
                 )}
               </div>
-            ))}
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {filteredTemplates.map(template => (
+                  <div key={template.id} className="relative">
+                    <TemplateCard
+                      template={template}
+                      onSelect={handleUseTemplate}
+                      onPreview={handlePreview}
+                      disabled={usingTemplateId !== null}
+                    />
+                    {usingTemplateId === template.id && (
+                      <div className="absolute inset-0 z-10 flex items-center justify-center rounded-[var(--radius-lg)] bg-bg/80">
+                        <div className="flex items-center gap-2 font-ui text-xs uppercase tracking-[0.08em] text-fg">
+                          <div className="h-4 w-4 animate-spin rounded-[var(--radius-pill)] border-2 border-line border-t-accent" />
+                          Creating…
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
-        )}
+        </div>
       </div>
 
       <TemplatePreviewModal

--- a/frontend/src/app/updates/page.tsx
+++ b/frontend/src/app/updates/page.tsx
@@ -20,30 +20,55 @@ const updates = [
 
 export default function UpdatesPage() {
   return (
-    <div className="content-shell py-12">
-      <MotionReveal>
-        <p className="overline">Updates</p>
-        <h1 className="section-title mt-2 text-white">Shipping log and platform progress.</h1>
-        <p className="mt-4 max-w-2xl text-zinc-300">
-          Product and engineering updates published with clear release dates and impact notes.
-        </p>
-      </MotionReveal>
+    <div className="bg-bg text-fg">
+      {/* folio strip */}
+      <div className="border-b border-line">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-2 font-ui text-[0.62rem] uppercase tracking-[0.16em] text-fg-3 sm:px-8">
+          <span>The Shipping Log</span>
+          <span className="hidden sm:inline">Set in Fraunces &amp; JetBrains Mono</span>
+          <span>{updates.length} releases</span>
+        </div>
+      </div>
 
-      <MotionStagger className="mt-8 space-y-4">
-        {updates.map((item) => (
-          <MotionItem key={item.title}>
-            <article className="surface-card edge-highlight p-5 transition duration-300 hover:border-orange-200/30">
-              <p className="text-xs uppercase tracking-wider text-zinc-500">{item.date}</p>
-              <h2 className="mt-2 text-xl font-semibold text-white">{item.title}</h2>
-              <div className="mt-3 space-y-2 text-zinc-300">
-                {item.points.map((point) => (
-                  <p key={point}>{point}</p>
-                ))}
-              </div>
-            </article>
-          </MotionItem>
-        ))}
-      </MotionStagger>
+      {/* ── masthead ── */}
+      <section className="mx-auto max-w-6xl px-5 py-16 sm:px-8 lg:py-24">
+        <MotionReveal>
+          <span className="font-ui text-xs uppercase tracking-[0.18em] text-fg-3">Updates</span>
+          <h1 className="mt-5 max-w-[18ch] text-balance font-display text-[clamp(2.4rem,6vw,4.6rem)] font-semibold leading-[1.0] tracking-[-0.025em] text-fg">
+            Shipping log and <em className="italic text-accent">platform progress.</em>
+          </h1>
+          <p className="mt-6 max-w-[46ch] font-body text-lg text-fg-2">
+            Product and engineering updates published with clear release dates and impact notes.
+          </p>
+        </MotionReveal>
+      </section>
+
+      {/* ── changelog ── */}
+      <section className="mx-auto max-w-6xl px-5 pb-24 sm:px-8">
+        <MotionStagger className="border-t border-line">
+          {updates.map((item, i) => (
+            <MotionItem key={item.title}>
+              <article className="grid gap-4 border-b border-line py-10 md:grid-cols-[.85fr_2.15fr] md:gap-10">
+                <div className="flex items-baseline gap-3 md:flex-col md:items-start md:gap-2">
+                  <span className="font-ui text-xs text-accent-strong">§ {updates.length - i}</span>
+                  <time className="font-ui text-xs uppercase tracking-[0.14em] text-fg-3">{item.date}</time>
+                </div>
+                <div>
+                  <h2 className="font-display text-2xl font-semibold text-fg">{item.title}</h2>
+                  <ul className="mt-4 space-y-3">
+                    {item.points.map((point) => (
+                      <li key={point} className="flex gap-3 font-body text-fg-2">
+                        <span aria-hidden className="mt-[0.55em] h-px w-4 shrink-0 bg-accent" />
+                        <span className="leading-relaxed">{point}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </article>
+            </MotionItem>
+          ))}
+        </MotionStagger>
+      </section>
     </div>
   )
 }

--- a/frontend/src/components/GlobalHeader.tsx
+++ b/frontend/src/components/GlobalHeader.tsx
@@ -11,11 +11,12 @@ import { useEntitlements } from '@/contexts/EntitlementsContext'
 import { usePWAInstall } from '@/hooks/usePWAInstall'
 import { clearAllDrafts } from '@/lib/offline-drafts'
 import { clearCompileQueue } from '@/lib/compile-queue'
+import ModeToggle from '@/components/theme/ModeToggle'
 
 const guestNav = [
   { label: 'Platform', href: '/platform' },
   { label: 'Templates', href: '/templates' },
-  { label: 'Pricing', href: '/billing' },
+  { label: 'Pricing', href: '/pricing' },
   { label: 'Resources', href: '/resources' },
   { label: 'FAQ', href: '/faq' },
 ]
@@ -65,7 +66,7 @@ export default function GlobalHeader() {
   const isAuthenticated = Boolean(resolvedUser)
   const effectiveGuestNav = flags.billing
     ? guestNav
-    : guestNav.filter((item) => item.href !== '/billing')
+    : guestNav.filter((item) => item.href !== '/pricing')
   // Gate feature-specific app nav items behind entitlements (fail-open via
   // can()). Core items without a `feature` key always show.
   const effectiveAppNav = appNav.filter((item) => !item.feature || can(item.feature))
@@ -94,21 +95,24 @@ export default function GlobalHeader() {
     window.location.href = '/'
   }
 
+  const menuLink =
+    'block rounded-[var(--radius-md)] px-3 py-2 text-sm text-fg-2 transition hover:bg-surface-2 hover:text-fg'
+
   return (
-    <header className="sticky top-0 z-50 border-b border-white/10 bg-black/65 backdrop-blur-xl">
+    <header className="sticky top-0 z-[var(--z-sticky)] border-b border-line bg-[color-mix(in_srgb,var(--bg)_88%,transparent)] backdrop-blur-md">
       <div className="mx-auto flex h-16 max-w-[1600px] items-center justify-between px-4 sm:px-6 lg:px-10">
-        <Link href="/" className="text-xl font-semibold tracking-tight text-white transition hover:text-orange-100">
+        <Link href="/" className="font-display text-xl font-semibold tracking-tight text-fg transition hover:text-accent">
           Latexy
         </Link>
 
-        <nav className="hidden items-center gap-8 md:flex">
+        <nav className="hidden items-center gap-7 md:flex">
           {activeNav.map((item) => {
             const active = pathname === item.href
             return (
               <Link
                 key={item.href}
                 href={item.href}
-                className={`text-sm font-medium transition ${active ? 'text-orange-200' : 'text-zinc-400 hover:text-white'}`}
+                className={`font-ui text-sm font-medium transition ${active ? 'text-accent-strong' : 'text-fg-2 hover:text-fg'}`}
               >
                 {item.label}
               </Link>
@@ -117,11 +121,12 @@ export default function GlobalHeader() {
         </nav>
 
         <div className="hidden items-center gap-3 md:flex">
+          <ModeToggle />
           {hydrated && canInstall && (
             <button
               onClick={promptInstall}
               title="Add Latexy to Home Screen"
-              className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium text-zinc-400 transition hover:border-white/20 hover:text-white"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line px-3 py-1.5 font-ui text-xs font-medium text-fg-2 transition hover:border-line-2 hover:text-fg"
             >
               <Download size={12} />
               Install
@@ -134,11 +139,11 @@ export default function GlobalHeader() {
                 aria-label={isUserMenuOpen ? 'Close account menu' : 'Open account menu'}
                 aria-expanded={isUserMenuOpen}
                 aria-haspopup="menu"
-                className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 py-1 pl-1 pr-3 text-xs font-semibold text-zinc-300 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/60"
+                className="flex items-center gap-2 rounded-[var(--radius-pill)] border border-line bg-surface-2 py-1 pl-1 pr-3 font-ui text-xs font-semibold text-fg-2 transition hover:text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               >
                 <span
                   aria-hidden
-                  className="flex h-6 w-6 items-center justify-center rounded-full bg-orange-300 text-[11px] font-bold text-slate-950"
+                  className="flex h-6 w-6 items-center justify-center rounded-[var(--radius-pill)] bg-accent text-[11px] font-bold text-accent-fg"
                 >
                   {firstName.charAt(0).toUpperCase()}
                 </span>
@@ -151,7 +156,7 @@ export default function GlobalHeader() {
                     <button
                       type="button"
                       onClick={() => setIsUserMenuOpen(false)}
-                      className="fixed inset-0 z-10"
+                      className="fixed inset-0 z-[var(--z-raised)]"
                       aria-label="Close account menu"
                     />
                     <motion.div
@@ -160,56 +165,26 @@ export default function GlobalHeader() {
                       exit={{ opacity: 0, y: 8, scale: 0.98 }}
                       role="menu"
                       aria-label="Account menu"
-                      className="absolute right-0 z-50 mt-2 w-56 rounded-xl border border-white/10 bg-zinc-900 p-2 shadow-2xl"
+                      className="absolute right-0 z-[var(--z-dropdown)] mt-2 w-56 rounded-[var(--radius-lg)] border border-line bg-surface p-2 shadow-[var(--shadow-2)]"
                     >
                       <div className="px-3 py-2">
-                        <p className="text-[10px] uppercase tracking-[0.2em] text-zinc-500">Account</p>
-                        <p className="mt-1 truncate text-sm font-semibold text-white">{resolvedUser?.email || 'Unknown account'}</p>
+                        <p className="font-ui text-[10px] uppercase tracking-[0.2em] text-fg-3">Account</p>
+                        <p className="mt-1 truncate text-sm font-semibold text-fg">{resolvedUser?.email || 'Unknown account'}</p>
                       </div>
-                      <div className="my-1 h-px bg-white/10" />
-                      <Link
-                        href="/dashboard"
-                        className="block rounded-lg px-3 py-2 text-sm text-zinc-300 transition hover:bg-white/5 hover:text-white"
-                        onClick={() => setIsUserMenuOpen(false)}
-                      >
-                        Dashboard
-                      </Link>
+                      <div className="my-1 h-px bg-line" />
+                      <Link href="/dashboard" className={menuLink} onClick={() => setIsUserMenuOpen(false)}>Dashboard</Link>
                       {flags.billing && (
-                        <Link
-                          href="/billing"
-                          className="block rounded-lg px-3 py-2 text-sm text-zinc-300 transition hover:bg-white/5 hover:text-white"
-                          onClick={() => setIsUserMenuOpen(false)}
-                        >
-                          Billing
-                        </Link>
+                        <Link href="/billing" className={menuLink} onClick={() => setIsUserMenuOpen(false)}>Billing</Link>
                       )}
-                      <Link
-                        href="/developer"
-                        className="block rounded-lg px-3 py-2 text-sm text-zinc-300 transition hover:bg-white/5 hover:text-white"
-                        onClick={() => setIsUserMenuOpen(false)}
-                      >
-                        Developer API
-                      </Link>
-                      <Link
-                        href="/byok"
-                        className="block rounded-lg px-3 py-2 text-sm text-zinc-300 transition hover:bg-white/5 hover:text-white"
-                        onClick={() => setIsUserMenuOpen(false)}
-                      >
-                        Settings
-                      </Link>
+                      <Link href="/developer" className={menuLink} onClick={() => setIsUserMenuOpen(false)}>Developer API</Link>
+                      <Link href="/byok" className={menuLink} onClick={() => setIsUserMenuOpen(false)}>Settings</Link>
                       {isAdmin && (
-                        <Link
-                          href="/admin"
-                          className="block rounded-lg px-3 py-2 text-sm text-zinc-300 transition hover:bg-white/5 hover:text-white"
-                          onClick={() => setIsUserMenuOpen(false)}
-                        >
-                          Admin
-                        </Link>
+                        <Link href="/admin" className={menuLink} onClick={() => setIsUserMenuOpen(false)}>Admin</Link>
                       )}
-                      <div className="my-1 h-px bg-white/10" />
+                      <div className="my-1 h-px bg-line" />
                       <button
                         onClick={handleSignOut}
-                        className="block w-full rounded-lg px-3 py-2 text-left text-sm text-rose-300 transition hover:bg-rose-500/10"
+                        className="block w-full rounded-[var(--radius-md)] px-3 py-2 text-left text-sm text-err transition hover:bg-[color-mix(in_srgb,var(--err)_12%,transparent)]"
                       >
                         Sign Out
                       </button>
@@ -220,24 +195,30 @@ export default function GlobalHeader() {
             </div>
           ) : (
             <>
-              <Link href="/login" className="text-sm font-medium text-zinc-400 transition hover:text-white">
+              <Link href="/login" className="font-ui text-sm font-medium text-fg-2 transition hover:text-fg">
                 Log In
               </Link>
-              <Link href="/try" className="btn-accent px-4 py-1.5 text-xs">
+              <Link
+                href="/try"
+                className="rounded-[var(--radius-md)] bg-accent px-4 py-1.5 font-ui text-xs font-semibold text-accent-fg transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+              >
                 Try Free
               </Link>
             </>
           )}
         </div>
 
-        <button
-          className="rounded-lg border border-white/10 px-3 py-1 text-xs font-semibold text-zinc-300 transition hover:border-white/20 hover:text-white md:hidden"
-          onClick={() => setIsMobileMenuOpen((open) => !open)}
-          aria-label={isMobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
-          aria-expanded={isMobileMenuOpen}
-        >
-          {isMobileMenuOpen ? 'Close' : 'Menu'}
-        </button>
+        <div className="flex items-center gap-2 md:hidden">
+          <ModeToggle />
+          <button
+            className="rounded-[var(--radius-md)] border border-line px-3 py-1 font-ui text-xs font-semibold text-fg-2 transition hover:border-line-2 hover:text-fg"
+            onClick={() => setIsMobileMenuOpen((open) => !open)}
+            aria-label={isMobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-expanded={isMobileMenuOpen}
+          >
+            {isMobileMenuOpen ? 'Close' : 'Menu'}
+          </button>
+        </div>
       </div>
 
       <AnimatePresence>
@@ -246,14 +227,14 @@ export default function GlobalHeader() {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="border-t border-white/10 bg-zinc-950 md:hidden"
+            className="border-t border-line bg-surface md:hidden"
           >
             <div className="space-y-1 p-4">
               {activeNav.map((item) => (
                 <Link
                   key={item.href}
                   href={item.href}
-                  className="block rounded-lg px-4 py-2 text-sm font-medium text-zinc-300 transition hover:bg-white/5 hover:text-white"
+                  className="block rounded-[var(--radius-md)] px-4 py-2.5 font-ui text-sm font-medium text-fg-2 transition hover:bg-surface-2 hover:text-fg"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   {item.label}
@@ -261,17 +242,17 @@ export default function GlobalHeader() {
               ))}
 
               {!isAuthenticated && (
-                <div className="mt-3 grid grid-cols-2 gap-2 border-t border-white/10 pt-3">
+                <div className="mt-3 grid grid-cols-2 gap-2 border-t border-line pt-3">
                   <Link
                     href="/login"
-                    className="rounded-lg border border-white/10 py-2 text-center text-sm font-medium text-white"
+                    className="rounded-[var(--radius-md)] border border-line py-2.5 text-center font-ui text-sm font-medium text-fg"
                     onClick={() => setIsMobileMenuOpen(false)}
                   >
                     Log In
                   </Link>
                   <Link
                     href="/try"
-                    className="rounded-lg bg-orange-300 py-2 text-center text-sm font-semibold text-slate-950"
+                    className="rounded-[var(--radius-md)] bg-accent py-2.5 text-center font-ui text-sm font-semibold text-accent-fg"
                     onClick={() => setIsMobileMenuOpen(false)}
                   >
                     Try Free

--- a/frontend/src/components/marketing/MarketingFooter.tsx
+++ b/frontend/src/components/marketing/MarketingFooter.tsx
@@ -9,19 +9,24 @@ export default function MarketingFooter() {
   if (hidden) return null
 
   return (
-    <footer className="mt-6 surface-panel edge-highlight px-5 py-6 sm:px-8">
-      <div className="flex flex-wrap items-center justify-between gap-4">
+    <footer className="mt-10 border-t border-line bg-surface-2">
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-5 py-8 sm:px-8">
         <div>
-          <p className="text-lg font-semibold text-white">Latexy</p>
-          <p className="text-sm text-zinc-400">Precision resume intelligence for modern applicants.</p>
+          <p className="font-display text-lg font-semibold text-fg">Latexy</p>
+          <p className="mt-0.5 font-body text-sm text-fg-2">Résumés, typeset — precision for modern applicants.</p>
         </div>
-        <div className="flex flex-wrap items-center gap-3 text-sm text-zinc-300">
-          <Link href="/platform" className="hover:text-white">Platform</Link>
-          <Link href="/resources" className="hover:text-white">Resources</Link>
-          <Link href="/updates" className="hover:text-white">Updates</Link>
-          <Link href="/faq" className="hover:text-white">FAQ</Link>
-          <Link href="/try" className="btn-accent">Open Studio</Link>
-        </div>
+        <nav className="flex flex-wrap items-center gap-5 font-ui text-sm text-fg-2">
+          <Link href="/platform" className="transition hover:text-fg">Platform</Link>
+          <Link href="/resources" className="transition hover:text-fg">Resources</Link>
+          <Link href="/updates" className="transition hover:text-fg">Updates</Link>
+          <Link href="/faq" className="transition hover:text-fg">FAQ</Link>
+          <Link
+            href="/try"
+            className="rounded-[var(--radius-md)] bg-accent px-4 py-1.5 font-semibold text-accent-fg transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          >
+            Open Studio
+          </Link>
+        </nav>
       </div>
     </footer>
   )


### PR DESCRIPTION
Refs #1073. Second phase of the Typeset × Compiler redesign. Re-skins the marketing surfaces to the Typeset token aesthetic. **Additive, zero functional regressions** — 493 unit tests pass, `next build` compiles, no route/behavior changes.

## What's in it
- **6 marketing pages re-skinned** (platform, templates, resources, faq, updates, developer) — built via the `redesign-marketing-pages` workflow, each with an adversarial review agent that verified **token-only styling + all content/links preserved** (diffed against HEAD) and fixed issues in place. All content/interactivity intact.
- **`GlobalHeader`** token-bound — every behavior preserved (auth-aware nav, entitlement gating, account/mobile menus, PWA install, admin link, sign-out cleanup, editor-route hide); **`ModeToggle` mounted** (desktop + mobile); Pricing nav → `/pricing`.
- **`MarketingFooter`** token-bound.
- **`/pricing`** is now a standalone Typeset marketing page (tier value + CTAs) instead of re-exporting the authenticated billing screen — resolves the PRD's two-aesthetics-one-component contradiction; live prices/checkout stay on `/billing`.

## Aesthetic
Serif display headings, mono uppercase labels, hairline rules, honest copy (fabricated stats removed), responsive + a11y (focus rings, motion-reduce), no glassmorphism/emoji-as-icons.

Next: Phase 3 (auth) → Phase 4 (app shell) → Phase 5 (editor/panel/modal bulk).