### PR TITLE
Redesign Phase 3: auth (Typeset)

### DIFF
--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { CheckCircle2 } from 'lucide-react'
 import { authClient } from '@/lib/auth-client'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('')
@@ -32,66 +35,93 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <div className="content-shell flex min-h-[80vh] items-center justify-center">
+    <div className="flex min-h-[80vh] items-center justify-center bg-bg px-5 py-16 sm:px-8">
       <div className="w-full max-w-md space-y-8">
         <div className="text-center">
-          <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Forgot password</h1>
-          <p className="mt-2 text-zinc-400">Enter your email and we&apos;ll send you a reset link</p>
+          <span className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">
+            Account recovery
+          </span>
+          <h1 className="mt-4 font-display text-[clamp(2rem,5vw,2.6rem)] font-semibold tracking-[-0.02em] text-fg">
+            Forgot password
+          </h1>
+          <p className="mt-3 font-body text-fg-2">
+            Enter your email and we&apos;ll send you a reset link.
+          </p>
         </div>
 
-        <div className="surface-panel edge-highlight p-6 sm:p-8">
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)] sm:p-8">
           {sent ? (
-            <div className="space-y-4 text-center">
-              <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-300">
-                If an account exists for <span className="font-semibold">{email}</span>, a password reset
-                link is on its way. Check your inbox.
+            <div className="space-y-6 text-center">
+              <div
+                className="flex items-start gap-3 rounded-[var(--radius-md)] border border-line-2 bg-accent-soft px-4 py-3 text-left font-body text-sm text-fg-2"
+                role="status"
+                aria-live="polite"
+              >
+                <CheckCircle2
+                  className="mt-0.5 h-5 w-5 flex-shrink-0 text-ok"
+                  aria-hidden="true"
+                />
+                <span>
+                  If an account exists for{' '}
+                  <span className="font-semibold text-fg">{email}</span>, a password reset link
+                  is on its way. Check your inbox.
+                </span>
               </div>
               <Link
                 href="/login"
-                className="inline-block text-sm font-semibold text-orange-200 hover:text-orange-100"
+                className="inline-flex items-center rounded-[var(--radius-sm)] font-ui text-sm font-semibold text-accent-strong transition duration-150 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
               >
                 Back to sign in
               </Link>
             </div>
           ) : (
-            <form onSubmit={handleSubmit} className="max-w-md mx-auto space-y-4">
+            <form onSubmit={handleSubmit} className="space-y-5">
               <div>
                 <label
                   htmlFor="email"
-                  className="block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400"
+                  className="block font-ui text-xs font-medium uppercase tracking-[0.16em] text-fg-3"
                 >
                   Email
                 </label>
-                <input
+                <Input
                   type="email"
                   id="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
-                  className="mt-2 block w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
+                  autoComplete="email"
+                  className="mt-2 h-11"
                 />
               </div>
 
               {error && (
-                <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">
+                <div
+                  className="rounded-[var(--radius-md)] border border-err/40 bg-surface-2 px-3 py-2 font-body text-sm text-err"
+                  role="alert"
+                  aria-live="assertive"
+                >
                   {error}
                 </div>
               )}
 
-              <button
+              <Button
                 type="submit"
-                disabled={isLoading}
-                className="btn-accent w-full py-2.5 text-sm disabled:opacity-50"
+                size="lg"
+                loading={isLoading}
+                className="w-full uppercase tracking-[0.06em]"
               >
-                {isLoading ? 'Sending...' : 'Send reset link'}
-              </button>
+                Send reset link
+              </Button>
             </form>
           )}
         </div>
 
-        <p className="text-center text-sm text-zinc-500">
+        <p className="text-center font-body text-sm text-fg-3">
           Remembered it?{' '}
-          <Link href="/login" className="font-semibold text-orange-200 hover:text-orange-100">
+          <Link
+            href="/login"
+            className="font-semibold text-accent-strong transition duration-150 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+          >
             Sign in
           </Link>
         </p>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,28 +5,36 @@ import SignInForm from '@/components/auth/SignInForm'
 
 export default function LoginPage() {
   return (
-    <div className="content-shell flex min-h-[80vh] items-center justify-center">
+    <div className="bg-bg text-fg">
+      <div className="mx-auto flex min-h-[80vh] max-w-6xl items-center justify-center px-5 py-16 sm:px-8">
         <div className="w-full max-w-md space-y-8">
           <div className="text-center">
-            <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            <span className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">
+              Sign in
+            </span>
+            <h1 className="mt-4 font-display text-[clamp(2rem,5vw,2.75rem)] font-semibold leading-[1.02] tracking-[-0.02em] text-fg">
               Welcome back
             </h1>
-            <p className="mt-2 text-zinc-400">
-              Sign in to your account to access your workspace
+            <p className="mt-3 font-body text-fg-2">
+              Sign in to your account to access your workspace.
             </p>
           </div>
 
-          <div className="surface-panel edge-highlight p-6 sm:p-8">
+          <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)] sm:p-8">
             <SignInForm />
           </div>
 
-          <p className="text-center text-sm text-zinc-500">
-            Don't have an account?{' '}
-            <Link href="/signup" className="font-semibold text-orange-200 hover:text-orange-100">
+          <p className="text-center font-body text-sm text-fg-3">
+            Don&apos;t have an account?{' '}
+            <Link
+              href="/signup"
+              className="font-medium text-accent-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg rounded-[var(--radius-sm)]"
+            >
               Sign up
             </Link>
           </p>
         </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -4,6 +4,8 @@ import { Suspense, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { authClient } from '@/lib/auth-client'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 
 function ResetPasswordInner() {
   const router = useRouter()
@@ -53,81 +55,92 @@ function ResetPasswordInner() {
   const invalidLink = !token || tokenError
 
   return (
-    <div className="content-shell flex min-h-[80vh] items-center justify-center">
-      <div className="w-full max-w-md space-y-8">
+    <div className="flex min-h-[80vh] items-center justify-center bg-bg px-5 py-16 sm:px-8">
+      <div className="w-full max-w-md">
         <div className="text-center">
-          <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Reset password</h1>
-          <p className="mt-2 text-zinc-400">Choose a new password for your account</p>
+          <span className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Account recovery</span>
+          <h1 className="mt-4 font-display text-4xl font-semibold tracking-[-0.02em] text-fg sm:text-5xl">
+            Reset password
+          </h1>
+          <p className="mt-3 font-body text-fg-2">Choose a new password for your account.</p>
         </div>
 
-        <div className="surface-panel edge-highlight p-6 sm:p-8">
+        <div className="mt-8 rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)] sm:p-8">
           {done ? (
-            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-center text-sm text-emerald-300">
+            <div
+              role="status"
+              aria-live="polite"
+              className="rounded-[var(--radius-md)] border border-line-2 bg-surface-2 px-4 py-3 text-center font-body text-sm text-ok"
+            >
               Password updated. Redirecting you to sign in&hellip;
             </div>
           ) : invalidLink ? (
             <div className="space-y-4 text-center">
-              <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-300">
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="rounded-[var(--radius-md)] border border-line-2 bg-surface-2 px-4 py-3 font-body text-sm text-err"
+              >
                 This reset link is invalid or has expired.
               </div>
               <Link
                 href="/forgot-password"
-                className="inline-block text-sm font-semibold text-orange-200 hover:text-orange-100"
+                className="inline-block rounded-[var(--radius-sm)] font-ui text-sm font-semibold text-accent-strong hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               >
                 Request a new link
               </Link>
             </div>
           ) : (
-            <form onSubmit={handleSubmit} className="max-w-md mx-auto space-y-4">
-              <div>
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="space-y-2">
                 <label
                   htmlFor="password"
-                  className="block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400"
+                  className="block font-ui text-xs uppercase tracking-[0.16em] text-fg-3"
                 >
                   New password
                 </label>
-                <input
+                <Input
                   type="password"
                   id="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
                   minLength={8}
-                  className="mt-2 block w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
+                  autoComplete="new-password"
                 />
               </div>
 
-              <div>
+              <div className="space-y-2">
                 <label
                   htmlFor="confirm"
-                  className="block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400"
+                  className="block font-ui text-xs uppercase tracking-[0.16em] text-fg-3"
                 >
                   Confirm password
                 </label>
-                <input
+                <Input
                   type="password"
                   id="confirm"
                   value={confirm}
                   onChange={(e) => setConfirm(e.target.value)}
                   required
                   minLength={8}
-                  className="mt-2 block w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
+                  autoComplete="new-password"
                 />
               </div>
 
               {error && (
-                <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">
+                <div
+                  role="alert"
+                  aria-live="assertive"
+                  className="rounded-[var(--radius-md)] border border-line-2 bg-surface-2 px-3 py-2 font-body text-sm text-err"
+                >
                   {error}
                 </div>
               )}
 
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="btn-accent w-full py-2.5 text-sm disabled:opacity-50"
-              >
-                {isLoading ? 'Updating...' : 'Update password'}
-              </button>
+              <Button type="submit" disabled={isLoading} loading={isLoading} className="h-11 w-full">
+                Update password
+              </Button>
             </form>
           )}
         </div>

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -5,28 +5,34 @@ import SignUpForm from '@/components/auth/SignUpForm'
 
 export default function SignUpPage() {
   return (
-    <div className="content-shell flex min-h-[80vh] items-center justify-center">
-        <div className="w-full max-w-lg space-y-8">
-          <div className="text-center">
-            <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-              Create an account
-            </h1>
-            <p className="mt-2 text-zinc-400">
-              Join Latexy and start building your career-winning resume
-            </p>
-          </div>
-
-          <div className="surface-panel edge-highlight p-6 sm:p-8">
-            <SignUpForm />
-          </div>
-
-          <p className="text-center text-sm text-zinc-500">
-            Already have an account?{' '}
-            <Link href="/login" className="font-semibold text-orange-200 hover:text-orange-100">
-              Sign in
-            </Link>
+    <div className="flex min-h-[80vh] items-center justify-center bg-bg px-5 py-16 sm:px-8">
+      <div className="w-full max-w-lg space-y-8">
+        <div className="text-center">
+          <span className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">
+            Get started
+          </span>
+          <h1 className="mt-3 font-display text-[clamp(2rem,5vw,2.75rem)] font-semibold tracking-[-0.02em] text-fg">
+            Create an account
+          </h1>
+          <p className="mt-3 font-body text-fg-2">
+            Join Latexy and start building your career-winning resume.
           </p>
         </div>
+
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)] sm:p-8">
+          <SignUpForm />
+        </div>
+
+        <p className="text-center font-body text-sm text-fg-3">
+          Already have an account?{' '}
+          <Link
+            href="/login"
+            className="font-medium text-accent-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg rounded-[var(--radius-sm)]"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/verify-email/page.tsx
+++ b/frontend/src/app/verify-email/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
+import { Check, Loader2, X } from 'lucide-react'
 import { authClient } from '@/lib/auth-client'
 
 type Status = 'verifying' | 'success' | 'error'
@@ -51,48 +52,67 @@ function VerifyEmailInner() {
   }, [token, urlError, verified])
 
   return (
-    <div className="content-shell flex min-h-[80vh] items-center justify-center">
-      <div className="w-full max-w-md space-y-8 text-center">
+    <div className="flex min-h-[80vh] items-center justify-center bg-bg px-5 py-16 sm:px-8">
+      <div
+        className="w-full max-w-md rounded-[var(--radius-lg)] border border-line bg-surface p-8 text-center shadow-[var(--shadow-2)] sm:p-10"
+        aria-live="polite"
+      >
         {status === 'verifying' && (
-          <div className="surface-panel edge-highlight p-8">
-            <h1 className="text-2xl font-bold text-white">Verifying your email&hellip;</h1>
-            <p className="mt-2 text-sm text-zinc-400">This will only take a moment.</p>
-          </div>
+          <>
+            <div
+              className="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-md)] border border-line-2 bg-surface-2 text-fg-3"
+              aria-hidden="true"
+            >
+              <Loader2 className="h-6 w-6 motion-safe:animate-spin motion-reduce:animate-none" strokeWidth={2} />
+            </div>
+            <h1 className="mt-6 font-display text-2xl font-semibold text-fg">
+              Verifying your email&hellip;
+            </h1>
+            <p className="mt-3 font-body text-sm text-fg-2">This will only take a moment.</p>
+          </>
         )}
 
         {status === 'success' && (
-          <div className="surface-panel edge-highlight p-8">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
-              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-              </svg>
+          <>
+            <div
+              className="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-md)] border border-line-2 bg-accent-soft text-accent-strong"
+              aria-hidden="true"
+            >
+              <Check className="h-6 w-6" strokeWidth={2} />
             </div>
-            <h1 className="mt-4 text-2xl font-bold text-white">Email verified</h1>
-            <p className="mt-2 text-sm text-zinc-400">
+            <h1 className="mt-6 font-display text-2xl font-semibold text-fg">Email verified</h1>
+            <p className="mt-3 font-body text-sm text-fg-2">
               Your email is confirmed. You&apos;re all set.
             </p>
-            <Link href="/workspace" className="btn-accent mt-6 inline-block px-6 py-2.5 text-sm">
+            <Link
+              href="/workspace"
+              className="mt-8 inline-flex min-h-[44px] items-center justify-center rounded-[var(--radius-md)] bg-accent px-6 py-3 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-accent-fg transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+            >
               Go to workspace
             </Link>
-          </div>
+          </>
         )}
 
         {status === 'error' && (
-          <div className="surface-panel edge-highlight p-8">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-rose-500/30 bg-rose-500/10 text-rose-300">
-              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
+          <>
+            <div
+              className="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-md)] border border-line-2 bg-surface-2 text-err"
+              aria-hidden="true"
+            >
+              <X className="h-6 w-6" strokeWidth={2} />
             </div>
-            <h1 className="mt-4 text-2xl font-bold text-white">Verification failed</h1>
-            <p className="mt-2 text-sm text-zinc-400">
+            <h1 className="mt-6 font-display text-2xl font-semibold text-fg">Verification failed</h1>
+            <p className="mt-3 font-body text-sm text-err">
               This verification link is invalid or has expired. You can request a new one from the
               banner in the app.
             </p>
-            <Link href="/workspace" className="btn-accent mt-6 inline-block px-6 py-2.5 text-sm">
+            <Link
+              href="/workspace"
+              className="mt-8 inline-flex min-h-[44px] items-center justify-center rounded-[var(--radius-md)] bg-accent px-6 py-3 font-ui text-sm font-semibold uppercase tracking-[0.06em] text-accent-fg transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none"
+            >
               Back to app
             </Link>
-          </div>
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/auth/SignInForm.tsx
+++ b/frontend/src/components/auth/SignInForm.tsx
@@ -3,10 +3,34 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { signIn, signInWithGoogle, signInWithGithub } from '@/lib/auth-client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 
 const GOOGLE_ENABLED = process.env.NEXT_PUBLIC_OAUTH_GOOGLE_ENABLED === 'true'
 const GITHUB_ENABLED = process.env.NEXT_PUBLIC_OAUTH_GITHUB_ENABLED === 'true'
 const ANY_OAUTH = GOOGLE_ENABLED || GITHUB_ENABLED
+
+const labelClass = 'block font-ui text-xs uppercase tracking-[0.16em] text-fg-3'
+const oauthBtnClass =
+  'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-[var(--radius-md)] border border-line-2 bg-surface px-3 py-2.5 font-ui text-sm font-medium text-fg transition duration-150 hover:border-accent hover:text-accent-strong disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none'
+
+/** Google mark, rendered in the current text color to stay token-bound. */
+function GoogleIcon() {
+  return (
+    <svg className="h-4 w-4 fill-current" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09zM12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23zM5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62zM12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+    </svg>
+  )
+}
+
+/** GitHub mark, rendered in the current text color to stay token-bound. */
+function GithubIcon() {
+  return (
+    <svg className="h-4 w-4 fill-current" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+    </svg>
+  )
+}
 
 export default function SignInForm() {
   const [email, setEmail] = useState('')
@@ -53,96 +77,109 @@ export default function SignInForm() {
   }
 
   return (
-    <div className="max-w-md mx-auto space-y-4">
-      {/* Social OAuth — buttons render only when the provider is configured */}
-      {ANY_OAUTH && (
-        <>
-          <div className={`grid gap-3 ${GOOGLE_ENABLED && GITHUB_ENABLED ? 'grid-cols-2' : 'grid-cols-1'}`}>
-            {GOOGLE_ENABLED && (
-              <button
-                type="button"
-                onClick={() => handleSocial('google')}
-                disabled={!!socialLoading || isLoading}
-                className="flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2.5 text-sm font-medium text-zinc-200 transition hover:bg-white/10 disabled:opacity-50"
-              >
-                <svg className="h-4 w-4" viewBox="0 0 24 24">
-                  <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                  <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                  <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                  <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                </svg>
-                {socialLoading === 'google' ? 'Redirecting...' : 'Google'}
-              </button>
-            )}
-            {GITHUB_ENABLED && (
-              <button
-                type="button"
-                onClick={() => handleSocial('github')}
-                disabled={!!socialLoading || isLoading}
-                className="flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2.5 text-sm font-medium text-zinc-200 transition hover:bg-white/10 disabled:opacity-50"
-              >
-                <svg className="h-4 w-4 fill-current" viewBox="0 0 24 24">
-                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
-                </svg>
-                {socialLoading === 'github' ? 'Redirecting...' : 'GitHub'}
-              </button>
-            )}
-          </div>
+    <div className="mx-auto w-full max-w-md rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)] sm:p-8">
+      <div className="mb-8 text-center">
+        <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Latexy</p>
+        <h1 className="mt-3 font-display text-3xl font-semibold tracking-[-0.02em] text-fg">
+          Welcome back
+        </h1>
+        <p className="mt-2 font-body text-sm text-fg-2">Sign in to continue to your workspace.</p>
+      </div>
 
-          <div className="flex items-center gap-3">
-            <div className="h-px flex-1 bg-white/10" />
-            <span className="text-xs text-zinc-500">or continue with email</span>
-            <div className="h-px flex-1 bg-white/10" />
-          </div>
-        </>
-      )}
+      <div className="space-y-5">
+        {/* Social OAuth — buttons render only when the provider is configured */}
+        {ANY_OAUTH && (
+          <>
+            <div className={`grid gap-3 ${GOOGLE_ENABLED && GITHUB_ENABLED ? 'grid-cols-2' : 'grid-cols-1'}`}>
+              {GOOGLE_ENABLED && (
+                <button
+                  type="button"
+                  onClick={() => handleSocial('google')}
+                  disabled={!!socialLoading || isLoading}
+                  className={oauthBtnClass}
+                >
+                  <GoogleIcon />
+                  {socialLoading === 'google' ? 'Redirecting...' : 'Google'}
+                </button>
+              )}
+              {GITHUB_ENABLED && (
+                <button
+                  type="button"
+                  onClick={() => handleSocial('github')}
+                  disabled={!!socialLoading || isLoading}
+                  className={oauthBtnClass}
+                >
+                  <GithubIcon />
+                  {socialLoading === 'github' ? 'Redirecting...' : 'GitHub'}
+                </button>
+              )}
+            </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label htmlFor="email" className="block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
-            Email
-          </label>
-          <input
-            type="email"
-            id="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="mt-2 block w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
-          />
-        </div>
-
-        <div>
-          <div className="flex items-center justify-between">
-            <label htmlFor="password" className="block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
-              Password
-            </label>
-            <Link href="/forgot-password" className="text-xs font-medium text-orange-200 hover:text-orange-100">
-              Forgot password?
-            </Link>
-          </div>
-          <input
-            type="password"
-            id="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className="mt-2 block w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
-          />
-        </div>
-
-        {error && (
-          <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">{error}</div>
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-line" />
+              <span className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">
+                or continue with email
+              </span>
+              <div className="h-px flex-1 bg-line" />
+            </div>
+          </>
         )}
 
-        <button
-          type="submit"
-          disabled={isLoading || !!socialLoading}
-          className="btn-accent w-full py-2.5 text-sm disabled:opacity-50"
-        >
-          {isLoading ? 'Signing in...' : 'Sign In'}
-        </button>
-      </form>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-2">
+            <label htmlFor="email" className={labelClass}>
+              Email
+            </label>
+            <Input
+              type="email"
+              id="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="min-h-[44px]"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label htmlFor="password" className={labelClass}>
+                Password
+              </label>
+              <Link
+                href="/forgot-password"
+                className="font-ui text-xs font-medium text-accent-strong hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg rounded-[var(--radius-sm)]"
+              >
+                Forgot password?
+              </Link>
+            </div>
+            <Input
+              type="password"
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="min-h-[44px]"
+            />
+          </div>
+
+          <div aria-live="polite">
+            {error && (
+              <div className="rounded-[var(--radius-md)] border border-line-2 bg-surface-2 px-3 py-2 font-body text-sm text-err">
+                {error}
+              </div>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            disabled={isLoading || !!socialLoading}
+            size="lg"
+            className="w-full min-h-[44px]"
+          >
+            {isLoading ? 'Signing in...' : 'Sign In'}
+          </Button>
+        </form>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/auth/SignUpForm.tsx
+++ b/frontend/src/components/auth/SignUpForm.tsx
@@ -2,10 +2,16 @@
 
 import { useState } from 'react'
 import { signUp, signInWithGoogle, signInWithGithub } from '@/lib/auth-client'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 
 const GOOGLE_ENABLED = process.env.NEXT_PUBLIC_OAUTH_GOOGLE_ENABLED === 'true'
 const GITHUB_ENABLED = process.env.NEXT_PUBLIC_OAUTH_GITHUB_ENABLED === 'true'
 const ANY_OAUTH = GOOGLE_ENABLED || GITHUB_ENABLED
+
+const labelClass = 'block font-ui text-xs uppercase tracking-[0.16em] text-fg-3'
+const oauthButtonClass =
+  'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-[var(--radius-md)] border border-line-2 bg-surface px-3 py-2.5 font-ui text-sm font-medium text-fg transition duration-150 hover:border-accent hover:text-accent-strong disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg motion-reduce:transition-none'
 
 export default function SignUpForm() {
   const [email, setEmail] = useState('')
@@ -53,7 +59,14 @@ export default function SignUpForm() {
   }
 
   return (
-    <div className="max-w-md mx-auto space-y-4">
+    <div className="mx-auto max-w-md space-y-6 rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)] sm:p-8">
+      <div className="space-y-1.5 text-center">
+        <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Create account</p>
+        <h1 className="font-display text-2xl font-semibold tracking-[-0.02em] text-fg sm:text-3xl">
+          Set your résumé right.
+        </h1>
+      </div>
+
       {/* Social OAuth — buttons render only when the provider is configured */}
       {ANY_OAUTH && (
         <>
@@ -63,9 +76,9 @@ export default function SignUpForm() {
                 type="button"
                 onClick={() => handleSocial('google')}
                 disabled={!!socialLoading || isLoading}
-                className="flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2.5 text-sm font-medium text-zinc-200 transition hover:bg-white/10 disabled:opacity-50"
+                className={oauthButtonClass}
               >
-                <svg className="h-4 w-4" viewBox="0 0 24 24">
+                <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
                   <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
                   <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
                   <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
@@ -79,9 +92,9 @@ export default function SignUpForm() {
                 type="button"
                 onClick={() => handleSocial('github')}
                 disabled={!!socialLoading || isLoading}
-                className="flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2.5 text-sm font-medium text-zinc-200 transition hover:bg-white/10 disabled:opacity-50"
+                className={oauthButtonClass}
               >
-                <svg className="h-4 w-4 fill-current" viewBox="0 0 24 24">
+                <svg className="h-4 w-4 fill-current" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
                 </svg>
                 {socialLoading === 'github' ? 'Redirecting...' : 'GitHub'}
@@ -90,68 +103,70 @@ export default function SignUpForm() {
           </div>
 
           <div className="flex items-center gap-3">
-            <div className="h-px flex-1 bg-white/10" />
-            <span className="text-xs text-zinc-500">or sign up with email</span>
-            <div className="h-px flex-1 bg-white/10" />
+            <div className="h-px flex-1 bg-line" />
+            <span className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">or sign up with email</span>
+            <div className="h-px flex-1 bg-line" />
           </div>
         </>
       )}
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label htmlFor="name" className="block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div className="space-y-2">
+          <label htmlFor="name" className={labelClass}>
             Full Name
           </label>
-          <input
+          <Input
             type="text"
             id="name"
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
-            className="mt-2 block w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
           />
         </div>
 
-        <div>
-          <label htmlFor="email" className="block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+        <div className="space-y-2">
+          <label htmlFor="email" className={labelClass}>
             Email
           </label>
-          <input
+          <Input
             type="email"
             id="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
-            className="mt-2 block w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
           />
         </div>
 
-        <div>
-          <label htmlFor="password" className="block text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+        <div className="space-y-2">
+          <label htmlFor="password" className={labelClass}>
             Password
           </label>
-          <input
+          <Input
             type="password"
             id="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
             minLength={8}
-            className="mt-2 block w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
           />
         </div>
 
-        {error && (
-          <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">{error}</div>
-        )}
+        <div aria-live="polite">
+          {error && (
+            <div className="rounded-[var(--radius-md)] border border-err/40 bg-err/10 px-3 py-2 font-body text-sm text-err">
+              {error}
+            </div>
+          )}
+        </div>
 
-        <button
+        <Button
           type="submit"
+          size="lg"
           disabled={isLoading || !!socialLoading}
-          className="btn-accent w-full py-2.5 text-sm disabled:opacity-50"
+          className="w-full"
         >
           {isLoading ? 'Creating account...' : 'Sign Up'}
-        </button>
+        </Button>
       </form>
     </div>
   )


### PR DESCRIPTION
Refs #1073. Third phase — re-skins the auth surfaces to the Typeset token aesthetic. Additive, zero functional regressions (493 tests pass, build compiles).

- 5 auth pages (login, signup, forgot-password, reset-password, verify-email) + the 2 form components, built via the `redesign-auth` workflow with a per-file adversarial review that verified **every form handler, auth-client call, field, validation, error/loading state, OAuth button, and link is preserved** (diffed against HEAD).
- Editorial centered auth cards, serif headings, mono labels, token Input/Button primitives, `text-err` errors with aria-live, focus rings, responsive.
- Google/GitHub OAuth brand-logo SVG fills intentionally kept for brand fidelity.