### PR TITLE
Redesign Phase 4: app shell (Compiler)

### DIFF
--- a/frontend/src/app/billing/page.tsx
+++ b/frontend/src/app/billing/page.tsx
@@ -328,9 +328,9 @@ function BillingPageContent() {
   if (!flags.billing) {
     return (
       <div className="content-shell">
-        <div className="surface-panel edge-highlight p-6 sm:p-8">
-          <h1 className="text-3xl font-bold text-white tracking-tight">All Features Included</h1>
-          <p className="mt-2 max-w-2xl text-zinc-400">
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 sm:p-8">
+          <h1 className="text-3xl font-bold text-fg tracking-tight">All Features Included</h1>
+          <p className="mt-2 max-w-2xl text-fg-2">
             All features are available to everyone — no billing or subscription required.
           </p>
         </div>
@@ -341,47 +341,47 @@ function BillingPageContent() {
   return (
     <div className="content-shell">
       <div className="space-y-6">
-        <section className="surface-panel edge-highlight p-6 sm:p-8">
-          <h1 className="text-3xl font-bold text-white tracking-tight">Pricing & Billing</h1>
-          <p className="mt-2 max-w-2xl text-zinc-400">
+        <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 sm:p-8">
+          <h1 className="text-3xl font-bold text-fg tracking-tight">Pricing & Billing</h1>
+          <p className="mt-2 max-w-2xl text-fg-2">
             Compare monthly and annual plans, unlock the student discount, and manage seats for team subscriptions.
           </p>
           {billingStatus && !billingStatus.available && (
-            <div className="mt-4 rounded-xl border border-amber-300/30 bg-amber-300/10 p-4 text-sm text-amber-100">
+            <div className="mt-4 rounded-[var(--radius-lg)] border border-warn/30 bg-warn/10 p-4 text-sm text-warn">
               <p className="font-semibold">
                 {billingStatus.mode === 'disabled' ? 'Billing Disabled' : 'Billing Unavailable'}
               </p>
-              <p className="mt-1 text-amber-100/80">{billingStatus.message}</p>
+              <p className="mt-1 text-warn/80">{billingStatus.message}</p>
             </div>
           )}
           {studentVerifyToken && !sessionToken && !isPending && (
-            <div className="mt-4 rounded-xl border border-sky-300/30 bg-sky-300/10 p-4 text-sm text-sky-100">
+            <div className="mt-4 rounded-[var(--radius-lg)] border border-accent/30 bg-accent-soft p-4 text-sm text-accent-strong">
               Sign in first to finish student verification.
             </div>
           )}
           {teamInviteToken && !sessionToken && !isPending && (
-            <div className="mt-4 rounded-xl border border-sky-300/30 bg-sky-300/10 p-4 text-sm text-sky-100">
+            <div className="mt-4 rounded-[var(--radius-lg)] border border-accent/30 bg-accent-soft p-4 text-sm text-accent-strong">
               Sign in with the invited email address to activate your team seat.
             </div>
           )}
         </section>
 
-        <section className="surface-panel edge-highlight p-5 sm:p-6">
+        <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 sm:p-6">
           <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-white">Choose a plan</h2>
-              <p className="mt-1 text-sm text-slate-400">Annual billing saves 20% on Basic, Pro, and BYOK.</p>
+              <h2 className="text-lg font-semibold text-fg">Choose a plan</h2>
+              <p className="mt-1 text-sm text-fg-2">Annual billing saves 20% on Basic, Pro, and BYOK.</p>
             </div>
-            <div className="inline-flex rounded-xl border border-white/10 bg-slate-950/70 p-1">
+            <div className="inline-flex rounded-[var(--radius-lg)] border border-line bg-bg p-1">
               <button
                 onClick={() => setBillingPeriod('monthly')}
-                className={`rounded-lg px-4 py-2 text-sm ${billingPeriod === 'monthly' ? 'bg-orange-300 text-slate-950' : 'text-slate-300'}`}
+                className={`rounded-[var(--radius-md)] px-4 py-2 text-sm ${billingPeriod === 'monthly' ? 'bg-accent text-accent-fg' : 'text-fg-2'}`}
               >
                 Monthly
               </button>
               <button
                 onClick={() => setBillingPeriod('annual')}
-                className={`rounded-lg px-4 py-2 text-sm ${billingPeriod === 'annual' ? 'bg-orange-300 text-slate-950' : 'text-slate-300'}`}
+                className={`rounded-[var(--radius-md)] px-4 py-2 text-sm ${billingPeriod === 'annual' ? 'bg-accent text-accent-fg' : 'text-fg-2'}`}
               >
                 Annual
               </button>
@@ -389,41 +389,41 @@ function BillingPageContent() {
           </div>
 
           <div className="mb-5 grid gap-4 lg:grid-cols-[1.6fr_1fr]">
-            <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4">
-              <p className="text-sm font-medium text-white">Have a coupon code?</p>
+            <div className="rounded-[var(--radius-lg)] border border-line bg-bg p-4">
+              <p className="text-sm font-medium text-fg">Have a coupon code?</p>
               <div className="mt-3 flex flex-col gap-3 sm:flex-row">
                 <input
                   value={couponCode}
                   onChange={(event) => setCouponCode(event.target.value.toUpperCase())}
                   placeholder="SAVE20"
-                  className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none placeholder:text-slate-500"
+                  className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none placeholder:text-fg-3"
                 />
                 <button
                   onClick={handleApplyCoupon}
                   disabled={couponLoading || !couponCode.trim()}
-                  className="rounded-lg border border-white/15 px-4 py-2 text-sm text-slate-100 hover:bg-white/10 disabled:opacity-60"
+                  className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-sm text-fg hover:bg-surface-2 disabled:opacity-60"
                 >
                   {couponLoading ? 'Applying...' : 'Apply'}
                 </button>
               </div>
               {couponState && (
-                <p className={`mt-3 text-sm ${couponState.valid ? 'text-emerald-200' : 'text-rose-300'}`}>
+                <p className={`mt-3 text-sm ${couponState.valid ? 'text-ok' : 'text-err'}`}>
                   {couponState.message}
                   {couponState.valid && couponState.discountPercent ? ` (${couponState.discountPercent}% off)` : ''}
                 </p>
               )}
             </div>
 
-            <div className="rounded-xl border border-sky-300/20 bg-sky-300/10 p-4">
-              <p className="text-sm font-semibold text-sky-100">Student plan</p>
-              <p className="mt-2 text-sm text-sky-50/80">
+            <div className="rounded-[var(--radius-lg)] border border-accent/20 bg-accent-soft p-4">
+              <p className="text-sm font-semibold text-accent-strong">Student plan</p>
+              <p className="mt-2 text-sm text-fg-2">
                 Get Pro-level features at 50% off after verifying an academic email address.
               </p>
             </div>
           </div>
 
           {loading ? (
-            <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-slate-300">Loading plans...</div>
+            <div className="rounded-[var(--radius-lg)] border border-line bg-bg p-4 text-fg-2">Loading plans...</div>
           ) : (
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
               {visiblePlans.map((plan) => (
@@ -441,11 +441,11 @@ function BillingPageContent() {
           )}
         </section>
 
-        <section className="surface-panel edge-highlight p-5 sm:p-6">
-          <h2 className="text-lg font-semibold text-white">Current subscription</h2>
+        <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 sm:p-6">
+          <h2 className="text-lg font-semibold text-fg">Current subscription</h2>
           <div className="mt-4">
             {isPending ? (
-              <div className="surface-card p-4 text-slate-300">Loading subscription state...</div>
+              <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-4 text-fg-2">Loading subscription state...</div>
             ) : isAuthenticated ? (
               <SubscriptionManager
                 authToken={sessionToken}
@@ -454,14 +454,14 @@ function BillingPageContent() {
                 onLoaded={setCurrentSubscription}
               />
             ) : (
-              <div className="surface-card p-5">
-                <h3 className="text-lg font-semibold text-white">Public pricing view</h3>
-                <p className="mt-2 text-sm text-slate-400">
+              <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+                <h3 className="text-lg font-semibold text-fg">Public pricing view</h3>
+                <p className="mt-2 text-sm text-fg-2">
                   Sign in to subscribe, manage billing, or redeem team invitations.
                 </p>
                 <button
                   onClick={() => router.push('/login?next=/billing')}
-                  className="mt-4 rounded-lg bg-orange-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-orange-200"
+                  className="mt-4 rounded-[var(--radius-md)] bg-accent px-4 py-2 text-sm font-semibold text-accent-fg hover:brightness-110"
                 >
                   Sign In to Subscribe
                 </button>
@@ -471,11 +471,11 @@ function BillingPageContent() {
         </section>
 
         {currentSubscription?.planId === 'team' && (
-          <section className="surface-panel edge-highlight p-5 sm:p-6">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 sm:p-6">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
               <div>
-                <h2 className="text-lg font-semibold text-white">Team seats</h2>
-                <p className="mt-1 text-sm text-slate-400">Invite up to 5 teammates and manage active seats.</p>
+                <h2 className="text-lg font-semibold text-fg">Team seats</h2>
+                <p className="mt-1 text-sm text-fg-2">Invite up to 5 teammates and manage active seats.</p>
               </div>
             </div>
 
@@ -484,12 +484,12 @@ function BillingPageContent() {
                 value={inviteEmail}
                 onChange={(event) => setInviteEmail(event.target.value)}
                 placeholder="teammate@company.com"
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none placeholder:text-slate-500"
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none placeholder:text-fg-3"
               />
               <button
                 onClick={handleInviteSeat}
                 disabled={teamLoading || !inviteEmail.trim()}
-                className="rounded-lg border border-white/15 px-4 py-2 text-sm text-slate-100 hover:bg-white/10 disabled:opacity-60"
+                className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-sm text-fg hover:bg-surface-2 disabled:opacity-60"
               >
                 {teamLoading ? 'Inviting...' : 'Invite teammate'}
               </button>
@@ -497,21 +497,21 @@ function BillingPageContent() {
 
             <div className="space-y-3">
               {teamSeats.length === 0 ? (
-                <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-sm text-slate-400">
+                <div className="rounded-[var(--radius-lg)] border border-line bg-bg p-4 text-sm text-fg-2">
                   No team seats assigned yet.
                 </div>
               ) : (
                 teamSeats.map((seat) => (
-                  <div key={seat.id} className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-slate-950/60 p-4">
+                  <div key={seat.id} className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-lg)] border border-line bg-bg p-4">
                     <div>
-                      <p className="text-sm font-medium text-white">{seat.member_email}</p>
-                      <p className="mt-1 text-xs text-slate-400">
+                      <p className="text-sm font-medium text-fg">{seat.member_email}</p>
+                      <p className="mt-1 text-xs text-fg-2">
                         {seat.status} • invited {new Date(seat.invited_at).toLocaleDateString()}
                       </p>
                     </div>
                     <button
                       onClick={() => handleRemoveSeat(seat.id)}
-                      className="rounded-lg border border-rose-300/30 bg-rose-300/10 px-3 py-2 text-sm text-rose-100 hover:bg-rose-300/20"
+                      className="rounded-[var(--radius-md)] border border-err/30 bg-err/10 px-3 py-2 text-sm text-err hover:bg-err/20"
                     >
                       Remove
                     </button>
@@ -523,9 +523,9 @@ function BillingPageContent() {
         )}
 
         {studentCheckoutPlan && (
-          <section className="surface-panel edge-highlight p-5 sm:p-6">
-            <h2 className="text-lg font-semibold text-white">Verify student plan</h2>
-            <p className="mt-2 max-w-2xl text-sm text-slate-400">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 sm:p-6">
+            <h2 className="text-lg font-semibold text-fg">Verify student plan</h2>
+            <p className="mt-2 max-w-2xl text-sm text-fg-2">
               Enter your academic email address. We’ll send a verification link before activating the discounted student plan.
             </p>
             <div className="mt-4 flex flex-col gap-3 sm:flex-row">
@@ -533,12 +533,12 @@ function BillingPageContent() {
                 value={studentEmail}
                 onChange={(event) => setStudentEmail(event.target.value)}
                 placeholder="you@university.edu"
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none placeholder:text-slate-500"
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none placeholder:text-fg-3"
               />
               <button
                 onClick={handleStudentCheckout}
                 disabled={!studentEmail.trim() || activePlan === studentCheckoutPlan}
-                className="rounded-lg bg-orange-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-orange-200 disabled:opacity-60"
+                className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-sm font-semibold text-accent-fg hover:brightness-110 disabled:opacity-60"
               >
                 {activePlan === studentCheckoutPlan ? 'Sending...' : 'Send Verification'}
               </button>
@@ -547,7 +547,7 @@ function BillingPageContent() {
                   setStudentCheckoutPlan(null)
                   setStudentEmail('')
                 }}
-                className="rounded-lg border border-white/15 px-4 py-2 text-sm text-slate-100 hover:bg-white/10"
+                className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-sm text-fg hover:bg-surface-2"
               >
                 Cancel
               </button>
@@ -564,7 +564,7 @@ export default function BillingPage() {
     <Suspense
       fallback={(
         <div className="content-shell">
-          <div className="surface-panel edge-highlight p-6 sm:p-8 text-slate-300">
+          <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 sm:p-8 text-fg-2">
             Loading billing page...
           </div>
         </div>

--- a/frontend/src/app/byok/page.tsx
+++ b/frontend/src/app/byok/page.tsx
@@ -43,29 +43,29 @@ export default function BYOKPage() {
   return (
     <div className="content-shell">
       <div className="space-y-6">
-        <section className="surface-panel edge-highlight p-6 sm:p-8 text-center sm:text-left">
-          <h1 className="text-3xl font-bold text-white tracking-tight">API Key Management</h1>
-          <p className="mt-2 mx-auto sm:mx-0 max-w-2xl text-zinc-400">
+        <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 sm:p-8 text-center sm:text-left">
+          <h1 className="text-3xl font-bold text-fg tracking-tight">API Key Management</h1>
+          <p className="mt-2 mx-auto sm:mx-0 max-w-2xl text-fg-2">
             Connect your own model provider keys for direct access and cost-efficient scaling.
           </p>
           <div className="mt-8 grid gap-4 md:grid-cols-3 text-left">
             {points.map((point) => (
-              <article key={point.title} className="surface-card p-5 border border-white/5 bg-white/[0.02]">
-                <h2 className="text-sm font-bold text-white uppercase tracking-wider">{point.title}</h2>
-                <p className="mt-2 text-sm text-zinc-400 leading-relaxed">{point.text}</p>
+              <article key={point.title} className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+                <h2 className="text-sm font-bold text-fg uppercase tracking-wider">{point.title}</h2>
+                <p className="mt-2 text-sm text-fg-2 leading-relaxed">{point.text}</p>
               </article>
             ))}
           </div>
         </section>
 
-        <section className="surface-panel edge-highlight p-5 sm:p-6">
+        <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 sm:p-6">
           <APIKeyManager onKeysChange={setUserApiKeys} />
         </section>
 
-        <section className="surface-panel edge-highlight p-5 sm:p-6">
+        <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 sm:p-6">
           <div className="mb-4">
-            <h2 className="text-xl font-semibold text-white">Provider Capabilities</h2>
-            <p className="text-sm text-zinc-400">
+            <h2 className="text-xl font-semibold text-fg">Provider Capabilities</h2>
+            <p className="text-sm text-fg-2">
               Explore supported providers, models, and features. Click a provider to see details.
             </p>
           </div>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -147,17 +147,17 @@ export default function DashboardPage() {
   if (!session) {
     return (
       <div className="content-shell">
-        <section className="surface-panel edge-highlight mx-auto max-w-3xl p-8 text-center">
-          <p className="overline">Analytics</p>
-          <h1 className="mt-2 text-3xl font-semibold text-white">Usage Intelligence Dashboard</h1>
-          <p className="mx-auto mt-3 max-w-xl text-zinc-400">
+        <section className="rounded-[var(--radius-lg)] border border-line bg-surface mx-auto max-w-3xl p-8 text-center">
+          <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Analytics</p>
+          <h1 className="mt-2 text-3xl font-semibold text-fg">Usage Intelligence Dashboard</h1>
+          <p className="mx-auto mt-3 max-w-xl text-fg-2">
             Signed-in users get pipeline analytics, feature usage charts, and run-performance signals over configurable time windows.
           </p>
           <div className="mt-6 flex justify-center gap-3">
-            <Link href="/login" className="btn-accent px-6 py-2.5 text-sm">
+            <Link href="/login" className="rounded-[var(--radius-md)] bg-accent px-6 py-2.5 text-sm font-semibold text-accent-fg hover:brightness-110">
               Sign In
             </Link>
-            <Link href="/" className="btn-ghost px-6 py-2.5 text-sm">
+            <Link href="/" className="rounded-[var(--radius-md)] border border-line-2 px-6 py-2.5 text-sm text-fg hover:bg-surface-2">
               View Public Site
             </Link>
           </div>
@@ -170,39 +170,39 @@ export default function DashboardPage() {
     <div className="content-shell space-y-6">
       <section className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <p className="overline">Dashboard</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">Usage Intelligence</h1>
-          <p className="mt-1 text-sm text-zinc-400">Detailed analytics for your personal resume optimization workflow.</p>
+          <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Dashboard</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-fg">Usage Intelligence</h1>
+          <p className="mt-1 text-sm text-fg-2">Detailed analytics for your personal resume optimization workflow.</p>
         </div>
         <div className="flex flex-wrap gap-2">
           {ranges.map((range) => (
             <button
               key={range.days}
               onClick={() => setSelectedRange(range.days)}
-              className={`rounded-lg border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition ${
+              className={`rounded-[var(--radius-md)] border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition ${
                 selectedRange === range.days
-                  ? 'border-orange-300/45 bg-orange-300/10 text-orange-200'
-                  : 'border-white/10 bg-white/5 text-zinc-400 hover:border-white/20 hover:text-white'
+                  ? 'border-accent bg-accent-soft text-accent-strong'
+                  : 'border-line bg-surface-2 text-fg-2 hover:border-line-2 hover:text-fg'
               }`}
             >
               {range.label}
             </button>
           ))}
-          <Link href="/workspace" className="btn-ghost px-4 py-1.5 text-xs">
+          <Link href="/workspace" className="rounded-[var(--radius-md)] border border-line-2 px-4 py-1.5 text-xs text-fg hover:bg-surface-2">
             Workspace
           </Link>
         </div>
       </section>
 
       {error && !loading && (
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-lg)] border border-err/30 bg-err/10 px-4 py-3">
           <div>
-            <p className="text-sm font-semibold text-rose-200">Couldn&apos;t load dashboard data</p>
-            <p className="text-xs text-rose-300/80">{error}</p>
+            <p className="text-sm font-semibold text-err">Couldn&apos;t load dashboard data</p>
+            <p className="text-xs text-err/80">{error}</p>
           </div>
           <button
             onClick={fetchDashboardData}
-            className="rounded-lg border border-rose-400/40 bg-rose-500/10 px-4 py-1.5 text-xs font-semibold text-rose-100 transition hover:bg-rose-500/20"
+            className="rounded-[var(--radius-md)] border border-err/40 bg-err/10 px-4 py-1.5 text-xs font-semibold text-err transition hover:bg-err/20"
           >
             Retry
           </button>
@@ -211,72 +211,72 @@ export default function DashboardPage() {
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
         {loading
-          ? Array.from({ length: 5 }).map((_, index) => <div key={index} className="surface-card h-28 animate-pulse" />)
+          ? Array.from({ length: 5 }).map((_, index) => <div key={index} className="rounded-[var(--radius-lg)] border border-line bg-surface h-28 animate-pulse" />)
           : kpis.map((item) => (
-              <article key={item.label} className="surface-card edge-highlight p-4">
-                <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">{item.label}</p>
-                <p className="mt-2 text-3xl font-semibold text-white">{item.value}</p>
-                <p className="mt-1 text-xs text-zinc-400">{item.note}</p>
+              <article key={item.label} className="rounded-[var(--radius-lg)] border border-line bg-surface p-4">
+                <p className="text-xs uppercase tracking-[0.14em] text-fg-3">{item.label}</p>
+                <p className="mt-2 text-3xl font-semibold text-fg">{item.value}</p>
+                <p className="mt-1 text-xs text-fg-2">{item.note}</p>
               </article>
             ))}
       </section>
 
       <div className="grid gap-6 xl:grid-cols-[1fr_340px]">
         <section className="space-y-6">
-          <article className="surface-panel edge-highlight p-5">
+          <article className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
             <div className="mb-3 flex items-end justify-between gap-4">
               <div>
-                <h2 className="text-lg font-semibold text-white">Activity Trend</h2>
-                <p className="text-xs text-zinc-500">Daily action density over the selected window</p>
+                <h2 className="text-lg font-semibold text-fg">Activity Trend</h2>
+                <p className="text-xs text-fg-3">Daily action density over the selected window</p>
               </div>
-              <span className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-zinc-500">
+              <span className="rounded-[var(--radius-md)] border border-line bg-surface-2 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-fg-3">
                 {selectedRange} day window
               </span>
             </div>
-            {loading ? <div className="h-[280px] animate-pulse rounded-xl bg-white/5" /> : <ActivityAreaChart data={dailySeries} />}
+            {loading ? <div className="h-[280px] animate-pulse rounded-[var(--radius-lg)] bg-surface-2" /> : <ActivityAreaChart data={dailySeries} />}
           </article>
 
-          <article className="surface-panel edge-highlight p-5">
+          <article className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
             <div className="mb-3">
-              <h2 className="text-lg font-semibold text-white">Feature Usage Mix</h2>
-              <p className="text-xs text-zinc-500">Most used actions in your current range</p>
+              <h2 className="text-lg font-semibold text-fg">Feature Usage Mix</h2>
+              <p className="text-xs text-fg-3">Most used actions in your current range</p>
             </div>
-            {loading ? <div className="h-[260px] animate-pulse rounded-xl bg-white/5" /> : <FeatureUsageBars data={featureSeries} />}
+            {loading ? <div className="h-[260px] animate-pulse rounded-[var(--radius-lg)] bg-surface-2" /> : <FeatureUsageBars data={featureSeries} />}
           </article>
 
-          <article className="surface-panel edge-highlight p-5">
+          <article className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
             <JobQueue maxJobs={10} showFilters={false} showSearch={false} />
           </article>
         </section>
 
         <aside className="space-y-6">
-          <article className="surface-panel edge-highlight p-5">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-300">Run Status Distribution</h2>
-            <div className="mt-4">{loading ? <div className="h-[220px] animate-pulse rounded-xl bg-white/5" /> : <StatusDonutChart data={statusSeries} />}</div>
+          <article className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-fg-2">Run Status Distribution</h2>
+            <div className="mt-4">{loading ? <div className="h-[220px] animate-pulse rounded-[var(--radius-lg)] bg-surface-2" /> : <StatusDonutChart data={statusSeries} />}</div>
           </article>
 
-          <article className="surface-panel edge-highlight p-5">
+          <article className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
             <div className="mb-3 flex items-center justify-between">
-              <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-300">Recent Runs</h2>
-              <Link href="/workspace/history" className="text-[10px] uppercase tracking-[0.12em] text-orange-200 hover:text-orange-100">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-fg-2">Recent Runs</h2>
+              <Link href="/workspace/history" className="text-[10px] uppercase tracking-[0.12em] text-accent-strong hover:brightness-110">
                 Full history
               </Link>
             </div>
             {loading ? (
               <div className="space-y-2">
                 {Array.from({ length: 4 }).map((_, index) => (
-                  <div key={index} className="h-14 animate-pulse rounded-lg bg-white/5" />
+                  <div key={index} className="h-14 animate-pulse rounded-[var(--radius-md)] bg-surface-2" />
                 ))}
               </div>
             ) : recentJobs.length === 0 ? (
-              <p className="text-sm text-zinc-500">No recent jobs recorded.</p>
+              <p className="text-sm text-fg-3">No recent jobs recorded.</p>
             ) : (
               <div className="space-y-2">
                 {recentJobs.map((job, index) => (
-                  <div key={job.job_id ?? `${job.last_updated}-${index}`} className="rounded-lg border border-white/10 bg-black/20 p-3">
-                    <p className="text-xs uppercase tracking-[0.12em] text-zinc-500">{job.stage || 'Pipeline'}</p>
-                    <p className="mt-1 text-sm capitalize text-zinc-200">{job.status}</p>
-                    <p className="mt-1 text-xs text-zinc-500">{new Date(job.last_updated * 1000).toLocaleString()}</p>
+                  <div key={job.job_id ?? `${job.last_updated}-${index}`} className="rounded-[var(--radius-md)] border border-line bg-surface-2 p-3">
+                    <p className="text-xs uppercase tracking-[0.12em] text-fg-3">{job.stage || 'Pipeline'}</p>
+                    <p className="mt-1 text-sm capitalize text-fg">{job.status}</p>
+                    <p className="mt-1 text-xs text-fg-3">{new Date(job.last_updated * 1000).toLocaleString()}</p>
                   </div>
                 ))}
               </div>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -249,31 +249,31 @@ function SettingsContent() {
   }
 
   return (
-    <div className="min-h-screen overflow-x-hidden bg-[#080808] px-4 py-10">
+    <div className="min-h-screen overflow-x-hidden bg-bg px-4 py-10">
       <div className="mx-auto max-w-xl space-y-8">
         {/* Header */}
         <div>
-          <h1 className="text-2xl font-semibold text-zinc-100">Settings</h1>
-          <p className="mt-1 text-sm text-zinc-500">Manage your account preferences</p>
+          <h1 className="text-2xl font-semibold text-fg">Settings</h1>
+          <p className="mt-1 text-sm text-fg-3">Manage your account preferences</p>
         </div>
 
         {/* GitHub Integration card */}
-        <div className="rounded-xl border border-white/[0.07] bg-[#0d0d0d] p-6 space-y-6">
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 space-y-6">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-zinc-800">
-              <Github size={14} className="text-zinc-200" />
+            <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] bg-surface-2">
+              <Github size={14} className="text-fg" />
             </div>
-            <h2 className="text-base font-semibold text-zinc-100">GitHub Integration</h2>
+            <h2 className="text-base font-semibold text-fg">GitHub Integration</h2>
           </div>
 
           {ghSuccess && (
-            <p className="rounded-lg bg-emerald-500/10 px-3 py-2 text-[11px] text-emerald-400 ring-1 ring-emerald-500/20">
+            <p className="rounded-[var(--radius-md)] bg-ok/10 px-3 py-2 text-[11px] text-ok ring-1 ring-ok/20">
               {ghSuccess}
             </p>
           )}
 
           {ghLoading ? (
-            <div className="flex items-center gap-2 text-zinc-500 text-sm">
+            <div className="flex items-center gap-2 text-fg-3 text-sm">
               <Loader2 size={14} className="animate-spin" />
               Checking GitHub status…
             </div>
@@ -281,12 +281,12 @@ function SettingsContent() {
             <div className="space-y-4">
               <div className="flex items-center justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/15">
-                    <CheckCircle size={14} className="text-emerald-400" />
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-ok/15">
+                    <CheckCircle size={14} className="text-ok" />
                   </div>
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-zinc-200 break-words">Connected as <span className="text-emerald-300">{ghStatus.username}</span></p>
-                    <p className="text-[11px] text-zinc-500">
+                    <p className="text-sm font-medium text-fg break-words">Connected as <span className="text-ok">{ghStatus.username}</span></p>
+                    <p className="text-[11px] text-fg-3">
                       Resume sync enabled. Toggle per-resume in the editor.
                     </p>
                   </div>
@@ -298,7 +298,7 @@ function SettingsContent() {
                   href={`https://github.com/${ghStatus.username}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-3 py-1.5 text-[11px] font-medium text-zinc-400 transition hover:text-zinc-200"
+                  className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-[11px] font-medium text-fg-2 transition hover:text-fg"
                 >
                   <ExternalLink size={11} />
                   View Profile
@@ -306,7 +306,7 @@ function SettingsContent() {
                 <button
                   onClick={handleDisconnectGitHub}
                   disabled={ghDisconnecting}
-                  className="flex items-center gap-1.5 rounded-lg border border-rose-500/20 px-3 py-1.5 text-[11px] font-medium text-rose-400 transition hover:bg-rose-500/10 disabled:opacity-40"
+                  className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-err/20 px-3 py-1.5 text-[11px] font-medium text-err transition hover:bg-err/10 disabled:opacity-40"
                 >
                   {ghDisconnecting ? <Loader2 size={11} className="animate-spin" /> : <Unlink size={11} />}
                   {ghDisconnecting ? 'Disconnecting…' : 'Disconnect'}
@@ -315,13 +315,13 @@ function SettingsContent() {
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-[12px] text-zinc-500">
+              <p className="text-[12px] text-fg-3">
                 Connect your GitHub account to sync resume LaTeX source to a private repository.
                 Push from the editor manually to save a version in Git.
               </p>
               <button
                 onClick={handleConnectGitHub}
-                className="flex items-center gap-2 rounded-lg bg-zinc-800 px-4 py-2 text-sm font-semibold text-zinc-100 ring-1 ring-white/[0.1] transition hover:bg-zinc-700"
+                className="flex items-center gap-2 rounded-[var(--radius-md)] bg-surface-2 px-4 py-2 text-sm font-semibold text-fg ring-1 ring-line transition hover:bg-surface-2 hover:brightness-110"
               >
                 <Github size={14} />
                 Connect GitHub
@@ -330,29 +330,29 @@ function SettingsContent() {
           )}
 
           {ghError && (
-            <p className="rounded-lg bg-rose-500/10 px-3 py-2 text-[11px] text-rose-400 ring-1 ring-rose-500/20">
+            <p className="rounded-[var(--radius-md)] bg-err/10 px-3 py-2 text-[11px] text-err ring-1 ring-err/20">
               {ghError}
             </p>
           )}
         </div>
 
         {/* Zotero Integration card (Feature 42) */}
-        <div className="rounded-xl border border-white/[0.07] bg-[#0d0d0d] p-6 space-y-6">
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 space-y-6">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[#CC2936]/15">
-              <BookOpen size={14} className="text-red-300" />
+            <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+              <BookOpen size={14} className="text-accent-strong" />
             </div>
-            <h2 className="text-base font-semibold text-zinc-100">Zotero Integration</h2>
+            <h2 className="text-base font-semibold text-fg">Zotero Integration</h2>
           </div>
 
           {zotSuccess && (
-            <p className="rounded-lg bg-emerald-500/10 px-3 py-2 text-[11px] text-emerald-400 ring-1 ring-emerald-500/20">
+            <p className="rounded-[var(--radius-md)] bg-ok/10 px-3 py-2 text-[11px] text-ok ring-1 ring-ok/20">
               {zotSuccess}
             </p>
           )}
 
           {zotLoading ? (
-            <div className="flex items-center gap-2 text-zinc-500 text-sm">
+            <div className="flex items-center gap-2 text-fg-3 text-sm">
               <Loader2 size={14} className="animate-spin" />
               Checking Zotero status…
             </div>
@@ -360,14 +360,14 @@ function SettingsContent() {
             <div className="space-y-4">
               <div className="flex items-center justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/15">
-                    <CheckCircle size={14} className="text-emerald-400" />
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-ok/15">
+                    <CheckCircle size={14} className="text-ok" />
                   </div>
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-zinc-200 break-words">
-                      Connected as <span className="text-emerald-300">@{zotStatus.username}</span>
+                    <p className="text-sm font-medium text-fg break-words">
+                      Connected as <span className="text-ok">@{zotStatus.username}</span>
                     </p>
-                    <p className="text-[11px] text-zinc-500">
+                    <p className="text-[11px] text-fg-3">
                       Import your library from the References panel in the editor.
                     </p>
                   </div>
@@ -376,7 +376,7 @@ function SettingsContent() {
               <button
                 onClick={handleDisconnectZotero}
                 disabled={zotDisconnecting}
-                className="flex items-center gap-1.5 rounded-lg border border-rose-500/20 px-3 py-1.5 text-[11px] font-medium text-rose-400 transition hover:bg-rose-500/10 disabled:opacity-40"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-err/20 px-3 py-1.5 text-[11px] font-medium text-err transition hover:bg-err/10 disabled:opacity-40"
               >
                 {zotDisconnecting ? <Loader2 size={11} className="animate-spin" /> : <Unlink size={11} />}
                 {zotDisconnecting ? 'Disconnecting…' : 'Disconnect Zotero'}
@@ -384,12 +384,12 @@ function SettingsContent() {
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-[12px] text-zinc-500">
+              <p className="text-[12px] text-fg-3">
                 Connect your Zotero account to import your reference library as BibTeX directly into any resume.
               </p>
               <button
                 onClick={handleConnectZotero}
-                className="flex items-center gap-2 rounded-lg bg-[#CC2936]/15 px-4 py-2 text-sm font-semibold text-red-200 ring-1 ring-red-500/20 transition hover:bg-[#CC2936]/25"
+                className="flex items-center gap-2 rounded-[var(--radius-md)] bg-accent-soft px-4 py-2 text-sm font-semibold text-accent-strong ring-1 ring-accent/20 transition hover:brightness-110"
               >
                 <ExternalLink size={14} />
                 Connect Zotero
@@ -398,29 +398,29 @@ function SettingsContent() {
           )}
 
           {zotError && (
-            <p className="rounded-lg bg-rose-500/10 px-3 py-2 text-[11px] text-rose-400 ring-1 ring-rose-500/20">
+            <p className="rounded-[var(--radius-md)] bg-err/10 px-3 py-2 text-[11px] text-err ring-1 ring-err/20">
               {zotError}
             </p>
           )}
         </div>
 
         {/* Mendeley Integration card (Feature 42) */}
-        <div className="rounded-xl border border-white/[0.07] bg-[#0d0d0d] p-6 space-y-6">
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 space-y-6">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-rose-500/10">
-              <BookOpen size={14} className="text-rose-300" />
+            <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+              <BookOpen size={14} className="text-accent-strong" />
             </div>
-            <h2 className="text-base font-semibold text-zinc-100">Mendeley Integration</h2>
+            <h2 className="text-base font-semibold text-fg">Mendeley Integration</h2>
           </div>
 
           {menSuccess && (
-            <p className="rounded-lg bg-emerald-500/10 px-3 py-2 text-[11px] text-emerald-400 ring-1 ring-emerald-500/20">
+            <p className="rounded-[var(--radius-md)] bg-ok/10 px-3 py-2 text-[11px] text-ok ring-1 ring-ok/20">
               {menSuccess}
             </p>
           )}
 
           {menLoading ? (
-            <div className="flex items-center gap-2 text-zinc-500 text-sm">
+            <div className="flex items-center gap-2 text-fg-3 text-sm">
               <Loader2 size={14} className="animate-spin" />
               Checking Mendeley status…
             </div>
@@ -428,14 +428,14 @@ function SettingsContent() {
             <div className="space-y-4">
               <div className="flex items-center justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/15">
-                    <CheckCircle size={14} className="text-emerald-400" />
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-ok/15">
+                    <CheckCircle size={14} className="text-ok" />
                   </div>
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-zinc-200 break-words">
-                      Connected as <span className="text-emerald-300">{menStatus.name ?? 'Mendeley User'}</span>
+                    <p className="text-sm font-medium text-fg break-words">
+                      Connected as <span className="text-ok">{menStatus.name ?? 'Mendeley User'}</span>
                     </p>
-                    <p className="text-[11px] text-zinc-500">
+                    <p className="text-[11px] text-fg-3">
                       Import your library from the References panel in the editor.
                     </p>
                   </div>
@@ -444,7 +444,7 @@ function SettingsContent() {
               <button
                 onClick={handleDisconnectMendeley}
                 disabled={menDisconnecting}
-                className="flex items-center gap-1.5 rounded-lg border border-rose-500/20 px-3 py-1.5 text-[11px] font-medium text-rose-400 transition hover:bg-rose-500/10 disabled:opacity-40"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-err/20 px-3 py-1.5 text-[11px] font-medium text-err transition hover:bg-err/10 disabled:opacity-40"
               >
                 {menDisconnecting ? <Loader2 size={11} className="animate-spin" /> : <Unlink size={11} />}
                 {menDisconnecting ? 'Disconnecting…' : 'Disconnect Mendeley'}
@@ -452,12 +452,12 @@ function SettingsContent() {
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-[12px] text-zinc-500">
+              <p className="text-[12px] text-fg-3">
                 Connect your Mendeley account to import your research library as BibTeX directly into any resume.
               </p>
               <button
                 onClick={handleConnectMendeley}
-                className="flex items-center gap-2 rounded-lg bg-rose-500/10 px-4 py-2 text-sm font-semibold text-rose-200 ring-1 ring-rose-500/20 transition hover:bg-rose-500/20"
+                className="flex items-center gap-2 rounded-[var(--radius-md)] bg-accent-soft px-4 py-2 text-sm font-semibold text-accent-strong ring-1 ring-accent/20 transition hover:brightness-110"
               >
                 <ExternalLink size={14} />
                 Connect Mendeley
@@ -466,41 +466,41 @@ function SettingsContent() {
           )}
 
           {menError && (
-            <p className="rounded-lg bg-rose-500/10 px-3 py-2 text-[11px] text-rose-400 ring-1 ring-rose-500/20">
+            <p className="rounded-[var(--radius-md)] bg-err/10 px-3 py-2 text-[11px] text-err ring-1 ring-err/20">
               {menError}
             </p>
           )}
         </div>
 
         {/* Dropbox Integration card (Feature 77) */}
-        <div className="rounded-xl border border-white/[0.07] bg-[#0d0d0d] p-6 space-y-6">
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 space-y-6">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-blue-500/15">
-              <Cloud size={14} className="text-blue-300" />
+            <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+              <Cloud size={14} className="text-accent-strong" />
             </div>
-            <h2 className="text-base font-semibold text-zinc-100">Dropbox Integration</h2>
+            <h2 className="text-base font-semibold text-fg">Dropbox Integration</h2>
           </div>
 
           {dbxSuccess && (
-            <p className="rounded-lg bg-emerald-500/10 px-3 py-2 text-[11px] text-emerald-400 ring-1 ring-emerald-500/20">
+            <p className="rounded-[var(--radius-md)] bg-ok/10 px-3 py-2 text-[11px] text-ok ring-1 ring-ok/20">
               {dbxSuccess}
             </p>
           )}
 
           {dbxLoading ? (
-            <div className="flex items-center gap-2 text-zinc-500 text-sm">
+            <div className="flex items-center gap-2 text-fg-3 text-sm">
               <Loader2 size={14} className="animate-spin" />
               Checking Dropbox status…
             </div>
           ) : dbxStatus.connected ? (
             <div className="space-y-4">
               <div className="flex min-w-0 items-center gap-3">
-                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/15">
-                  <CheckCircle size={14} className="text-emerald-400" />
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-ok/15">
+                  <CheckCircle size={14} className="text-ok" />
                 </div>
                 <div className="min-w-0">
-                  <p className="text-sm font-medium text-zinc-200">Dropbox connected</p>
-                  <p className="text-[11px] text-zinc-500">
+                  <p className="text-sm font-medium text-fg">Dropbox connected</p>
+                  <p className="text-[11px] text-fg-3">
                     Sync is enabled. Toggle per-resume sync from the editor toolbar.
                   </p>
                 </div>
@@ -508,7 +508,7 @@ function SettingsContent() {
               <button
                 onClick={handleDisconnectDropbox}
                 disabled={dbxDisconnecting}
-                className="flex items-center gap-1.5 rounded-lg border border-rose-500/20 px-3 py-1.5 text-[11px] font-medium text-rose-400 transition hover:bg-rose-500/10 disabled:opacity-40"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-err/20 px-3 py-1.5 text-[11px] font-medium text-err transition hover:bg-err/10 disabled:opacity-40"
               >
                 {dbxDisconnecting ? <Loader2 size={11} className="animate-spin" /> : <Unlink size={11} />}
                 {dbxDisconnecting ? 'Disconnecting…' : 'Disconnect Dropbox'}
@@ -516,14 +516,14 @@ function SettingsContent() {
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-[12px] text-zinc-500">
+              <p className="text-[12px] text-fg-3">
                 Connect your Dropbox account to sync resume LaTeX source to{' '}
-                <span className="font-mono text-zinc-400">/Latexy/</span> in your Dropbox.
+                <span className="font-mono text-fg-2">/Latexy/</span> in your Dropbox.
                 Push and pull from the editor toolbar per resume.
               </p>
               <button
                 onClick={handleConnectDropbox}
-                className="flex items-center gap-2 rounded-lg bg-blue-500/15 px-4 py-2 text-sm font-semibold text-blue-200 ring-1 ring-blue-500/20 transition hover:bg-blue-500/25"
+                className="flex items-center gap-2 rounded-[var(--radius-md)] bg-accent-soft px-4 py-2 text-sm font-semibold text-accent-strong ring-1 ring-accent/20 transition hover:brightness-110"
               >
                 <Cloud size={14} />
                 Connect Dropbox
@@ -532,23 +532,23 @@ function SettingsContent() {
           )}
 
           {dbxError && (
-            <p className="rounded-lg bg-rose-500/10 px-3 py-2 text-[11px] text-rose-400 ring-1 ring-rose-500/20">
+            <p className="rounded-[var(--radius-md)] bg-err/10 px-3 py-2 text-[11px] text-err ring-1 ring-err/20">
               {dbxError}
             </p>
           )}
         </div>
 
         {/* Notification preferences card */}
-        <div className="rounded-xl border border-white/[0.07] bg-[#0d0d0d] p-6 space-y-6">
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 space-y-6">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-violet-500/15">
-              <Bell size={14} className="text-violet-300" />
+            <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+              <Bell size={14} className="text-accent-strong" />
             </div>
-            <h2 className="text-base font-semibold text-zinc-100">Email Notifications</h2>
+            <h2 className="text-base font-semibold text-fg">Email Notifications</h2>
           </div>
 
           {loading ? (
-            <div className="flex items-center gap-2 text-zinc-500 text-sm">
+            <div className="flex items-center gap-2 text-fg-3 text-sm">
               <Loader2 size={14} className="animate-spin" />
               Loading preferences…
             </div>
@@ -557,12 +557,12 @@ function SettingsContent() {
               {/* Job completed toggle */}
               <label className="flex items-start justify-between gap-4 cursor-pointer">
                 <div className="flex items-start gap-3">
-                  <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
-                    <Mail size={13} className="text-emerald-400" />
+                  <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+                    <Mail size={13} className="text-accent-strong" />
                   </div>
                   <div>
-                    <p className="text-sm font-medium text-zinc-200">Job completion emails</p>
-                    <p className="mt-0.5 text-[11px] text-zinc-500">
+                    <p className="text-sm font-medium text-fg">Job completion emails</p>
+                    <p className="mt-0.5 text-[11px] text-fg-3">
                       Receive an email when your resume optimization or compilation finishes
                     </p>
                   </div>
@@ -578,28 +578,28 @@ function SettingsContent() {
                     }
                   }}
                   className={`relative mt-0.5 h-5 w-9 shrink-0 rounded-full transition-colors ${
-                    prefs.job_completed ? 'bg-violet-600' : 'bg-white/10'
+                    prefs.job_completed ? 'bg-accent' : 'bg-surface-2'
                   }`}
                 >
                   <span
-                    className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                    className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-fg shadow transition-transform ${
                       prefs.job_completed ? 'translate-x-4' : 'translate-x-0'
                     }`}
                   />
                 </button>
               </label>
 
-              <div className="border-t border-white/[0.05]" />
+              <div className="border-t border-line" />
 
               {/* Weekly digest toggle */}
               <label className="flex items-start justify-between gap-4 cursor-pointer">
                 <div className="flex items-start gap-3">
-                  <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
-                    <Calendar size={13} className="text-blue-400" />
+                  <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+                    <Calendar size={13} className="text-accent-strong" />
                   </div>
                   <div>
-                    <p className="text-sm font-medium text-zinc-200">Weekly digest</p>
-                    <p className="mt-0.5 text-[11px] text-zinc-500">
+                    <p className="text-sm font-medium text-fg">Weekly digest</p>
+                    <p className="mt-0.5 text-[11px] text-fg-3">
                       A Monday morning summary of your resume activity and ATS score trends
                     </p>
                   </div>
@@ -615,11 +615,11 @@ function SettingsContent() {
                     }
                   }}
                   className={`relative mt-0.5 h-5 w-9 shrink-0 rounded-full transition-colors ${
-                    prefs.weekly_digest ? 'bg-violet-600' : 'bg-white/10'
+                    prefs.weekly_digest ? 'bg-accent' : 'bg-surface-2'
                   }`}
                 >
                   <span
-                    className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                    className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-fg shadow transition-transform ${
                       prefs.weekly_digest ? 'translate-x-4' : 'translate-x-0'
                     }`}
                   />
@@ -629,7 +629,7 @@ function SettingsContent() {
           )}
 
           {error && (
-            <p className="rounded-lg bg-rose-500/10 px-3 py-2 text-[11px] text-rose-400 ring-1 ring-rose-500/20">
+            <p className="rounded-[var(--radius-md)] bg-err/10 px-3 py-2 text-[11px] text-err ring-1 ring-err/20">
               {error}
             </p>
           )}
@@ -638,12 +638,12 @@ function SettingsContent() {
             <button
               onClick={handleSave}
               disabled={saving || loading}
-              className="flex items-center gap-2 rounded-lg bg-violet-600/80 px-4 py-2 text-sm font-semibold text-white ring-1 ring-violet-500/30 transition hover:bg-violet-600 disabled:opacity-40"
+              className="flex items-center gap-2 rounded-[var(--radius-md)] bg-accent px-4 py-2 text-sm font-semibold text-accent-fg transition hover:brightness-110 disabled:opacity-40"
             >
               {saving ? (
                 <Loader2 size={13} className="animate-spin" />
               ) : saved ? (
-                <CheckCircle size={13} className="text-emerald-300" />
+                <CheckCircle size={13} className="text-accent-fg" />
               ) : (
                 <Save size={13} />
               )}
@@ -653,22 +653,22 @@ function SettingsContent() {
         </div>
 
         {/* Desktop notifications card */}
-        <div className="rounded-xl border border-white/[0.07] bg-[#0d0d0d] p-6 space-y-6">
+        <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-6 space-y-6">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-orange-500/15">
-              <Monitor size={14} className="text-orange-300" />
+            <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+              <Monitor size={14} className="text-accent-strong" />
             </div>
-            <h2 className="text-base font-semibold text-zinc-100">Desktop Notifications</h2>
+            <h2 className="text-base font-semibold text-fg">Desktop Notifications</h2>
           </div>
 
           <label className="flex items-start justify-between gap-4 cursor-pointer">
             <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-500/10">
-                <Bell size={13} className="text-orange-400" />
+              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+                <Bell size={13} className="text-accent-strong" />
               </div>
               <div>
-                <p className="text-sm font-medium text-zinc-200">Browser notifications</p>
-                <p className="mt-0.5 text-[11px] text-zinc-500">
+                <p className="text-sm font-medium text-fg">Browser notifications</p>
+                <p className="mt-0.5 text-[11px] text-fg-3">
                   Get notified when compilation or optimization finishes while the tab is in the background
                 </p>
               </div>
@@ -690,11 +690,11 @@ function SettingsContent() {
                 }
               }}
               className={`relative mt-0.5 h-5 w-9 shrink-0 rounded-full transition-colors ${
-                desktopNotifs ? 'bg-orange-600' : 'bg-white/10'
+                desktopNotifs ? 'bg-accent' : 'bg-surface-2'
               }`}
             >
               <span
-                className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-fg shadow transition-transform ${
                   desktopNotifs ? 'translate-x-4' : 'translate-x-0'
                 }`}
               />
@@ -702,7 +702,7 @@ function SettingsContent() {
           </label>
 
           {typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'denied' && (
-            <p className="rounded-lg bg-yellow-500/10 px-3 py-2 text-[11px] text-yellow-400 ring-1 ring-yellow-500/20">
+            <p className="rounded-[var(--radius-md)] bg-warn/10 px-3 py-2 text-[11px] text-warn ring-1 ring-warn/20">
               Notifications are blocked by your browser. Update your site permissions to enable them.
             </p>
           )}

--- a/frontend/src/app/tracker/page.tsx
+++ b/frontend/src/app/tracker/page.tsx
@@ -28,19 +28,19 @@ import LoadingSpinner from '@/components/LoadingSpinner'
 // ------------------------------------------------------------------ //
 
 const COLUMNS = [
-  { id: 'applied', label: 'Applied', color: 'border-t-blue-500/60', badge: 'bg-blue-500/10 text-blue-300' },
-  { id: 'phone_screen', label: 'Phone Screen', color: 'border-t-violet-500/60', badge: 'bg-violet-500/10 text-violet-300' },
-  { id: 'technical', label: 'Technical', color: 'border-t-amber-500/60', badge: 'bg-amber-500/10 text-amber-300' },
-  { id: 'onsite', label: 'On-Site', color: 'border-t-orange-500/60', badge: 'bg-orange-500/10 text-orange-300' },
-  { id: 'offer', label: 'Offer', color: 'border-t-emerald-500/60', badge: 'bg-emerald-500/10 text-emerald-300' },
-  { id: 'rejected', label: 'Rejected', color: 'border-t-rose-500/60', badge: 'bg-rose-500/10 text-rose-300' },
-  { id: 'withdrawn', label: 'Withdrawn', color: 'border-t-zinc-500/60', badge: 'bg-zinc-500/10 text-zinc-400' },
+  { id: 'applied', label: 'Applied', color: 'border-t-accent/60', badge: 'bg-accent-soft text-accent-strong' },
+  { id: 'phone_screen', label: 'Phone Screen', color: 'border-t-accent/60', badge: 'bg-accent-soft text-accent-strong' },
+  { id: 'technical', label: 'Technical', color: 'border-t-warn/60', badge: 'bg-warn/10 text-warn' },
+  { id: 'onsite', label: 'On-Site', color: 'border-t-accent/60', badge: 'bg-accent-soft text-accent-strong' },
+  { id: 'offer', label: 'Offer', color: 'border-t-ok/60', badge: 'bg-ok/10 text-ok' },
+  { id: 'rejected', label: 'Rejected', color: 'border-t-err/60', badge: 'bg-err/10 text-err' },
+  { id: 'withdrawn', label: 'Withdrawn', color: 'border-t-line-2', badge: 'bg-surface-2 text-fg-3' },
 ] as const
 
 function atsColor(score: number) {
-  if (score >= 75) return 'bg-emerald-500/10 text-emerald-300 ring-emerald-400/20'
-  if (score >= 55) return 'bg-amber-500/10 text-amber-300 ring-amber-400/20'
-  return 'bg-rose-500/10 text-rose-300 ring-rose-400/20'
+  if (score >= 75) return 'bg-ok/10 text-ok ring-ok/20'
+  if (score >= 55) return 'bg-warn/10 text-warn ring-warn/20'
+  return 'bg-err/10 text-err ring-err/20'
 }
 
 function timeAgo(iso: string) {
@@ -71,12 +71,12 @@ function CompanyAvatar({ name, logoUrl }: { name: string; logoUrl: string | null
         src={logoUrl}
         alt={name}
         onError={() => setImgFailed(true)}
-        className="h-8 w-8 flex-shrink-0 rounded-lg object-contain bg-white/5 p-0.5"
+        className="h-8 w-8 flex-shrink-0 rounded-[var(--radius-md)] object-contain bg-surface-2 p-0.5"
       />
     )
   }
   return (
-    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-zinc-800 text-[11px] font-bold text-zinc-300">
+    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-surface-2 text-[11px] font-bold text-fg-2">
       {initials || '?'}
     </div>
   )
@@ -130,8 +130,8 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
     <div
       ref={setNodeRef}
       style={style}
-      className={`group relative rounded-xl border border-white/10 bg-zinc-900 p-3.5 shadow-sm transition hover:border-white/20 ${
-        isDragging ? 'shadow-2xl ring-1 ring-orange-300/20' : ''
+      className={`group relative rounded-[var(--radius-lg)] border border-line bg-surface p-3.5 shadow-sm transition hover:border-line-2 ${
+        isDragging ? 'shadow-[var(--shadow-2)] ring-1 ring-accent/20' : ''
       }`}
     >
       {/* Drag handle area */}
@@ -139,8 +139,8 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
         <div className="flex items-start gap-2.5">
           <CompanyAvatar name={app.company_name} logoUrl={app.company_logo_url} />
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-semibold text-white leading-tight">{app.company_name}</p>
-            <p className="truncate text-xs text-zinc-400 mt-0.5">{app.role_title}</p>
+            <p className="truncate text-sm font-semibold text-fg leading-tight">{app.company_name}</p>
+            <p className="truncate text-xs text-fg-2 mt-0.5">{app.role_title}</p>
           </div>
         </div>
       </div>
@@ -152,14 +152,14 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
             ATS {Math.round(app.ats_score_at_submission)}
           </span>
         )}
-        <span className="text-[10px] text-zinc-600">{timeAgo(app.applied_at)}</span>
+        <span className="text-[10px] text-fg-3">{timeAgo(app.applied_at)}</span>
         {app.job_url && (
           <a
             href={app.job_url}
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            className="ml-auto text-zinc-600 transition hover:text-zinc-300"
+            className="ml-auto text-fg-3 transition hover:text-fg-2"
           >
             <ExternalLink size={11} />
           </a>
@@ -172,7 +172,7 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
           ref={menuTriggerRef}
           type="button"
           onClick={(e) => { e.stopPropagation(); menuOpen ? setMenuOpen(false) : openMenu() }}
-          className="rounded p-1 text-zinc-600 transition hover:bg-white/5 hover:text-zinc-300"
+          className="rounded p-1 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
         >
           <MoreHorizontal size={14} />
         </button>
@@ -189,7 +189,7 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
               tabIndex={-1}
             />
             <div
-              className="z-[201] w-36 rounded-xl border border-white/10 bg-zinc-900 p-1 shadow-xl"
+              className="z-[201] w-36 rounded-[var(--radius-lg)] border border-line bg-surface p-1 shadow-[var(--shadow-2)]"
               style={{
                 position: 'fixed',
                 top: menuPos.top,
@@ -200,14 +200,14 @@ function ApplicationCard({ app, onDelete, onEdit, isDragging = false }: Applicat
               <button
                 type="button"
                 onClick={() => { setMenuOpen(false); onEdit(app) }}
-                className="flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-xs text-zinc-300 transition hover:bg-white/5"
+                className="flex w-full items-center gap-2 rounded-[var(--radius-md)] px-3 py-1.5 text-xs text-fg-2 transition hover:bg-surface-2"
               >
                 <Pencil size={12} /> Edit
               </button>
               <button
                 type="button"
                 onClick={() => { setMenuOpen(false); onDelete(app.id) }}
-                className="flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-xs text-rose-400 transition hover:bg-rose-500/10"
+                className="flex w-full items-center gap-2 rounded-[var(--radius-md)] px-3 py-1.5 text-xs text-err transition hover:bg-err/10"
               >
                 <Trash2 size={12} /> Delete
               </button>
@@ -236,9 +236,9 @@ interface ColumnProps {
 
 function KanbanColumn({ columnId, label, colorClass, badgeClass, apps, onDelete, onEdit }: ColumnProps) {
   return (
-    <div className={`flex min-h-[200px] w-[80vw] max-w-[300px] flex-shrink-0 flex-col rounded-xl border border-white/10 bg-zinc-950 border-t-2 sm:w-[260px] ${colorClass}`}>
+    <div className={`flex min-h-[200px] w-[80vw] max-w-[300px] flex-shrink-0 flex-col rounded-[var(--radius-lg)] border border-line bg-bg border-t-2 sm:w-[260px] ${colorClass}`}>
       <div className="flex items-center gap-2 px-3.5 py-3">
-        <span className="text-xs font-semibold text-zinc-300">{label}</span>
+        <span className="text-xs font-semibold text-fg-2">{label}</span>
         <span className={`ml-auto rounded-full px-2 py-0.5 text-[10px] font-bold ${badgeClass}`}>
           {apps.length}
         </span>
@@ -250,7 +250,7 @@ function KanbanColumn({ columnId, label, colorClass, badgeClass, apps, onDelete,
           ))}
         </SortableContext>
         {apps.length === 0 && (
-          <div className="flex h-16 items-center justify-center rounded-lg border border-dashed border-white/10 text-[11px] text-zinc-700">
+          <div className="flex h-16 items-center justify-center rounded-[var(--radius-md)] border border-dashed border-line text-[11px] text-fg-3">
             Drop here
           </div>
         )}
@@ -266,26 +266,26 @@ function KanbanColumn({ columnId, label, colorClass, badgeClass, apps, onDelete,
 function StatsBar({ stats }: { stats: TrackerStats | null }) {
   if (!stats || stats.total_applications === 0) return null
   return (
-    <div className="flex flex-wrap gap-4 rounded-xl border border-white/10 bg-zinc-950 px-5 py-3 text-xs">
-      <span className="text-zinc-400">
-        <span className="font-semibold text-white">{stats.total_applications}</span> total
+    <div className="flex flex-wrap gap-4 rounded-[var(--radius-lg)] border border-line bg-bg px-5 py-3 text-xs">
+      <span className="text-fg-2">
+        <span className="font-semibold text-fg">{stats.total_applications}</span> total
       </span>
-      <span className="text-zinc-400">
+      <span className="text-fg-2">
         Response rate:{' '}
-        <span className="font-semibold text-white">{Math.round(stats.response_rate * 100)}%</span>
+        <span className="font-semibold text-fg">{Math.round(stats.response_rate * 100)}%</span>
       </span>
-      <span className="text-zinc-400">
+      <span className="text-fg-2">
         Offer rate:{' '}
-        <span className="font-semibold text-white">{Math.round(stats.offer_rate * 100)}%</span>
+        <span className="font-semibold text-fg">{Math.round(stats.offer_rate * 100)}%</span>
       </span>
       {stats.avg_ats_score != null && (
-        <span className="text-zinc-400">
-          Avg ATS: <span className="font-semibold text-white">{Math.round(stats.avg_ats_score)}</span>
+        <span className="text-fg-2">
+          Avg ATS: <span className="font-semibold text-fg">{Math.round(stats.avg_ats_score)}</span>
         </span>
       )}
-      <span className="text-zinc-400">
+      <span className="text-fg-2">
         This week:{' '}
-        <span className="font-semibold text-white">{stats.applications_this_week}</span>
+        <span className="font-semibold text-fg">{stats.applications_this_week}</span>
       </span>
     </div>
   )
@@ -457,20 +457,20 @@ export default function TrackerPage() {
       {/* Header */}
       <section className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <p className="overline">Tracker</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">Job Applications</h1>
-          <p className="mt-1 text-sm text-zinc-400">
+          <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Tracker</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-fg">Job Applications</h1>
+          <p className="mt-1 text-sm text-fg-2">
             Track every application across its full lifecycle.
           </p>
         </div>
         <div className="flex gap-2">
-          <Link href="/workspace" className="btn-ghost px-4 py-2 text-xs">
+          <Link href="/workspace" className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs text-fg hover:bg-surface-2">
             Workspace
           </Link>
           <button
             type="button"
             onClick={() => setShowAddModal(true)}
-            className="btn-accent flex items-center gap-1.5 px-4 py-2 text-xs"
+            className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg hover:brightness-110 flex items-center gap-1.5"
           >
             <Plus size={13} />
             Add Application
@@ -506,12 +506,12 @@ export default function TrackerPage() {
 
           <DragOverlay>
             {activeApp && (
-              <div className="w-[260px] rounded-xl border border-orange-300/20 bg-zinc-900 p-3.5 shadow-2xl ring-1 ring-orange-300/20">
+              <div className="w-[260px] rounded-[var(--radius-lg)] border border-accent/20 bg-surface p-3.5 shadow-[var(--shadow-2)] ring-1 ring-accent/20">
                 <div className="flex items-start gap-2.5">
                   <CompanyAvatar name={activeApp.company_name} logoUrl={activeApp.company_logo_url} />
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-semibold text-white">{activeApp.company_name}</p>
-                    <p className="truncate text-xs text-zinc-400">{activeApp.role_title}</p>
+                    <p className="truncate text-sm font-semibold text-fg">{activeApp.company_name}</p>
+                    <p className="truncate text-xs text-fg-2">{activeApp.role_title}</p>
                   </div>
                 </div>
               </div>
@@ -611,56 +611,56 @@ function EditApplicationModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl"
+        className="w-full max-w-md rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-white/10 px-5 py-4">
-          <h2 className="text-sm font-semibold text-white">Edit Application</h2>
-          <button type="button" onClick={onClose} className="rounded-lg p-1.5 text-zinc-500 hover:text-white">
+        <div className="flex items-center justify-between border-b border-line px-5 py-4">
+          <h2 className="text-sm font-semibold text-fg">Edit Application</h2>
+          <button type="button" onClick={onClose} className="rounded-[var(--radius-md)] p-1.5 text-fg-3 hover:text-fg">
             <X size={16} />
           </button>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4 p-5">
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">Company</label>
+              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">Company</label>
               <input value={companyName} onChange={(e) => setCompanyName(e.target.value)} required
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40" />
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent" />
             </div>
             <div>
-              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">Role</label>
+              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">Role</label>
               <input value={roleTitle} onChange={(e) => setRoleTitle(e.target.value)} required
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40" />
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent" />
             </div>
           </div>
           <div>
-            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">Status</label>
+            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">Status</label>
             <select value={status} onChange={(e) => setStatus(e.target.value)}
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40">
+              className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent">
               {STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
             </select>
           </div>
           <div>
-            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">Job URL</label>
+            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">Job URL</label>
             <input type="url" value={jobUrl} onChange={(e) => setJobUrl(e.target.value)} placeholder="https://..."
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40" />
+              className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent" />
           </div>
           <div>
-            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">Notes</label>
+            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">Notes</label>
             <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={2}
-              className="w-full resize-none rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40" />
+              className="w-full resize-none rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent" />
           </div>
-          <div className="flex justify-end gap-2 border-t border-white/10 pt-4">
+          <div className="flex justify-end gap-2 border-t border-line pt-4">
             <button type="button" onClick={onClose}
-              className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 hover:text-white">
+              className="rounded-[var(--radius-md)] border border-line px-4 py-2 text-xs font-semibold text-fg-2 hover:text-fg">
               Cancel
             </button>
             <button type="submit" disabled={isSubmitting}
-              className="btn-accent px-4 py-2 text-xs disabled:opacity-50">
+              className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg hover:brightness-110 disabled:opacity-50">
               {isSubmitting ? 'Saving…' : 'Save Changes'}
             </button>
           </div>

--- a/frontend/src/app/workspace/page.tsx
+++ b/frontend/src/app/workspace/page.tsx
@@ -403,10 +403,10 @@ export default function WorkspacePage() {
   if (!session) {
     return (
       <div className="content-shell">
-        <section className="surface-panel edge-highlight mx-auto max-w-2xl p-8 text-center">
-          <h1 className="text-2xl font-semibold text-white">Sign in required</h1>
-          <p className="mt-2 text-zinc-400">Please sign in to access your workspace and resumes.</p>
-          <Link href="/login" className="btn-accent mt-6">
+        <section className="rounded-[var(--radius-lg)] border border-line bg-surface mx-auto max-w-2xl p-8 text-center">
+          <h1 className="text-2xl font-semibold text-fg">Sign in required</h1>
+          <p className="mt-2 text-fg-2">Please sign in to access your workspace and resumes.</p>
+          <Link href="/login" className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-sm font-semibold text-accent-fg hover:brightness-110 mt-6">
             Continue to Login
           </Link>
         </section>
@@ -416,21 +416,21 @@ export default function WorkspacePage() {
 
   // Shared card renderer for both master and variant resumes
   const renderResumeCard = (resume: ResumeResponse, isVariant = false, parentTitle?: string) => (
-    <article key={resume.id} className={`surface-card edge-highlight flex flex-col p-5 ${isVariant ? 'border-l-2 border-l-orange-500/20' : ''}`}>
+    <article key={resume.id} className={`rounded-[var(--radius-lg)] border border-line bg-surface flex flex-col p-5 ${isVariant ? 'border-l-2 border-l-accent/20' : ''}`}>
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
-          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">
+          <p className="text-xs uppercase tracking-[0.14em] text-fg-3">
             {isVariant ? 'Variant' : 'Resume'}
           </p>
           {resume.pinned && (
-            <span className="flex items-center gap-0.5 rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold text-amber-300">
+            <span className="flex items-center gap-0.5 rounded bg-warn/15 px-1.5 py-0.5 text-[9px] font-semibold text-warn">
               <Pin size={8} />Pinned
             </span>
           )}
           {!isVariant && getVariantCount(resume) > 0 && (
             <button
               onClick={() => toggleExpand(resume.id)}
-              className="flex items-center gap-1 rounded-md bg-orange-500/10 px-2 py-0.5 text-[10px] font-semibold text-orange-300 ring-1 ring-orange-400/20 transition hover:bg-orange-500/20"
+              className="flex items-center gap-1 rounded-[var(--radius-md)] bg-accent-soft px-2 py-0.5 text-[10px] font-semibold text-accent-strong ring-1 ring-accent transition hover:brightness-110"
             >
               <GitFork size={10} />
               {getVariantCount(resume)}
@@ -439,28 +439,28 @@ export default function WorkspacePage() {
           )}
         </div>
         {matchMap[resume.id] && matchMap[resume.id].similarity_score != null && (
-          <span className={`shrink-0 rounded-md px-2 py-0.5 text-[10px] font-bold tabular-nums ring-1 ${
+          <span className={`shrink-0 rounded-[var(--radius-md)] px-2 py-0.5 text-[10px] font-bold tabular-nums ring-1 ${
             (matchMap[resume.id].similarity_score as number) >= 0.8
-              ? 'bg-emerald-500/10 text-emerald-300 ring-emerald-400/20'
+              ? 'bg-ok/10 text-ok ring-ok/20'
               : (matchMap[resume.id].similarity_score as number) >= 0.6
-              ? 'bg-amber-500/10 text-amber-300 ring-amber-400/20'
-              : 'bg-rose-500/10 text-rose-300 ring-rose-400/20'
+              ? 'bg-warn/10 text-warn ring-warn/20'
+              : 'bg-err/10 text-err ring-err/20'
           }`}>
             {Math.round((matchMap[resume.id].similarity_score as number) * 100)}% match
           </span>
         )}
       </div>
-      <h3 className="mt-2 line-clamp-2 text-lg font-semibold text-white">{resume.title}</h3>
+      <h3 className="mt-2 line-clamp-2 text-lg font-semibold text-fg">{resume.title}</h3>
       {isVariant && parentTitle && (
-        <p className="mt-0.5 text-[10px] text-zinc-500">Variant of: {parentTitle}</p>
+        <p className="mt-0.5 text-[10px] text-fg-3">Variant of: {parentTitle}</p>
       )}
       <p
         className={`mt-2 text-xs ${
           resume.freshness_status === 'very_stale'
-            ? 'text-rose-400'
+            ? 'text-err'
             : resume.freshness_status === 'stale'
-            ? 'text-amber-400'
-            : 'text-zinc-500'
+            ? 'text-warn'
+            : 'text-fg-3'
         }`}
         title={new Date(resume.updated_at).toLocaleString()}
       >
@@ -478,8 +478,8 @@ export default function WorkspacePage() {
               onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
               className={`rounded-full px-2 py-0.5 text-[10px] font-medium transition ${
                 activeTagFilter === tag
-                  ? 'bg-violet-500/30 text-violet-200 ring-1 ring-violet-400/40'
-                  : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-300'
+                  ? 'bg-accent-soft text-accent-strong ring-1 ring-accent'
+                  : 'bg-surface-2 text-fg-2 hover:brightness-110 hover:text-fg'
               }`}
             >
               {tag}
@@ -491,26 +491,26 @@ export default function WorkspacePage() {
       <div className="mt-6 grid grid-cols-3 gap-2 text-xs">
         <Link
           href={`/workspace/${resume.id}/edit`}
-          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-center font-semibold text-zinc-200 transition hover:bg-white/10"
+          className="rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-center font-semibold text-fg transition hover:brightness-110"
         >
           Edit
         </Link>
         <Link
           href={`/workspace/${resume.id}/optimize`}
-          className="rounded-lg border border-orange-300/20 bg-orange-300/10 px-3 py-2 text-center font-semibold text-orange-200 transition hover:bg-orange-300/20"
+          className="rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-2 text-center font-semibold text-accent-strong transition hover:brightness-110"
         >
           Optimize
         </Link>
         <button
           onClick={() => setQuickTailorResume(resume)}
-          className="flex items-center justify-center gap-1 rounded-lg border border-amber-400/20 bg-amber-500/10 px-3 py-2 font-semibold text-amber-300 transition hover:bg-amber-500/20"
+          className="flex items-center justify-center gap-1 rounded-[var(--radius-md)] border border-warn/20 bg-warn/10 px-3 py-2 font-semibold text-warn transition hover:bg-warn/20"
         >
           <Zap size={11} />
           Tailor
         </button>
         <Link
           href={`/workspace/${resume.id}/cover-letter`}
-          className="col-span-3 rounded-lg border border-violet-300/20 bg-violet-300/10 px-3 py-2 text-center font-semibold text-violet-200 transition hover:bg-violet-300/20"
+          className="col-span-3 rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-2 text-center font-semibold text-accent-strong transition hover:brightness-110"
         >
           Cover Letter
         </Link>
@@ -518,14 +518,14 @@ export default function WorkspacePage() {
       <div className="mt-2 flex flex-wrap gap-2">
         <button
           onClick={() => openForkModal(resume.id, resume.title)}
-          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-xs font-semibold text-zinc-400 transition hover:bg-white/[0.06] hover:text-zinc-200"
+          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-xs font-semibold text-fg-2 transition hover:brightness-110 hover:text-fg"
         >
           <GitFork size={11} />
           Fork
         </button>
         <button
           onClick={() => { setTranslateModalResumeId(resume.id); setTranslateSelectedLang('fr') }}
-          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-lg border border-sky-400/20 bg-sky-500/[0.06] px-3 py-2 text-xs font-semibold text-sky-300 transition hover:bg-sky-500/10"
+          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-2 text-xs font-semibold text-accent-strong transition hover:brightness-110"
           title="Translate to another language"
         >
           <Globe size={11} />
@@ -534,7 +534,7 @@ export default function WorkspacePage() {
         <button
           onClick={() => handleGeneratePortfolio(resume.id)}
           disabled={isGeneratingPortfolio === resume.id}
-          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-lg border border-emerald-400/20 bg-emerald-500/[0.06] px-3 py-2 text-xs font-semibold text-emerald-300 transition hover:bg-emerald-500/10 disabled:opacity-50"
+          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-2 text-xs font-semibold text-accent-strong transition hover:brightness-110 disabled:opacity-50"
           title="Generate portfolio site"
         >
           {isGeneratingPortfolio === resume.id
@@ -546,10 +546,10 @@ export default function WorkspacePage() {
         </button>
         <button
           onClick={() => setShareModalResumeId(resume.id)}
-          className={`flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-xs font-semibold transition ${
+          className={`flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-[var(--radius-md)] border px-3 py-2 text-xs font-semibold transition ${
             resume.share_token
-              ? 'border-sky-400/25 bg-sky-500/10 text-sky-300 hover:bg-sky-500/20'
-              : 'border-white/10 bg-white/[0.03] text-zinc-400 hover:bg-white/[0.06] hover:text-zinc-200'
+              ? 'border-accent bg-accent-soft text-accent-strong hover:brightness-110'
+              : 'border-line bg-surface-2 text-fg-2 hover:brightness-110 hover:text-fg'
           }`}
         >
           <Share2 size={11} />
@@ -558,20 +558,20 @@ export default function WorkspacePage() {
         {isVariant && resume.parent_resume_id && (
           <button
             onClick={() => handleCompareWithParent(resume.id)}
-            className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-lg border border-violet-400/20 bg-violet-500/[0.06] px-3 py-2 text-xs font-semibold text-violet-300 transition hover:bg-violet-500/10"
+            className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-2 text-xs font-semibold text-accent-strong transition hover:brightness-110"
           >
             Compare
           </button>
         )}
         <button
           onClick={() => setTrackerModalResumeId(resume.id)}
-          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-lg border border-sky-400/20 bg-sky-500/[0.06] px-3 py-2 text-xs font-semibold text-sky-300 transition hover:bg-sky-500/10"
+          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-xs font-semibold text-fg-2 transition hover:brightness-110 hover:text-fg"
         >
           Track
         </button>
         <button
           onClick={() => setApplyModalResume(resume)}
-          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-lg border border-orange-400/20 bg-orange-500/[0.06] px-3 py-2 text-xs font-semibold text-orange-300 transition hover:bg-orange-500/10"
+          className="flex flex-1 basis-[calc(50%-0.25rem)] items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-2 text-xs font-semibold text-accent-strong transition hover:brightness-110"
           title="Apply to a job with this resume"
         >
           <Send size={11} />
@@ -584,7 +584,7 @@ export default function WorkspacePage() {
       <div className="mt-2">
         <button
           onClick={() => setReferencesModalResume(resume)}
-          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/[0.06] bg-white/[0.02] py-2 text-xs font-semibold text-zinc-500 transition hover:bg-white/[0.06] hover:text-violet-300"
+          className="flex w-full items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-line bg-surface-2 py-2 text-xs font-semibold text-fg-3 transition hover:brightness-110 hover:text-accent-strong"
         >
           <BookUser size={11} />
           Generate References Page
@@ -593,11 +593,11 @@ export default function WorkspacePage() {
 
       {/* Pin / Archive / Tag actions */}
       {!isVariant && (
-        <div className="mt-2 flex gap-1.5 border-t border-white/[0.05] pt-2">
+        <div className="mt-2 flex gap-1.5 border-t border-line pt-2">
           <button
             onClick={() => handlePin(resume.id, !!resume.pinned)}
             title={resume.pinned ? 'Unpin' : 'Pin to top'}
-            className="flex items-center gap-1 rounded-md px-2 py-1 text-[10px] text-zinc-500 transition hover:bg-amber-500/10 hover:text-amber-300"
+            className="flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1 text-[10px] text-fg-3 transition hover:bg-warn/10 hover:text-warn"
           >
             {resume.pinned ? <PinOff size={10} /> : <Pin size={10} />}
             {resume.pinned ? 'Unpin' : 'Pin'}
@@ -608,7 +608,7 @@ export default function WorkspacePage() {
               setTagEditValue(resume.tags?.join(', ') ?? '')
             }}
             title="Edit tags"
-            className="flex items-center gap-1 rounded-md px-2 py-1 text-[10px] text-zinc-500 transition hover:bg-violet-500/10 hover:text-violet-300"
+            className="flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1 text-[10px] text-fg-3 transition hover:bg-accent-soft hover:text-accent-strong"
           >
             <Tag size={10} />
             Tags
@@ -620,7 +620,7 @@ export default function WorkspacePage() {
               }
             }}
             title="Archive resume"
-            className="flex items-center gap-1 rounded-md px-2 py-1 text-[10px] text-zinc-500 transition hover:bg-rose-500/10 hover:text-rose-400"
+            className="flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1 text-[10px] text-fg-3 transition hover:bg-err/10 hover:text-err"
           >
             <Archive size={10} />
             Archive
@@ -634,10 +634,10 @@ export default function WorkspacePage() {
     <div className="content-shell space-y-6">
       {/* Stale resume banner (Feature 48) */}
       {!staleBannerDismissed && veryStaleResumes.length > 0 && (
-        <div className="flex items-center justify-between gap-3 rounded-xl border border-amber-400/20 bg-amber-500/[0.07] px-4 py-3">
+        <div className="flex items-center justify-between gap-3 rounded-[var(--radius-lg)] border border-warn/20 bg-warn/[0.07] px-4 py-3">
           <div className="flex items-center gap-2.5">
-            <AlertTriangle size={14} className="shrink-0 text-amber-400" />
-            <p className="text-[13px] text-amber-200">
+            <AlertTriangle size={14} className="shrink-0 text-warn" />
+            <p className="text-[13px] text-warn">
               <strong>{veryStaleResumes.length}</strong>{' '}
               {veryStaleResumes.length === 1 ? "resume hasn't" : "resumes haven't"} been updated in 90+ days.
               Update {veryStaleResumes.length === 1 ? 'it' : 'them'} to stay competitive.
@@ -645,7 +645,7 @@ export default function WorkspacePage() {
           </div>
           <button
             onClick={() => setStaleBannerDismissed(true)}
-            className="shrink-0 rounded-md p-1 text-amber-500 transition hover:bg-amber-500/10 hover:text-amber-300"
+            className="shrink-0 rounded-[var(--radius-md)] p-1 text-warn transition hover:bg-warn/10 hover:text-warn"
             aria-label="Dismiss"
           >
             <X size={14} />
@@ -655,25 +655,25 @@ export default function WorkspacePage() {
 
       <section className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <p className="overline">Workspace</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">Resume Library</h1>
-          <p className="mt-1 text-sm text-zinc-400">Create, edit, and optimize resumes from a single workspace.</p>
+          <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Workspace</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-fg">Resume Library</h1>
+          <p className="mt-1 text-sm text-fg-2">Create, edit, and optimize resumes from a single workspace.</p>
         </div>
         <div className="flex flex-wrap gap-2">
           <button
             onClick={() => setProjectSearchOpen(true)}
             title="Search resumes (⌘⇧F)"
-            className="btn-ghost px-3 py-2 text-xs flex items-center gap-1.5"
+            className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-3 py-2 text-xs flex items-center gap-1.5"
           >
             <Search className="w-3.5 h-3.5" />
             <span className="hidden sm:inline">Search</span>
           </button>
-          <Link href="/workspace/history" className="btn-ghost px-4 py-2 text-xs">
+          <Link href="/workspace/history" className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
             Run History
           </Link>
           <button
             onClick={() => setMatchModalOpen(true)}
-            className="rounded-lg border border-violet-400/20 bg-violet-500/10 px-4 py-2 text-xs font-semibold text-violet-200 transition hover:bg-violet-500/20"
+            className="rounded-[var(--radius-md)] border border-accent bg-accent-soft px-4 py-2 text-xs font-semibold text-accent-strong transition hover:brightness-110"
           >
             Match to Job
           </button>
@@ -692,7 +692,7 @@ export default function WorkspacePage() {
                 setExportMenuOpen(o => !o)
               }}
               disabled={exportLoading}
-              className="btn-ghost flex items-center gap-1.5 px-3 py-2 text-xs"
+              className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 flex items-center gap-1.5 px-3 py-2 text-xs"
             >
               {exportLoading ? (
                 <Loader2 size={12} className="animate-spin" />
@@ -703,7 +703,7 @@ export default function WorkspacePage() {
               <ChevronDown size={11} />
             </button>
             {exportMenuOpen && (
-              <div className={`absolute right-0 z-50 max-h-[min(20rem,calc(100vh-6rem))] w-44 overflow-y-auto rounded-lg border border-white/[0.08] bg-[#111] py-1 shadow-xl ${
+              <div className={`absolute right-0 z-50 max-h-[min(20rem,calc(100vh-6rem))] w-44 overflow-y-auto rounded-[var(--radius-md)] border border-line bg-surface py-1 shadow-[var(--shadow-2)] ${
                 exportMenuFlipUp ? 'bottom-full mb-1' : 'top-full mt-1'
               }`}>
                 {([
@@ -714,7 +714,7 @@ export default function WorkspacePage() {
                   <button
                     key={format}
                     onClick={() => handleBulkExport(format)}
-                    className="w-full px-3 py-2 text-left text-[12px] text-zinc-400 transition hover:bg-white/[0.05] hover:text-zinc-200"
+                    className="w-full px-3 py-2 text-left text-[12px] text-fg-2 transition hover:bg-surface-2 hover:text-fg"
                   >
                     {label}
                   </button>
@@ -727,41 +727,41 @@ export default function WorkspacePage() {
             href="/workspace/merge"
             aria-label="Merge resumes"
             title="Merge resumes"
-            className="btn-ghost flex items-center gap-1.5 px-4 py-2 text-xs"
+            className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 flex items-center gap-1.5 px-4 py-2 text-xs"
           >
             <GitMerge size={12} aria-hidden="true" />
             <span className="hidden sm:inline">Merge</span>
           </Link>
 
-          <Link href="/workspace/new" className="btn-accent px-4 py-2 text-xs">
+          <Link href="/workspace/new" className="rounded-[var(--radius-md)] bg-accent font-semibold text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
             New Resume
           </Link>
         </div>
       </section>
 
-      <section className="surface-panel edge-highlight p-4 sm:p-5">
+      <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-4 sm:p-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <input
             type="text"
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
             placeholder="Search resume titles"
-            className="w-full max-w-md rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+            className="w-full max-w-md rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
           />
 
-          <div className="flex rounded-lg border border-white/10 bg-white/5 p-1 text-xs">
+          <div className="flex rounded-[var(--radius-md)] border border-line bg-surface-2 p-1 text-xs">
             <button
               onClick={() => setViewMode('grid')}
-              className={`rounded-md px-3 py-1.5 uppercase tracking-[0.12em] transition ${
-                viewMode === 'grid' ? 'bg-white/10 text-white' : 'text-zinc-400 hover:text-zinc-200'
+              className={`rounded-[var(--radius-md)] px-3 py-1.5 uppercase tracking-[0.12em] transition ${
+                viewMode === 'grid' ? 'bg-surface-2 text-fg' : 'text-fg-2 hover:text-fg'
               }`}
             >
               Grid
             </button>
             <button
               onClick={() => setViewMode('list')}
-              className={`rounded-md px-3 py-1.5 uppercase tracking-[0.12em] transition ${
-                viewMode === 'list' ? 'bg-white/10 text-white' : 'text-zinc-400 hover:text-zinc-200'
+              className={`rounded-[var(--radius-md)] px-3 py-1.5 uppercase tracking-[0.12em] transition ${
+                viewMode === 'list' ? 'bg-surface-2 text-fg' : 'text-fg-2 hover:text-fg'
               }`}
             >
               List
@@ -773,17 +773,17 @@ export default function WorkspacePage() {
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
         <section>
           {isLoading ? (
-            <div className="surface-panel edge-highlight flex h-72 items-center justify-center">
+            <div className="rounded-[var(--radius-lg)] border border-line bg-surface flex h-72 items-center justify-center">
               <LoadingSpinner />
             </div>
           ) : filteredResumes.length === 0 ? (
-            <div className="surface-panel edge-highlight px-6 py-16 text-center">
-              <h2 className="text-lg font-semibold text-white">No resumes found</h2>
-              <p className="mt-2 text-sm text-zinc-400">
+            <div className="rounded-[var(--radius-lg)] border border-line bg-surface px-6 py-16 text-center">
+              <h2 className="text-lg font-semibold text-fg">No resumes found</h2>
+              <p className="mt-2 text-sm text-fg-2">
                 {searchQuery ? `No results for "${searchQuery}".` : 'Create your first resume to start your pipeline.'}
               </p>
               {!searchQuery && (
-                <Link href="/workspace/new" className="btn-accent mt-5 px-4 py-2 text-xs">
+                <Link href="/workspace/new" className="rounded-[var(--radius-md)] bg-accent font-semibold text-accent-fg hover:brightness-110 mt-5 px-4 py-2 text-xs">
                   Create Resume
                 </Link>
               )}
@@ -795,7 +795,7 @@ export default function WorkspacePage() {
                   <div key={resume.id}>
                     {renderResumeCard(resume)}
                     {expandedParents.has(resume.id) && variantMap[resume.id] && (
-                      <div className="ml-6 mt-2 space-y-3 border-l-2 border-orange-500/20 pl-4">
+                      <div className="ml-6 mt-2 space-y-3 border-l-2 border-accent/20 pl-4">
                         {variantMap[resume.id].map((variant) => renderResumeCard(variant, true, resume.title))}
                       </div>
                     )}
@@ -804,17 +804,17 @@ export default function WorkspacePage() {
               </div>
             </div>
           ) : (
-            <div className="surface-panel edge-highlight overflow-hidden">
+            <div className="rounded-[var(--radius-lg)] border border-line bg-surface overflow-hidden">
               <table className="w-full text-left">
                 <thead>
-                  <tr className="border-b border-white/10 bg-white/[0.03] text-[11px] uppercase tracking-[0.14em] text-zinc-500">
+                  <tr className="border-b border-line bg-surface-2 text-[11px] uppercase tracking-[0.14em] text-fg-3">
                     <th className="px-4 py-3 font-semibold">Title</th>
                     {matchResults.length > 0 && <th className="px-4 py-3 font-semibold text-right">Match</th>}
                     <th className="px-4 py-3 font-semibold text-right">Updated</th>
                     <th className="px-4 py-3 font-semibold text-right">Actions</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-white/10">
+                <tbody className="divide-y divide-line">
                   {masterResumes.map((resume) => (
                     <>
                       <tr key={resume.id}>
@@ -823,16 +823,16 @@ export default function WorkspacePage() {
                             {getVariantCount(resume) > 0 && (
                               <button
                                 onClick={() => toggleExpand(resume.id)}
-                                className="flex items-center gap-1 text-orange-400 transition hover:text-orange-300"
+                                className="flex items-center gap-1 text-accent-strong transition hover:brightness-110"
                               >
                                 {expandedParents.has(resume.id) ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
                               </button>
                             )}
-                            <Link href={`/workspace/${resume.id}/edit`} className="text-sm font-medium text-white transition hover:text-orange-200">
+                            <Link href={`/workspace/${resume.id}/edit`} className="text-sm font-medium text-fg transition hover:text-accent-strong">
                               {resume.title}
                             </Link>
                             {getVariantCount(resume) > 0 && (
-                              <span className="flex items-center gap-1 rounded-md bg-orange-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-orange-300">
+                              <span className="flex items-center gap-1 rounded-[var(--radius-md)] bg-accent-soft px-1.5 py-0.5 text-[10px] font-semibold text-accent-strong">
                                 <GitFork size={9} />{getVariantCount(resume)}
                               </span>
                             )}
@@ -841,23 +841,23 @@ export default function WorkspacePage() {
                         {matchResults.length > 0 && (
                           <td className="px-4 py-3 text-right">
                             {matchMap[resume.id] && matchMap[resume.id].similarity_score != null ? (
-                              <span className={`rounded-md px-2 py-0.5 text-[10px] font-bold tabular-nums ring-1 ${
+                              <span className={`rounded-[var(--radius-md)] px-2 py-0.5 text-[10px] font-bold tabular-nums ring-1 ${
                                 (matchMap[resume.id].similarity_score as number) >= 0.8
-                                  ? 'bg-emerald-500/10 text-emerald-300 ring-emerald-400/20'
+                                  ? 'bg-ok/10 text-ok ring-ok/20'
                                   : (matchMap[resume.id].similarity_score as number) >= 0.6
-                                  ? 'bg-amber-500/10 text-amber-300 ring-amber-400/20'
-                                  : 'bg-rose-500/10 text-rose-300 ring-rose-400/20'
+                                  ? 'bg-warn/10 text-warn ring-warn/20'
+                                  : 'bg-err/10 text-err ring-err/20'
                               }`}>
                                 {Math.round((matchMap[resume.id].similarity_score as number) * 100)}%
                               </span>
                             ) : (
-                              <span className="text-zinc-700">—</span>
+                              <span className="text-fg-3">—</span>
                             )}
                           </td>
                         )}
                         <td className={`px-4 py-3 text-right text-sm ${
-                          resume.freshness_status === 'very_stale' ? 'text-rose-400' :
-                          resume.freshness_status === 'stale' ? 'text-amber-400' : 'text-zinc-400'
+                          resume.freshness_status === 'very_stale' ? 'text-err' :
+                          resume.freshness_status === 'stale' ? 'text-warn' : 'text-fg-2'
                         }`} title={new Date(resume.updated_at).toLocaleString()}>
                           {resume.days_since_updated != null && resume.days_since_updated > 0
                             ? `${resume.days_since_updated}d ago`
@@ -867,39 +867,39 @@ export default function WorkspacePage() {
                           <div className="inline-flex gap-2 items-center">
                             <Link
                               href={`/workspace/${resume.id}/edit`}
-                              className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-semibold text-zinc-300 transition hover:border-white/20 hover:text-white"
+                              className="rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs font-semibold text-fg-2 transition hover:border-line-2 hover:text-fg"
                             >
                               Edit
                             </Link>
                             <Link
                               href={`/workspace/${resume.id}/optimize`}
-                              className="rounded-lg border border-orange-300/25 bg-orange-300/10 px-3 py-1.5 text-xs font-semibold text-orange-200 transition hover:bg-orange-300/20"
+                              className="rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-1.5 text-xs font-semibold text-accent-strong transition hover:brightness-110"
                             >
                               Optimize
                             </Link>
                             <Link
                               href={`/workspace/${resume.id}/cover-letter`}
-                              className="rounded-lg border border-violet-300/25 bg-violet-300/10 px-3 py-1.5 text-xs font-semibold text-violet-200 transition hover:bg-violet-300/20"
+                              className="rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-1.5 text-xs font-semibold text-accent-strong transition hover:brightness-110"
                             >
                               CL
                             </Link>
                             <button
                               onClick={() => setQuickTailorResume(resume)}
-                              className="flex items-center gap-1 rounded-lg border border-amber-400/20 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-300 transition hover:bg-amber-500/20"
+                              className="flex items-center gap-1 rounded-[var(--radius-md)] border border-warn/20 bg-warn/10 px-3 py-1.5 text-xs font-semibold text-warn transition hover:bg-warn/20"
                             >
                               <Zap size={11} />
                               Tailor
                             </button>
                             <button
                               onClick={() => openForkModal(resume.id, resume.title)}
-                              className="flex items-center gap-1 rounded-lg border border-white/10 px-3 py-1.5 text-xs font-semibold text-zinc-400 transition hover:border-white/20 hover:text-zinc-200"
+                              className="flex items-center gap-1 rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs font-semibold text-fg-2 transition hover:border-line-2 hover:text-fg"
                             >
                               <GitFork size={11} />
                               Fork
                             </button>
                             <button
                               onClick={() => setReferencesModalResume(resume)}
-                              className="flex items-center gap-1 rounded-lg border border-white/[0.08] px-3 py-1.5 text-xs font-semibold text-zinc-400 transition hover:border-violet-400/30 hover:text-violet-300"
+                              className="flex items-center gap-1 rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs font-semibold text-fg-2 transition hover:border-accent hover:text-accent-strong"
                             >
                               <BookUser size={11} />
                               Refs
@@ -909,24 +909,24 @@ export default function WorkspacePage() {
                         </td>
                       </tr>
                       {expandedParents.has(resume.id) && variantMap[resume.id]?.map((variant) => (
-                        <tr key={variant.id} className="bg-white/[0.01]">
+                        <tr key={variant.id} className="bg-surface-2">
                           <td className="py-3 pl-12 pr-4">
                             <div className="flex items-center gap-2">
-                              <GitFork size={11} className="text-orange-500/50" />
-                              <Link href={`/workspace/${variant.id}/edit`} className="text-sm font-medium text-zinc-300 transition hover:text-orange-200">
+                              <GitFork size={11} className="text-accent/50" />
+                              <Link href={`/workspace/${variant.id}/edit`} className="text-sm font-medium text-fg-2 transition hover:text-accent-strong">
                                 {variant.title}
                               </Link>
-                              <span className="text-[10px] text-zinc-600">variant</span>
+                              <span className="text-[10px] text-fg-3">variant</span>
                             </div>
                           </td>
                           {matchResults.length > 0 && (
                             <td className="px-4 py-3 text-right">
-                              <span className="text-zinc-700">—</span>
+                              <span className="text-fg-3">—</span>
                             </td>
                           )}
                           <td className={`px-4 py-3 text-right text-sm ${
-                            variant.freshness_status === 'very_stale' ? 'text-rose-400' :
-                            variant.freshness_status === 'stale' ? 'text-amber-400' : 'text-zinc-500'
+                            variant.freshness_status === 'very_stale' ? 'text-err' :
+                            variant.freshness_status === 'stale' ? 'text-warn' : 'text-fg-3'
                           }`} title={new Date(variant.updated_at).toLocaleString()}>
                             {variant.days_since_updated != null && variant.days_since_updated > 0
                               ? `${variant.days_since_updated}d ago`
@@ -936,19 +936,19 @@ export default function WorkspacePage() {
                             <div className="inline-flex gap-2 items-center">
                               <Link
                                 href={`/workspace/${variant.id}/edit`}
-                                className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-semibold text-zinc-300 transition hover:border-white/20 hover:text-white"
+                                className="rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs font-semibold text-fg-2 transition hover:border-line-2 hover:text-fg"
                               >
                                 Edit
                               </Link>
                               <button
                                 onClick={() => handleCompareWithParent(variant.id)}
-                                className="rounded-lg border border-violet-400/20 bg-violet-500/[0.06] px-3 py-1.5 text-xs font-semibold text-violet-300 transition hover:bg-violet-500/10"
+                                className="rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-1.5 text-xs font-semibold text-accent-strong transition hover:brightness-110"
                               >
                                 Compare
                               </button>
                               <button
                                 onClick={() => openForkModal(variant.id, variant.title)}
-                                className="flex items-center gap-1 rounded-lg border border-white/10 px-3 py-1.5 text-xs font-semibold text-zinc-400 transition hover:border-white/20 hover:text-zinc-202"
+                                className="flex items-center gap-1 rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs font-semibold text-fg-2 transition hover:border-line-2 hover:text-fg"
                               >
                                 <GitFork size={11} />
                                 Fork
@@ -968,28 +968,28 @@ export default function WorkspacePage() {
           {/* Archived resumes section (Feature 39) */}
           {showArchived && (
             <div className="mt-6">
-              <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.12em] text-zinc-500">
+              <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.12em] text-fg-3">
                 <Archive size={12} />
                 Archived
               </h2>
               {archivedLoading ? (
                 <div className="flex items-center justify-center py-8"><LoadingSpinner /></div>
               ) : archivedResumes.length === 0 ? (
-                <p className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-6 text-center text-sm text-zinc-600">
+                <p className="rounded-[var(--radius-lg)] border border-line bg-surface-2 px-4 py-6 text-center text-sm text-fg-3">
                   No archived resumes.
                 </p>
               ) : (
                 <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                   {archivedResumes.map(r => (
-                    <div key={r.id} className="surface-card edge-highlight flex items-center justify-between gap-3 p-4 opacity-60">
+                    <div key={r.id} className="rounded-[var(--radius-lg)] border border-line bg-surface flex items-center justify-between gap-3 p-4 opacity-60">
                       <div className="min-w-0">
-                        <p className="truncate text-sm font-medium text-zinc-300">{r.title}</p>
-                        <p className="text-[11px] text-zinc-600">Archived</p>
+                        <p className="truncate text-sm font-medium text-fg-2">{r.title}</p>
+                        <p className="text-[11px] text-fg-3">Archived</p>
                       </div>
                       <button
                         onClick={() => handleUnarchive(r.id)}
                         title="Restore"
-                        className="flex shrink-0 items-center gap-1 rounded-md px-2 py-1.5 text-[10px] font-medium text-zinc-500 ring-1 ring-white/10 transition hover:bg-emerald-500/10 hover:text-emerald-400"
+                        className="flex shrink-0 items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[10px] font-medium text-fg-3 ring-1 ring-line transition hover:bg-ok/10 hover:text-ok"
                       >
                         <ArchiveRestore size={11} />
                         Restore
@@ -1004,19 +1004,19 @@ export default function WorkspacePage() {
           {/* My Templates section (Feature 39E) */}
           {templateResumes.length > 0 && !activeTagFilter && (
             <div className="mt-6">
-              <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.12em] text-zinc-500">
+              <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.12em] text-fg-3">
                 <LayoutTemplate size={12} />
                 My Templates
               </h2>
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                 {templateResumes.map(r => (
-                  <article key={r.id} className="surface-card edge-highlight flex flex-col gap-2 p-4">
+                  <article key={r.id} className="rounded-[var(--radius-lg)] border border-line bg-surface flex flex-col gap-2 p-4">
                     <div className="flex items-center gap-2">
-                      <LayoutTemplate size={11} className="text-zinc-600" />
-                      <p className="truncate text-sm font-medium text-zinc-300">{r.title}</p>
+                      <LayoutTemplate size={11} className="text-fg-3" />
+                      <p className="truncate text-sm font-medium text-fg-2">{r.title}</p>
                     </div>
                     <div className="flex gap-2">
-                      <a href={`/workspace/${r.id}/edit`} className="flex-1 rounded-md border border-white/10 bg-white/[0.03] px-3 py-1.5 text-center text-[11px] font-semibold text-zinc-400 transition hover:bg-white/[0.06] hover:text-zinc-200">
+                      <a href={`/workspace/${r.id}/edit`} className="flex-1 rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-1.5 text-center text-[11px] font-semibold text-fg-2 transition hover:brightness-110 hover:text-fg">
                         Edit
                       </a>
                       <button
@@ -1027,7 +1027,7 @@ export default function WorkspacePage() {
                             toast.success('Removed from templates')
                           } catch { toast.error('Failed') }
                         }}
-                        className="rounded-md border border-white/10 px-2 py-1.5 text-[11px] text-zinc-600 transition hover:text-rose-400"
+                        className="rounded-[var(--radius-md)] border border-line px-2 py-1.5 text-[11px] text-fg-3 transition hover:text-err"
                         title="Remove from templates"
                       >
                         <X size={12} />
@@ -1042,18 +1042,18 @@ export default function WorkspacePage() {
 
         <aside className="space-y-4">
           {/* Tag Filter + Archive (Feature 39) */}
-          <section className="surface-panel edge-highlight p-5">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-300 flex items-center gap-2">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-fg-2 flex items-center gap-2">
               <Tag size={12} />
               Organize
             </h2>
             {allTags.length > 0 ? (
               <div className="mt-3 space-y-1">
-                <p className="text-[10px] uppercase tracking-wide text-zinc-600 mb-2">Filter by tag</p>
+                <p className="text-[10px] uppercase tracking-wide text-fg-3 mb-2">Filter by tag</p>
                 <button
                   onClick={() => setActiveTagFilter(null)}
-                  className={`w-full rounded-md px-3 py-1.5 text-left text-xs transition ${
-                    !activeTagFilter ? 'bg-white/[0.06] text-zinc-200' : 'text-zinc-500 hover:bg-white/[0.03] hover:text-zinc-300'
+                  className={`w-full rounded-[var(--radius-md)] px-3 py-1.5 text-left text-xs transition ${
+                    !activeTagFilter ? 'bg-surface-2 text-fg' : 'text-fg-3 hover:bg-surface-2 hover:text-fg-2'
                   }`}
                 >
                   All resumes
@@ -1062,21 +1062,21 @@ export default function WorkspacePage() {
                   <button
                     key={tag}
                     onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
-                    className={`flex w-full items-center gap-1.5 rounded-md px-3 py-1.5 text-left text-xs transition ${
+                    className={`flex w-full items-center gap-1.5 rounded-[var(--radius-md)] px-3 py-1.5 text-left text-xs transition ${
                       activeTagFilter === tag
-                        ? 'bg-violet-500/20 text-violet-200'
-                        : 'text-zinc-500 hover:bg-white/[0.03] hover:text-zinc-300'
+                        ? 'bg-accent-soft text-accent-strong'
+                        : 'text-fg-3 hover:bg-surface-2 hover:text-fg-2'
                     }`}
                   >
-                    <span className="h-1.5 w-1.5 rounded-full bg-violet-400/60" />
+                    <span className="h-1.5 w-1.5 rounded-full bg-accent/60" />
                     {tag}
                   </button>
                 ))}
               </div>
             ) : (
-              <p className="mt-2 text-xs text-zinc-600">Add tags to resumes to filter here.</p>
+              <p className="mt-2 text-xs text-fg-3">Add tags to resumes to filter here.</p>
             )}
-            <div className="mt-4 border-t border-white/[0.05] pt-3">
+            <div className="mt-4 border-t border-line pt-3">
               <button
                 onClick={() => {
                   setShowArchived(v => {
@@ -1084,7 +1084,7 @@ export default function WorkspacePage() {
                     return !v
                   })
                 }}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-zinc-500 transition hover:bg-rose-500/10 hover:text-rose-400"
+                className="flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-xs text-fg-3 transition hover:bg-err/10 hover:text-err"
               >
                 <Archive size={11} />
                 {showArchived ? 'Hide Archived' : 'View Archived'}
@@ -1092,61 +1092,61 @@ export default function WorkspacePage() {
             </div>
           </section>
 
-          <section className="surface-panel edge-highlight p-5">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-300">Recent Activity</h2>
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-fg-2">Recent Activity</h2>
             {jobs.length === 0 ? (
-              <p className="mt-3 text-sm text-zinc-500">No recent runs yet.</p>
+              <p className="mt-3 text-sm text-fg-3">No recent runs yet.</p>
             ) : (
               <div className="mt-4 space-y-3">
                 {jobs.slice(0, 5).map((job, index) => (
-                  <div key={job.job_id ?? `${job.last_updated}-${index}`} className="rounded-lg border border-white/10 bg-black/25 p-3">
-                    <p className="text-xs uppercase tracking-[0.12em] text-zinc-500">{job.stage || 'Pipeline'}</p>
-                    <p className="mt-1 text-sm capitalize text-zinc-200">{job.status}</p>
-                    <p className="mt-1 text-xs text-zinc-500">{new Date(job.last_updated * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</p>
+                  <div key={job.job_id ?? `${job.last_updated}-${index}`} className="rounded-[var(--radius-md)] border border-line bg-bg p-3">
+                    <p className="text-xs uppercase tracking-[0.12em] text-fg-3">{job.stage || 'Pipeline'}</p>
+                    <p className="mt-1 text-sm capitalize text-fg">{job.status}</p>
+                    <p className="mt-1 text-xs text-fg-3">{new Date(job.last_updated * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</p>
                   </div>
                 ))}
               </div>
             )}
             {jobs.length > 0 && (
-              <Link href="/workspace/history" className="mt-4 inline-block text-xs font-semibold uppercase tracking-[0.12em] text-orange-200 transition hover:text-orange-100">
+              <Link href="/workspace/history" className="mt-4 inline-block text-xs font-semibold uppercase tracking-[0.12em] text-accent-strong transition hover:brightness-110">
                 View Full History
               </Link>
             )}
           </section>
 
           {atsStats && atsStats.optimized_count > 0 && (
-            <section className="surface-panel edge-highlight p-5">
+            <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
               <div className="flex items-center gap-2 mb-3">
-                <BarChart2 size={13} className="text-orange-300/70" />
-                <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-300">ATS Scores</h3>
+                <BarChart2 size={13} className="text-accent-strong/70" />
+                <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-fg-2">ATS Scores</h3>
               </div>
               <div className="grid grid-cols-3 gap-3 text-center">
                 <div>
-                  <p className="text-lg font-bold tabular-nums text-orange-300">
+                  <p className="text-lg font-bold tabular-nums text-accent-strong">
                     {atsStats.avg_ats_score != null ? Math.round(atsStats.avg_ats_score) : '—'}
                   </p>
-                  <p className="text-[10px] text-zinc-600 mt-0.5">Avg</p>
+                  <p className="text-[10px] text-fg-3 mt-0.5">Avg</p>
                 </div>
                 <div>
-                  <p className="text-lg font-bold tabular-nums text-emerald-400">
+                  <p className="text-lg font-bold tabular-nums text-ok">
                     {atsStats.best_ats_score != null ? Math.round(atsStats.best_ats_score) : '—'}
                   </p>
-                  <p className="text-[10px] text-zinc-600 mt-0.5">Best</p>
+                  <p className="text-[10px] text-fg-3 mt-0.5">Best</p>
                 </div>
                 <div>
-                  <p className="text-lg font-bold tabular-nums text-zinc-200">
+                  <p className="text-lg font-bold tabular-nums text-fg">
                     {atsStats.optimized_count}
                   </p>
-                  <p className="text-[10px] text-zinc-600 mt-0.5">Optimized</p>
+                  <p className="text-[10px] text-fg-3 mt-0.5">Optimized</p>
                 </div>
               </div>
             </section>
           )}
 
-          <section className="surface-panel edge-highlight p-5">
-            <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-300">Workflow Tip</h3>
-            <p className="mt-2 text-sm text-zinc-400">
-              Use <strong className="text-zinc-300">Fork</strong> to create role-specific variants of a resume. Edit each variant independently, then compare with the parent to review changes.
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-fg-2">Workflow Tip</h3>
+            <p className="mt-2 text-sm text-fg-2">
+              Use <strong className="text-fg">Fork</strong> to create role-specific variants of a resume. Edit each variant independently, then compare with the parent to review changes.
             </p>
           </section>
         </aside>
@@ -1154,15 +1154,15 @@ export default function WorkspacePage() {
 
       {/* Fork modal */}
       {forkModalResumeId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setForkModalResumeId(null)}>
-          <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl" onClick={e => e.stopPropagation()}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--overlay)]" onClick={() => setForkModalResumeId(null)}>
+          <div className="w-full max-w-sm rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)]" onClick={e => e.stopPropagation()}>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-base font-semibold text-white">Create Variant</h3>
-              <button onClick={() => setForkModalResumeId(null)} className="rounded-md p-1.5 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-300">
+              <h3 className="text-base font-semibold text-fg">Create Variant</h3>
+              <button onClick={() => setForkModalResumeId(null)} className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2">
                 <X size={16} />
               </button>
             </div>
-            <p className="text-xs text-zinc-500 mb-4">This creates a linked copy you can customize for a specific role.</p>
+            <p className="text-xs text-fg-3 mb-4">This creates a linked copy you can customize for a specific role.</p>
             <input
               type="text"
               value={forkTitle}
@@ -1170,19 +1170,19 @@ export default function WorkspacePage() {
               onKeyDown={e => { if (e.key === 'Enter' && !isForking) handleFork(forkModalResumeId, forkTitle); if (e.key === 'Escape') setForkModalResumeId(null) }}
               placeholder="Variant title"
               autoFocus
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40 mb-4"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none transition focus:border-accent mb-4"
             />
             <div className="flex gap-2 justify-end">
               <button
                 onClick={() => setForkModalResumeId(null)}
-                className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 transition hover:text-zinc-200"
+                className="rounded-[var(--radius-md)] border border-line px-4 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg"
               >
                 Cancel
               </button>
               <button
                 onClick={() => handleFork(forkModalResumeId, forkTitle)}
                 disabled={isForking}
-                className="btn-accent px-4 py-2 text-xs disabled:opacity-50"
+                className="rounded-[var(--radius-md)] bg-accent font-semibold text-accent-fg hover:brightness-110 px-4 py-2 text-xs disabled:opacity-50"
               >
                 {isForking ? 'Creating...' : 'Create Variant'}
               </button>
@@ -1193,23 +1193,23 @@ export default function WorkspacePage() {
 
       {/* Translate modal */}
       {translateModalResumeId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setTranslateModalResumeId(null)}>
-          <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl" onClick={e => e.stopPropagation()}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--overlay)]" onClick={() => setTranslateModalResumeId(null)}>
+          <div className="w-full max-w-sm rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)]" onClick={e => e.stopPropagation()}>
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">
-                <Globe size={16} className="text-sky-400" />
-                <h3 className="text-base font-semibold text-white">Translate Resume</h3>
+                <Globe size={16} className="text-accent-strong" />
+                <h3 className="text-base font-semibold text-fg">Translate Resume</h3>
               </div>
-              <button onClick={() => setTranslateModalResumeId(null)} className="rounded-md p-1.5 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-300">
+              <button onClick={() => setTranslateModalResumeId(null)} className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2">
                 <X size={16} />
               </button>
             </div>
-            <p className="text-xs text-zinc-500 mb-4">Creates a new variant with prose translated by AI. LaTeX commands are preserved exactly.</p>
-            <label className="block text-xs font-medium text-zinc-400 mb-1.5">Target Language</label>
+            <p className="text-xs text-fg-3 mb-4">Creates a new variant with prose translated by AI. LaTeX commands are preserved exactly.</p>
+            <label className="block text-xs font-medium text-fg-2 mb-1.5">Target Language</label>
             <select
               value={translateSelectedLang}
               onChange={e => setTranslateSelectedLang(e.target.value)}
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-sky-400/40 mb-5"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none transition focus:border-accent mb-5"
             >
               {TRANSLATE_LANGUAGES.map(l => (
                 <option key={l.code} value={l.code}>{l.name}</option>
@@ -1218,14 +1218,14 @@ export default function WorkspacePage() {
             <div className="flex gap-2 justify-end">
               <button
                 onClick={() => setTranslateModalResumeId(null)}
-                className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 transition hover:text-zinc-200"
+                className="rounded-[var(--radius-md)] border border-line px-4 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg"
               >
                 Cancel
               </button>
               <button
                 onClick={() => handleTranslate(translateModalResumeId, translateSelectedLang)}
                 disabled={isTranslating}
-                className="flex items-center gap-1.5 rounded-lg bg-sky-500/15 px-4 py-2 text-xs font-semibold text-sky-300 ring-1 ring-sky-400/30 transition hover:bg-sky-500/25 disabled:opacity-50"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-accent-soft px-4 py-2 text-xs font-semibold text-accent-strong ring-1 ring-accent transition hover:brightness-110 disabled:opacity-50"
               >
                 {isTranslating ? <><Loader2 size={12} className="animate-spin" /> Translating…</> : <><Globe size={12} /> Translate</>}
               </button>
@@ -1345,18 +1345,18 @@ export default function WorkspacePage() {
 
       {/* Tag Edit modal (Feature 39) */}
       {tagEditResumeId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setTagEditResumeId(null)}>
-          <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl" onClick={e => e.stopPropagation()}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--overlay)]" onClick={() => setTagEditResumeId(null)}>
+          <div className="w-full max-w-sm rounded-[var(--radius-lg)] border border-line bg-surface p-6 shadow-[var(--shadow-2)]" onClick={e => e.stopPropagation()}>
             <div className="mb-4 flex items-center justify-between">
-              <h3 className="flex items-center gap-2 text-base font-semibold text-white">
-                <Tag size={14} className="text-violet-400" />
+              <h3 className="flex items-center gap-2 text-base font-semibold text-fg">
+                <Tag size={14} className="text-accent-strong" />
                 Edit Tags
               </h3>
-              <button onClick={() => setTagEditResumeId(null)} className="rounded-md p-1.5 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-300">
+              <button onClick={() => setTagEditResumeId(null)} className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2">
                 <X size={16} />
               </button>
             </div>
-            <p className="mb-3 text-xs text-zinc-500">Enter tags separated by commas (max 10, each ≤30 chars)</p>
+            <p className="mb-3 text-xs text-fg-3">Enter tags separated by commas (max 10, each ≤30 chars)</p>
             <input
               type="text"
               value={tagEditValue}
@@ -1364,13 +1364,13 @@ export default function WorkspacePage() {
               onKeyDown={e => { if (e.key === 'Enter') handleSaveTags(); if (e.key === 'Escape') setTagEditResumeId(null) }}
               placeholder="e.g. frontend, senior, remote"
               autoFocus
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-violet-400/40 mb-4"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none transition focus:border-accent mb-4"
             />
             <div className="flex gap-2 justify-end">
-              <button onClick={() => setTagEditResumeId(null)} className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 transition hover:text-zinc-200">
+              <button onClick={() => setTagEditResumeId(null)} className="rounded-[var(--radius-md)] border border-line px-4 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg">
                 Cancel
               </button>
-              <button onClick={handleSaveTags} className="rounded-lg bg-violet-600 px-4 py-2 text-xs font-semibold text-white transition hover:bg-violet-500">
+              <button onClick={handleSaveTags} className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg transition hover:brightness-110">
                 Save Tags
               </button>
             </div>

--- a/frontend/src/app/workspaces/page.tsx
+++ b/frontend/src/app/workspaces/page.tsx
@@ -59,16 +59,16 @@ export default function WorkspacesPage() {
   const userId = session.user.id
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100 p-6 max-w-4xl mx-auto">
+    <div className="min-h-screen bg-bg text-fg p-6 max-w-4xl mx-auto">
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center gap-3">
-          <Building2 className="h-6 w-6 text-violet-400" />
+          <Building2 className="h-6 w-6 text-accent-strong" />
           <h1 className="text-2xl font-semibold">Team Workspaces</h1>
         </div>
         <button
           onClick={() => setShowCreate(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-violet-600 hover:bg-violet-500 rounded-lg text-sm font-medium transition-colors"
+          className="flex items-center gap-2 px-4 py-2 bg-accent hover:brightness-110 text-accent-fg rounded-[var(--radius-md)] text-sm font-medium transition-colors"
         >
           <Plus className="h-4 w-4" />
           New Workspace
@@ -77,8 +77,8 @@ export default function WorkspacesPage() {
 
       {/* Create form */}
       {showCreate && (
-        <div className="mb-6 p-4 bg-zinc-900 border border-zinc-700 rounded-xl">
-          <p className="text-sm font-medium text-zinc-300 mb-3">Workspace name</p>
+        <div className="mb-6 p-4 bg-surface border border-line rounded-[var(--radius-lg)]">
+          <p className="text-sm font-medium text-fg-2 mb-3">Workspace name</p>
           <div className="flex gap-3">
             <input
               autoFocus
@@ -86,18 +86,18 @@ export default function WorkspacesPage() {
               onChange={(e) => setNewName(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
               placeholder="e.g. Engineering Team"
-              className="flex-1 bg-zinc-800 border border-zinc-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-violet-500"
+              className="flex-1 bg-surface-2 border border-line-2 rounded-[var(--radius-md)] px-3 py-2 text-sm focus:outline-none focus:border-accent"
             />
             <button
               onClick={handleCreate}
               disabled={creating || !newName.trim()}
-              className="px-4 py-2 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 rounded-lg text-sm font-medium transition-colors"
+              className="px-4 py-2 bg-accent hover:brightness-110 text-accent-fg disabled:opacity-50 rounded-[var(--radius-md)] text-sm font-medium transition-colors"
             >
               {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Create'}
             </button>
             <button
               onClick={() => { setShowCreate(false); setNewName('') }}
-              className="px-3 py-2 text-zinc-400 hover:text-zinc-200 text-sm transition-colors"
+              className="px-3 py-2 text-fg-2 hover:text-fg text-sm transition-colors"
             >
               Cancel
             </button>
@@ -107,7 +107,7 @@ export default function WorkspacesPage() {
 
       {/* Workspace grid */}
       {workspaces.length === 0 ? (
-        <div className="text-center py-20 text-zinc-500">
+        <div className="text-center py-20 text-fg-3">
           <Building2 className="h-12 w-12 mx-auto mb-4 opacity-30" />
           <p className="text-lg mb-1">No workspaces yet</p>
           <p className="text-sm">Create a workspace to collaborate with your team.</p>
@@ -117,22 +117,22 @@ export default function WorkspacesPage() {
           {workspaces.map((ws) => (
             <div
               key={ws.id}
-              className="group relative bg-zinc-900 border border-zinc-800 hover:border-zinc-600 rounded-xl p-5 transition-colors"
+              className="group relative bg-surface border border-line hover:border-line-2 rounded-[var(--radius-lg)] p-5 transition-colors"
             >
               <Link href={`/workspaces/${ws.id}`} className="block">
                 <div className="flex items-start justify-between mb-3">
                   <div className="flex items-center gap-3">
-                    <div className="h-9 w-9 rounded-lg bg-violet-500/20 flex items-center justify-center">
-                      <Building2 className="h-4 w-4 text-violet-400" />
+                    <div className="h-9 w-9 rounded-[var(--radius-md)] bg-accent-soft flex items-center justify-center">
+                      <Building2 className="h-4 w-4 text-accent-strong" />
                     </div>
                     <div>
-                      <p className="font-medium text-zinc-100">{ws.name}</p>
-                      <p className="text-xs text-zinc-500 capitalize">{ws.plan_id} plan</p>
+                      <p className="font-medium text-fg">{ws.name}</p>
+                      <p className="text-xs text-fg-3 capitalize">{ws.plan_id} plan</p>
                     </div>
                   </div>
                 </div>
 
-                <div className="flex gap-4 text-sm text-zinc-400">
+                <div className="flex gap-4 text-sm text-fg-2">
                   <span className="flex items-center gap-1">
                     <Users className="h-3.5 w-3.5" />
                     {ws.member_count}/{ws.max_members} members
@@ -145,7 +145,7 @@ export default function WorkspacesPage() {
               {ws.owner_id === userId && (
                 <button
                   onClick={(e) => { e.preventDefault(); handleDelete(ws) }}
-                  className="absolute top-3 right-3 p-1.5 opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-rose-400 transition-all"
+                  className="absolute top-3 right-3 p-1.5 opacity-0 group-hover:opacity-100 text-fg-3 hover:text-err transition-all"
                   title="Delete workspace"
                 >
                   <Trash2 className="h-3.5 w-3.5" />


### PR DESCRIPTION
Refs #1073. Fourth phase — re-skins the authenticated app-shell pages (dashboard, workspace/workspaces lists, billing, settings, byok, tracker) to the Compiler token aesthetic. **Additive, zero functional regressions** — 493 tests pass, build compiles.

Method: **surgical class-replacement only** (via the `redesign-appshell` workflow, high-effort agents). Each file's review agent diffed against HEAD to confirm **only classNames/colors changed — zero logic edits** (`logicPreserved: true` on all 7, including the 1382-line workspace list), with an explicit token mapping (zinc→surface/fg tiers, orange→accent, green→ok / red→err / amber→warn, decorative rainbow collapsed to accent, legacy `surface-*`/`btn-*` classes expanded to tokens).

Embedded panels/modals (Phase 5) may still look un-skinned — that's expected; the page chrome is now token-driven.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated billing, BYOK, dashboard, settings, tracker, workspace, and workspaces pages with consistent shared theme styling.
  * Improved visual consistency for backgrounds, borders, typography, buttons, cards, controls, status indicators, loading states, and dialogs.
  * Preserved existing layouts, content, interactions, and page functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->