### PR TITLE
Redesign Phase 5a: modal components (tokens)

### DIFF
--- a/frontend/src/components/AddApplicationModal.tsx
+++ b/frontend/src/components/AddApplicationModal.tsx
@@ -88,20 +88,20 @@ export default function AddApplicationModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] backdrop-blur-sm p-4"
       onClick={onClose}
     >
       <div
-        className="relative w-full max-w-lg rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl"
+        className="relative w-full max-w-lg rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/10 px-5 py-4">
-          <h2 className="text-sm font-semibold text-white">Add Application</h2>
+        <div className="flex items-center justify-between border-b border-line px-5 py-4">
+          <h2 className="text-sm font-semibold text-fg">Add Application</h2>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-white"
+            className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <X size={16} />
           </button>
@@ -111,7 +111,7 @@ export default function AddApplicationModal({
         <form onSubmit={handleSubmit} className="space-y-4 p-5">
           <div className="grid grid-cols-2 gap-3">
             <div className="col-span-2 sm:col-span-1">
-              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">
+              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">
                 Company *
               </label>
               <input
@@ -121,11 +121,11 @@ export default function AddApplicationModal({
                 onChange={(e) => setCompanyName(e.target.value)}
                 placeholder="e.g. Google"
                 required
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
               />
             </div>
             <div className="col-span-2 sm:col-span-1">
-              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">
+              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">
                 Role *
               </label>
               <input
@@ -134,20 +134,20 @@ export default function AddApplicationModal({
                 onChange={(e) => setRoleTitle(e.target.value)}
                 placeholder="e.g. Software Engineer"
                 required
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
               />
             </div>
           </div>
 
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">
+              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">
                 Status
               </label>
               <select
                 value={status}
                 onChange={(e) => setStatus(e.target.value)}
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
               >
                 {STATUSES.map((s) => (
                   <option key={s.value} value={s.value}>
@@ -157,20 +157,20 @@ export default function AddApplicationModal({
               </select>
             </div>
             <div>
-              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">
+              <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">
                 Applied On
               </label>
               <input
                 type="date"
                 value={appliedAt}
                 onChange={(e) => setAppliedAt(e.target.value)}
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
               />
             </div>
           </div>
 
           <div>
-            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">
+            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">
               Job URL
             </label>
             <input
@@ -178,18 +178,18 @@ export default function AddApplicationModal({
               value={jobUrl}
               onChange={(e) => setJobUrl(e.target.value)}
               placeholder="https://..."
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
             />
           </div>
 
           <div>
-            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">
+            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">
               Linked Resume
             </label>
             <select
               value={resumeId}
               onChange={(e) => setResumeId(e.target.value)}
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
             >
               <option value="">— None —</option>
               {resumes.map((r) => (
@@ -202,7 +202,7 @@ export default function AddApplicationModal({
           </div>
 
           <div>
-            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-zinc-500">
+            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-widest text-fg-3">
               Notes
             </label>
             <textarea
@@ -210,7 +210,7 @@ export default function AddApplicationModal({
               onChange={(e) => setNotes(e.target.value)}
               placeholder="Referral, recruiter name, etc."
               rows={2}
-              className="w-full resize-none rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+              className="w-full resize-none rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
             />
           </div>
 
@@ -218,7 +218,7 @@ export default function AddApplicationModal({
             <button
               type="button"
               onClick={() => setShowJD((v) => !v)}
-              className="text-xs font-semibold text-zinc-500 transition hover:text-zinc-300"
+              className="text-xs font-semibold text-fg-3 transition hover:text-fg-2"
             >
               {showJD ? '▲ Hide' : '▼ Show'} job description
             </button>
@@ -228,23 +228,23 @@ export default function AddApplicationModal({
                 onChange={(e) => setJobDescription(e.target.value)}
                 placeholder="Paste the full job description..."
                 rows={5}
-                className="mt-2 w-full resize-none rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-orange-300/40"
+                className="mt-2 w-full resize-none rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
               />
             )}
           </div>
 
-          <div className="flex justify-end gap-2 border-t border-white/10 pt-4">
+          <div className="flex justify-end gap-2 border-t border-line pt-4">
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 transition hover:text-white"
+              className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={isSubmitting || !companyName.trim() || !roleTitle.trim()}
-              className="btn-accent px-4 py-2 text-xs disabled:opacity-50"
+              className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg hover:brightness-110 disabled:opacity-50"
             >
               {isSubmitting ? 'Adding…' : 'Add Application'}
             </button>

--- a/frontend/src/components/ApplyModal.tsx
+++ b/frontend/src/components/ApplyModal.tsx
@@ -152,24 +152,24 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
 
   const platformLabel = preview?.platform === 'greenhouse' ? 'Greenhouse' : 'Lever'
   const platformColor = preview?.platform === 'greenhouse'
-    ? 'text-emerald-300'
-    : 'text-violet-300'
+    ? 'text-ok'
+    : 'text-accent-strong'
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
-      <div className="relative w-full max-w-lg rounded-2xl border border-white/[0.08] bg-[#0f0f0f] shadow-2xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[var(--overlay)] backdrop-blur-sm">
+      <div className="relative w-full max-w-lg rounded-[var(--radius-lg)] border border-line bg-surface shadow-[var(--shadow-2)]">
 
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-4">
+        <div className="flex items-center justify-between border-b border-line px-6 py-4">
           <div>
-            <h2 className="text-base font-semibold text-white">Apply with One Click</h2>
+            <h2 className="text-base font-semibold text-fg">Apply with One Click</h2>
             {resumeTitle && (
-              <p className="mt-0.5 text-xs text-zinc-500">Using: {resumeTitle}</p>
+              <p className="mt-0.5 text-xs text-fg-3">Using: {resumeTitle}</p>
             )}
           </div>
           <button
             onClick={onClose}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-200"
+            className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <X size={15} />
           </button>
@@ -182,10 +182,10 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
               key={s}
               className={`h-1 flex-1 rounded-full transition-all ${
                 step === 'success' || step === 'error'
-                  ? 'bg-emerald-500/30'
+                  ? 'bg-ok/30'
                   : i <= (['url', 'preview', 'form'] as Step[]).indexOf(step as Step)
-                  ? 'bg-orange-400/60'
-                  : 'bg-white/[0.06]'
+                  ? 'bg-accent/60'
+                  : 'bg-line'
               }`}
             />
           ))}
@@ -197,7 +197,7 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
           {step === 'url' && (
             <>
               <div>
-                <label className="mb-1.5 block text-xs font-medium text-zinc-400">
+                <label className="mb-1.5 block text-xs font-medium text-fg-2">
                   Job URL
                 </label>
                 <input
@@ -206,10 +206,10 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
                   value={jobUrl}
                   onChange={e => setJobUrl(e.target.value)}
                   onKeyDown={e => { if (e.key === 'Enter') handleDetect() }}
-                  className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white outline-none transition placeholder:text-zinc-600 focus:border-orange-300/40"
+                  className="w-full rounded-[var(--radius-lg)] border border-line bg-bg px-4 py-3 text-sm text-fg outline-none transition placeholder:text-fg-3 focus:border-accent"
                   autoFocus
                 />
-                <p className="mt-1.5 text-[11px] text-zinc-600">
+                <p className="mt-1.5 text-[11px] text-fg-3">
                   Supports Greenhouse (boards.greenhouse.io) and Lever (jobs.lever.co)
                 </p>
               </div>
@@ -217,7 +217,7 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
               <button
                 onClick={handleDetect}
                 disabled={!jobUrl.trim() || detecting}
-                className="flex w-full items-center justify-center gap-2 rounded-xl bg-orange-400/15 border border-orange-400/25 px-4 py-3 text-sm font-semibold text-orange-200 transition hover:bg-orange-400/20 disabled:cursor-not-allowed disabled:opacity-40"
+                className="flex w-full items-center justify-center gap-2 rounded-[var(--radius-lg)] bg-accent-soft border border-accent px-4 py-3 text-sm font-semibold text-accent-strong transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {detecting ? (
                   <><Loader2 size={14} className="animate-spin" /> Fetching job details…</>
@@ -231,17 +231,17 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
           {/* ── STEP: PREVIEW ─────────────────────────────────── */}
           {step === 'preview' && preview && (
             <>
-              <div className="rounded-xl border border-white/[0.07] bg-white/[0.03] p-4 space-y-3">
+              <div className="rounded-[var(--radius-lg)] border border-line bg-surface-2 p-4 space-y-3">
                 <div className="flex items-center gap-2">
                   <span className={`text-[10px] font-bold uppercase tracking-[0.12em] ${platformColor}`}>
                     {platformLabel}
                   </span>
                 </div>
                 <div>
-                  <h3 className="text-base font-semibold text-white line-clamp-2">
+                  <h3 className="text-base font-semibold text-fg line-clamp-2">
                     {preview.title || 'Unknown role'}
                   </h3>
-                  <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-400">
+                  <div className="mt-2 flex flex-wrap gap-3 text-xs text-fg-2">
                     <span className="flex items-center gap-1">
                       <Building2 size={11} />
                       {preview.company}
@@ -264,13 +264,13 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
                   href={preview.apply_url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-300 transition"
+                  className="inline-flex items-center gap-1 text-[11px] text-fg-3 hover:text-fg-2 transition"
                 >
                   View on {platformLabel} <ExternalLink size={10} />
                 </a>
               </div>
 
-              <p className="text-xs text-zinc-500">
+              <p className="text-xs text-fg-3">
                 We will submit your compiled resume PDF directly to this posting. You&apos;ll fill in your
                 contact details next.
               </p>
@@ -278,13 +278,13 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
               <div className="flex gap-3">
                 <button
                   onClick={() => setStep('url')}
-                  className="flex items-center gap-1.5 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-zinc-400 transition hover:text-zinc-200"
+                  className="flex items-center gap-1.5 rounded-[var(--radius-lg)] border border-line px-4 py-2.5 text-sm text-fg-2 transition hover:text-fg"
                 >
                   <ArrowLeft size={13} /> Back
                 </button>
                 <button
                   onClick={() => setStep('form')}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-orange-400/15 border border-orange-400/25 px-4 py-2.5 text-sm font-semibold text-orange-200 transition hover:bg-orange-400/20"
+                  className="flex flex-1 items-center justify-center gap-2 rounded-[var(--radius-lg)] bg-accent-soft border border-accent px-4 py-2.5 text-sm font-semibold text-accent-strong transition hover:brightness-110"
                 >
                   Fill in details <ArrowRight size={13} />
                 </button>
@@ -297,79 +297,79 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
             <>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="mb-1 block text-[11px] text-zinc-500">First name *</label>
+                  <label className="mb-1 block text-[11px] text-fg-3">First name *</label>
                   <input
                     value={formFirst}
                     onChange={e => setFormFirst(e.target.value)}
-                    className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none focus:border-orange-300/40"
+                    className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none focus:border-accent"
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-[11px] text-zinc-500">Last name *</label>
+                  <label className="mb-1 block text-[11px] text-fg-3">Last name *</label>
                   <input
                     value={formLast}
                     onChange={e => setFormLast(e.target.value)}
-                    className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none focus:border-orange-300/40"
+                    className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none focus:border-accent"
                   />
                 </div>
               </div>
 
               <div>
-                <label className="mb-1 block text-[11px] text-zinc-500">Email *</label>
+                <label className="mb-1 block text-[11px] text-fg-3">Email *</label>
                 <input
                   type="email"
                   value={formEmail}
                   onChange={e => setFormEmail(e.target.value)}
-                  className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none focus:border-orange-300/40"
+                  className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none focus:border-accent"
                 />
               </div>
 
               <div>
-                <label className="mb-1 block text-[11px] text-zinc-500">Phone</label>
+                <label className="mb-1 block text-[11px] text-fg-3">Phone</label>
                 <input
                   type="tel"
                   value={formPhone}
                   onChange={e => setFormPhone(e.target.value)}
-                  className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none focus:border-orange-300/40"
+                  className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none focus:border-accent"
                 />
               </div>
 
               {preview.platform === 'lever' && (
                 <div>
-                  <label className="mb-1 block text-[11px] text-zinc-500">Company / School</label>
+                  <label className="mb-1 block text-[11px] text-fg-3">Company / School</label>
                   <input
                     value={formOrg}
                     onChange={e => setFormOrg(e.target.value)}
                     placeholder="Current employer or university"
-                    className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none focus:border-orange-300/40"
+                    className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none focus:border-accent"
                   />
                 </div>
               )}
 
               <div>
-                <label className="mb-1 block text-[11px] text-zinc-500">
-                  Cover letter <span className="text-zinc-700">(optional)</span>
+                <label className="mb-1 block text-[11px] text-fg-3">
+                  Cover letter <span className="text-fg-3">(optional)</span>
                 </label>
                 <textarea
                   value={coverLetter}
                   onChange={e => setCoverLetter(e.target.value)}
                   rows={4}
                   placeholder="Write a short cover letter or leave blank…"
-                  className="w-full resize-none rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-white outline-none focus:border-orange-300/40"
+                  className="w-full resize-none rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none focus:border-accent"
                 />
               </div>
 
               <div className="flex gap-3">
                 <button
                   onClick={() => setStep('preview')}
-                  className="flex items-center gap-1.5 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-zinc-400 transition hover:text-zinc-200"
+                  className="flex items-center gap-1.5 rounded-[var(--radius-lg)] border border-line px-4 py-2.5 text-sm text-fg-2 transition hover:text-fg"
                 >
                   <ArrowLeft size={13} /> Back
                 </button>
                 <button
                   onClick={handleSubmit}
                   disabled={submitting || !formFirst || !formLast || !formEmail}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-orange-400/15 border border-orange-400/25 px-4 py-2.5 text-sm font-semibold text-orange-200 transition hover:bg-orange-400/20 disabled:cursor-not-allowed disabled:opacity-40"
+                  className="flex flex-1 items-center justify-center gap-2 rounded-[var(--radius-lg)] bg-accent-soft border border-accent px-4 py-2.5 text-sm font-semibold text-accent-strong transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   {submitting ? (
                     <><Loader2 size={14} className="animate-spin" /> Submitting…</>
@@ -384,26 +384,26 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
           {/* ── STEP: SUCCESS ─────────────────────────────────── */}
           {step === 'success' && result && (
             <div className="flex flex-col items-center gap-4 py-4 text-center">
-              <CheckCircle2 size={40} className="text-emerald-400" />
+              <CheckCircle2 size={40} className="text-ok" />
               <div>
-                <h3 className="text-base font-semibold text-white">Application Submitted!</h3>
-                <p className="mt-1 text-sm text-zinc-400">
+                <h3 className="text-base font-semibold text-fg">Application Submitted!</h3>
+                <p className="mt-1 text-sm text-fg-2">
                   Your resume was sent to{' '}
-                  <span className="font-medium text-zinc-200">
+                  <span className="font-medium text-fg">
                     {result.company_name || preview?.company}
                   </span>{' '}
-                  for <span className="font-medium text-zinc-200">{result.job_title || 'the role'}</span>.
+                  for <span className="font-medium text-fg">{result.job_title || 'the role'}</span>.
                 </p>
               </div>
               {result.job_tracker_id && (
                 <a
                   href="/tracker"
-                  className="rounded-xl border border-sky-400/25 bg-sky-400/10 px-4 py-2 text-sm font-semibold text-sky-300 transition hover:bg-sky-400/20"
+                  className="rounded-[var(--radius-lg)] border border-accent bg-accent-soft px-4 py-2 text-sm font-semibold text-accent-strong transition hover:brightness-110"
                 >
                   View in Job Tracker →
                 </a>
               )}
-              <button onClick={onClose} className="text-xs text-zinc-600 hover:text-zinc-400 transition">
+              <button onClick={onClose} className="text-xs text-fg-3 hover:text-fg-2 transition">
                 Close
               </button>
             </div>
@@ -412,17 +412,17 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
           {/* ── STEP: ERROR ───────────────────────────────────── */}
           {step === 'error' && (
             <div className="flex flex-col items-center gap-4 py-4 text-center">
-              <AlertCircle size={36} className="text-rose-400" />
+              <AlertCircle size={36} className="text-err" />
               <div>
-                <h3 className="text-base font-semibold text-white">Submission Failed</h3>
-                <p className="mt-1 text-sm text-zinc-400 break-words">
+                <h3 className="text-base font-semibold text-fg">Submission Failed</h3>
+                <p className="mt-1 text-sm text-fg-2 break-words">
                   {errorMessage || 'An unexpected error occurred.'}
                 </p>
               </div>
               <div className="flex gap-3">
                 <button
                   onClick={() => setStep('form')}
-                  className="rounded-xl border border-white/10 px-4 py-2 text-sm text-zinc-400 transition hover:text-zinc-200"
+                  className="rounded-[var(--radius-lg)] border border-line px-4 py-2 text-sm text-fg-2 transition hover:text-fg"
                 >
                   Try Again
                 </button>
@@ -431,7 +431,7 @@ export default function ApplyModal({ resumeId, resumeTitle, defaultJobUrl = '', 
                     href={preview.apply_url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center gap-1.5 rounded-xl border border-amber-400/25 bg-amber-400/10 px-4 py-2 text-sm font-semibold text-amber-300 transition hover:bg-amber-400/20"
+                    className="flex items-center gap-1.5 rounded-[var(--radius-lg)] border border-warn bg-warn/10 px-4 py-2 text-sm font-semibold text-warn transition hover:brightness-110"
                   >
                     Open on {platformLabel} <ExternalLink size={12} />
                   </a>

--- a/frontend/src/components/ChangeReviewModal.tsx
+++ b/frontend/src/components/ChangeReviewModal.tsx
@@ -25,9 +25,9 @@ type HunkState = {
 }
 
 const KIND_META: Record<ChangeHunk['kind'], { label: string; cls: string }> = {
-  modified: { label: 'Modified', cls: 'bg-amber-500/15 text-amber-200 ring-amber-400/20' },
-  added: { label: 'Added', cls: 'bg-emerald-500/15 text-emerald-200 ring-emerald-400/20' },
-  removed: { label: 'Removed', cls: 'bg-rose-500/15 text-rose-200 ring-rose-400/20' },
+  modified: { label: 'Modified', cls: 'bg-warn/15 text-warn ring-warn/20' },
+  added: { label: 'Added', cls: 'bg-ok/15 text-ok ring-ok/20' },
+  removed: { label: 'Removed', cls: 'bg-err/15 text-err ring-err/20' },
 }
 
 export default function ChangeReviewModal({
@@ -136,40 +136,40 @@ export default function ChangeReviewModal({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] p-4 backdrop-blur-sm"
         onClick={onClose}
       >
         <motion.div
           initial={{ opacity: 0, scale: 0.97, y: 8 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.97 }}
-          className="flex max-h-[88vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl"
+          className="flex max-h-[88vh] w-full max-w-3xl flex-col overflow-hidden rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
-          <div className="flex items-center justify-between border-b border-white/10 px-5 py-4">
+          <div className="flex items-center justify-between border-b border-line px-5 py-4">
             <div>
-              <h2 className="text-sm font-semibold text-zinc-100">Review changes</h2>
-              <p className="mt-0.5 text-[11px] text-zinc-500">
+              <h2 className="text-sm font-semibold text-fg">Review changes</h2>
+              <p className="mt-0.5 text-[11px] text-fg-3">
                 Accept, reject, or edit each suggestion. Only accepted changes are applied.
               </p>
             </div>
-            <button onClick={onClose} className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-zinc-200">
+            <button onClick={onClose} className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg">
               <X size={16} />
             </button>
           </div>
 
           {/* Toolbar */}
           {hunks && hunks.length > 0 && (
-            <div className="flex items-center justify-between gap-3 border-b border-white/5 px-5 py-2.5">
-              <span className="text-[11px] text-zinc-500">
+            <div className="flex items-center justify-between gap-3 border-b border-line px-5 py-2.5">
+              <span className="text-[11px] text-fg-3">
                 {acceptedCount} of {hunks.length} accepted
               </span>
               <div className="flex gap-2">
-                <button onClick={() => setAll(true)} className="rounded-md px-2 py-1 text-[11px] font-medium text-emerald-300 transition hover:bg-emerald-500/10">
+                <button onClick={() => setAll(true)} className="rounded-[var(--radius-md)] px-2 py-1 text-[11px] font-medium text-ok transition hover:bg-ok/10">
                   Accept all
                 </button>
-                <button onClick={() => setAll(false)} className="rounded-md px-2 py-1 text-[11px] font-medium text-zinc-400 transition hover:bg-white/5">
+                <button onClick={() => setAll(false)} className="rounded-[var(--radius-md)] px-2 py-1 text-[11px] font-medium text-fg-2 transition hover:bg-surface-2">
                   Reject all
                 </button>
               </div>
@@ -179,15 +179,15 @@ export default function ChangeReviewModal({
           {/* Body */}
           <div className="scrollbar-subtle min-h-0 flex-1 overflow-y-auto px-5 py-4">
             {loading && (
-              <div className="flex items-center justify-center gap-2 py-16 text-sm text-zinc-500">
+              <div className="flex items-center justify-center gap-2 py-16 text-sm text-fg-3">
                 <Loader2 size={16} className="animate-spin" /> Computing changes…
               </div>
             )}
             {error && !loading && (
-              <div className="rounded-lg border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">{error}</div>
+              <div className="rounded-[var(--radius-md)] border border-err/20 bg-err/10 px-4 py-3 text-sm text-err">{error}</div>
             )}
             {!loading && !error && hunks && hunks.length === 0 && (
-              <div className="py-16 text-center text-sm text-zinc-500">
+              <div className="py-16 text-center text-sm text-fg-3">
                 No substantive changes to review — the optimized result matches your resume.
               </div>
             )}
@@ -200,28 +200,28 @@ export default function ChangeReviewModal({
                   return (
                     <li
                       key={h.id}
-                      className={`rounded-xl border p-3 transition ${
-                        s.accepted ? 'border-white/10 bg-white/[0.02]' : 'border-white/5 bg-transparent opacity-60'
+                      className={`rounded-[var(--radius-lg)] border p-3 transition ${
+                        s.accepted ? 'border-line bg-surface' : 'border-line bg-transparent opacity-60'
                       }`}
                     >
                       <div className="mb-2 flex items-center gap-2">
                         <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ${meta.cls}`}>
                           {meta.label}
                         </span>
-                        {h.section && <span className="text-[11px] text-zinc-500">{h.section}</span>}
+                        {h.section && <span className="text-[11px] text-fg-3">{h.section}</span>}
                         <div className="ml-auto flex items-center gap-1">
                           <button
                             onClick={() => startEdit(h.id)}
                             title="Edit"
-                            className="rounded-md p-1 text-zinc-500 transition hover:bg-white/5 hover:text-zinc-200"
+                            className="rounded-[var(--radius-md)] p-1 text-fg-3 transition hover:bg-surface-2 hover:text-fg"
                           >
                             <Pencil size={12} />
                           </button>
                           <button
                             onClick={() => toggle(h.id)}
                             title={s.accepted ? 'Reject' : 'Accept'}
-                            className={`rounded-md p-1 transition ${
-                              s.accepted ? 'text-emerald-300 hover:bg-emerald-500/10' : 'text-zinc-500 hover:bg-white/5'
+                            className={`rounded-[var(--radius-md)] p-1 transition ${
+                              s.accepted ? 'text-ok hover:bg-ok/10' : 'text-fg-3 hover:bg-surface-2'
                             }`}
                           >
                             {s.accepted ? <Check size={13} /> : <X size={13} />}
@@ -231,7 +231,7 @@ export default function ChangeReviewModal({
 
                       {/* Diff preview */}
                       {h.original_text.trim() && (
-                        <pre className="mb-1 overflow-x-auto whitespace-pre-wrap rounded-md bg-rose-500/[0.06] px-2 py-1 text-[11px] leading-relaxed text-rose-200/80">
+                        <pre className="mb-1 overflow-x-auto whitespace-pre-wrap rounded-[var(--radius-md)] bg-err/[0.06] px-2 py-1 text-[11px] leading-relaxed text-err">
                           <code>- {h.original_text.trim()}</code>
                         </pre>
                       )}
@@ -240,25 +240,25 @@ export default function ChangeReviewModal({
                           <textarea
                             value={s.newText}
                             onChange={(e) => setEditText(h.id, e.target.value)}
-                            className="scrollbar-subtle h-24 w-full resize-none rounded-md border border-orange-400/30 bg-black/40 px-2 py-1 text-[11px] leading-relaxed text-zinc-100 outline-none focus:border-orange-300/60"
+                            className="scrollbar-subtle h-24 w-full resize-none rounded-[var(--radius-md)] border border-accent/30 bg-bg px-2 py-1 text-[11px] leading-relaxed text-fg outline-none focus:border-accent"
                           />
                           <button
                             onClick={() => resetEdit(h.id, h.new_text)}
-                            className="mt-1 flex items-center gap-1 text-[10px] text-zinc-500 transition hover:text-zinc-300"
+                            className="mt-1 flex items-center gap-1 text-[10px] text-fg-3 transition hover:text-fg-2"
                           >
                             <RotateCcw size={10} /> Reset to suggestion
                           </button>
                         </div>
                       ) : (
                         s.newText.trim() && (
-                          <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-emerald-500/[0.06] px-2 py-1 text-[11px] leading-relaxed text-emerald-200/90">
+                          <pre className="overflow-x-auto whitespace-pre-wrap rounded-[var(--radius-md)] bg-ok/[0.06] px-2 py-1 text-[11px] leading-relaxed text-ok">
                             <code>+ {s.newText.trim()}</code>
                           </pre>
                         )
                       )}
 
                       {h.rationale && (
-                        <p className="mt-1.5 text-[10px] italic text-zinc-500">{h.rationale}</p>
+                        <p className="mt-1.5 text-[10px] italic text-fg-3">{h.rationale}</p>
                       )}
                     </li>
                   )
@@ -268,14 +268,14 @@ export default function ChangeReviewModal({
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-end gap-3 border-t border-white/10 px-5 py-3.5">
-            <button onClick={onClose} className="text-xs font-semibold text-zinc-400 transition hover:text-zinc-200">
+          <div className="flex items-center justify-end gap-3 border-t border-line px-5 py-3.5">
+            <button onClick={onClose} className="text-xs font-semibold text-fg-2 transition hover:text-fg">
               Cancel
             </button>
             <button
               onClick={handleApply}
               disabled={applying || loading || !hunks || hunks.length === 0}
-              className="btn-accent px-4 py-2 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {applying ? 'Applying…' : `Apply ${acceptedCount} change${acceptedCount === 1 ? '' : 's'}`}
             </button>

--- a/frontend/src/components/CompareModal.tsx
+++ b/frontend/src/components/CompareModal.tsx
@@ -158,25 +158,25 @@ export default function CompareModal({
     originalStream.status === 'processing'
 
   const modalClasses = isFullscreen
-    ? 'relative flex h-screen w-screen flex-col bg-zinc-950'
-    : 'relative flex h-[85vh] w-[95vw] max-w-7xl flex-col rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl'
+    ? 'relative flex h-screen w-screen flex-col bg-bg'
+    : 'relative flex h-[85vh] w-[95vw] max-w-7xl flex-col rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]'
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] backdrop-blur-sm">
       <div className={modalClasses}>
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/10 px-5 py-3">
+        <div className="flex items-center justify-between border-b border-line px-5 py-3">
           <div className="flex items-center gap-4">
-            <h2 className="text-sm font-semibold text-white">Before / After Optimization</h2>
+            <h2 className="text-sm font-semibold text-fg">Before / After Optimization</h2>
 
             {/* Tab toggle */}
-            <div className="flex items-center gap-1 rounded-lg border border-white/10 bg-white/[0.03] p-0.5">
+            <div className="flex items-center gap-1 rounded-[var(--radius-md)] border border-line bg-surface p-0.5">
               <button
                 onClick={() => setActiveTab('diff')}
-                className={`rounded-md px-3 py-1 text-xs font-medium transition ${
+                className={`rounded-[var(--radius-md)] px-3 py-1 text-xs font-medium transition ${
                   activeTab === 'diff'
-                    ? 'bg-white/10 text-white'
-                    : 'text-zinc-500 hover:text-zinc-300'
+                    ? 'bg-surface-2 text-fg'
+                    : 'text-fg-3 hover:text-fg-2'
                 }`}
               >
                 LaTeX Diff
@@ -185,12 +185,12 @@ export default function CompareModal({
                 onClick={() => optimizedPdfUrl && setActiveTab('pdf')}
                 disabled={!optimizedPdfUrl}
                 title={!optimizedPdfUrl ? 'No compiled PDF available for this comparison' : undefined}
-                className={`rounded-md px-3 py-1 text-xs font-medium transition ${
+                className={`rounded-[var(--radius-md)] px-3 py-1 text-xs font-medium transition ${
                   activeTab === 'pdf'
-                    ? 'bg-white/10 text-white'
+                    ? 'bg-surface-2 text-fg'
                     : optimizedPdfUrl
-                      ? 'text-zinc-500 hover:text-zinc-300'
-                      : 'cursor-not-allowed text-zinc-700'
+                      ? 'text-fg-3 hover:text-fg-2'
+                      : 'cursor-not-allowed text-fg-3'
                 }`}
               >
                 PDF Preview
@@ -199,10 +199,10 @@ export default function CompareModal({
 
             {activeTab === 'diff' && diffStats && (
               <div className="flex items-center gap-2 text-[11px]">
-                <span className="text-emerald-400">+{diffStats.added}</span>
-                <span className="text-rose-400">−{diffStats.removed}</span>
-                <span className="text-zinc-600">·</span>
-                <span className="text-zinc-500">
+                <span className="text-ok">+{diffStats.added}</span>
+                <span className="text-err">−{diffStats.removed}</span>
+                <span className="text-fg-3">·</span>
+                <span className="text-fg-3">
                   {diffStats.changed} section{diffStats.changed !== 1 ? 's' : ''} changed
                 </span>
               </div>
@@ -213,7 +213,7 @@ export default function CompareModal({
             {onRestore && (
               <button
                 onClick={() => onRestore(originalLatex)}
-                className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-1.5 text-xs text-zinc-300 transition hover:border-white/20 hover:text-white"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs text-fg-2 transition hover:border-line-2 hover:text-fg"
               >
                 <RotateCcw size={12} />
                 Restore Original
@@ -222,7 +222,7 @@ export default function CompareModal({
             <button
               type="button"
               onClick={() => setIsFullscreen((v) => !v)}
-              className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-white"
+              className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg"
               title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
               aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
             >
@@ -230,7 +230,7 @@ export default function CompareModal({
             </button>
             <button
               onClick={onClose}
-              className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-white"
+              className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg"
             >
               <X size={16} />
             </button>
@@ -238,11 +238,11 @@ export default function CompareModal({
         </div>
 
         {/* Column labels */}
-        <div className="grid grid-cols-2 border-b border-white/5 text-[11px]">
-          <div className="truncate border-r border-white/5 px-4 py-1.5 text-zinc-500">
+        <div className="grid grid-cols-2 border-b border-line text-[11px]">
+          <div className="truncate border-r border-line px-4 py-1.5 text-fg-3">
             Before Optimization
           </div>
-          <div className="truncate px-4 py-1.5 text-zinc-500">After Optimization</div>
+          <div className="truncate px-4 py-1.5 text-fg-3">After Optimization</div>
         </div>
 
         {/* Content */}
@@ -272,34 +272,34 @@ export default function CompareModal({
 
           {/* PDF Preview tab */}
           {activeTab === 'pdf' && (
-            <div className="grid h-full grid-cols-2 divide-x divide-white/5">
+            <div className="grid h-full grid-cols-2 divide-x divide-line">
               {/* Left: Before (original — needs compile) */}
               <div ref={leftWrapperRef} className="flex h-full flex-col overflow-hidden">
                 {!originalPdfUrl && !isOriginalLoading && (
-                  <div className="flex h-full flex-col items-center justify-center gap-3 bg-[#1a1a1a]">
-                    <FileText className="h-9 w-9 text-zinc-700" />
-                    <p className="text-xs text-zinc-500">Original PDF not compiled yet</p>
+                  <div className="flex h-full flex-col items-center justify-center gap-3 bg-surface-2">
+                    <FileText className="h-9 w-9 text-fg-3" />
+                    <p className="text-xs text-fg-3">Original PDF not compiled yet</p>
                     {compileError && (
-                      <p className="max-w-[220px] text-center text-[11px] text-rose-400">{compileError}</p>
+                      <p className="max-w-[220px] text-center text-[11px] text-err">{compileError}</p>
                     )}
                     <button
                       onClick={handleCompileOriginal}
-                      className="flex items-center gap-1.5 rounded-lg border border-orange-400/25 bg-orange-400/10 px-4 py-2 text-xs font-semibold text-orange-300 transition hover:bg-orange-400/20"
+                      className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-accent bg-accent-soft px-4 py-2 text-xs font-semibold text-accent-strong transition hover:brightness-110"
                     >
                       Compile Original
                     </button>
                   </div>
                 )}
                 {isOriginalLoading && (
-                  <div className="flex h-full flex-col items-center justify-center gap-3 bg-[#1a1a1a]">
-                    <Loader2 className="h-6 w-6 animate-spin text-orange-400" />
-                    <p className="text-xs text-zinc-500">
+                  <div className="flex h-full flex-col items-center justify-center gap-3 bg-surface-2">
+                    <Loader2 className="h-6 w-6 animate-spin text-accent-strong" />
+                    <p className="text-xs text-fg-3">
                       {originalStream.stage || 'Compiling…'}
                     </p>
                     {originalStream.percent > 0 && (
-                      <div className="h-1 w-40 overflow-hidden rounded-full bg-white/10">
+                      <div className="h-1 w-40 overflow-hidden rounded-full bg-surface-2">
                         <div
-                          className="h-full rounded-full bg-orange-400 transition-all"
+                          className="h-full rounded-full bg-accent transition-all"
                           style={{ width: `${originalStream.percent}%` }}
                         />
                       </div>

--- a/frontend/src/components/CompileSettingsModal.tsx
+++ b/frontend/src/components/CompileSettingsModal.tsx
@@ -147,21 +147,21 @@ export default function CompileSettingsModal({
   return (
     <div
       ref={backdropRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] backdrop-blur-sm"
       onClick={(e) => { if (e.target === backdropRef.current) onClose() }}
     >
-      <div className="relative w-full max-w-md rounded-2xl border border-white/[0.08] bg-[#0d0d0d] shadow-2xl">
+      <div className="relative w-full max-w-md rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/[0.06] px-5 py-4">
+        <div className="flex items-center justify-between border-b border-line px-5 py-4">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-violet-500/15">
-              <Settings2 size={14} className="text-violet-300" />
+            <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+              <Settings2 size={14} className="text-accent-strong" />
             </div>
-            <h2 className="text-sm font-semibold text-zinc-100">Compile Settings</h2>
+            <h2 className="text-sm font-semibold text-fg">Compile Settings</h2>
           </div>
           <button
             onClick={onClose}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-200"
+            className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <X size={14} />
           </button>
@@ -171,7 +171,7 @@ export default function CompileSettingsModal({
         <div className="space-y-5 px-5 py-5">
           {/* Compiler */}
           <div className="space-y-2">
-            <label className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            <label className="text-[11px] font-medium uppercase tracking-wider text-fg-3">
               Compiler Engine
             </label>
             <div className="grid grid-cols-3 gap-1.5">
@@ -179,14 +179,14 @@ export default function CompileSettingsModal({
                 <button
                   key={opt.id}
                   onClick={() => setCompiler(opt.id)}
-                  className={`flex flex-col items-start gap-0.5 rounded-lg border px-3 py-2.5 text-left transition ${
+                  className={`flex flex-col items-start gap-0.5 rounded-[var(--radius-md)] border px-3 py-2.5 text-left transition ${
                     compiler === opt.id
-                      ? 'border-violet-500/40 bg-violet-500/10 text-violet-200'
-                      : 'border-white/[0.07] text-zinc-400 hover:border-white/[0.12] hover:text-zinc-200'
+                      ? 'border-accent bg-accent-soft text-accent-strong'
+                      : 'border-line text-fg-2 hover:border-line-2 hover:text-fg'
                   }`}
                 >
                   <span className="text-[12px] font-semibold">{opt.label}</span>
-                  <span className="text-[10px] text-zinc-600 leading-tight">{opt.desc}</span>
+                  <span className="text-[10px] text-fg-3 leading-tight">{opt.desc}</span>
                 </button>
               ))}
             </div>
@@ -194,13 +194,13 @@ export default function CompileSettingsModal({
 
           {/* TeX Live Version */}
           <div className="space-y-2">
-            <label className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            <label className="text-[11px] font-medium uppercase tracking-wider text-fg-3">
               TeX Live Version
             </label>
             <select
               value={texliveVersion}
               onChange={(e) => setTexliveVersion(e.target.value)}
-              className="w-full rounded-lg border border-white/[0.08] bg-[#141414] px-3 py-2 text-[12px] text-zinc-200 outline-none focus:border-violet-500/40 focus:ring-1 focus:ring-violet-500/20"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-[12px] text-fg outline-none focus:border-accent focus:ring-1 focus:ring-accent"
             >
               {TEXLIVE_VERSIONS.map((v) => (
                 <option key={v.value} value={v.value}>
@@ -212,7 +212,7 @@ export default function CompileSettingsModal({
 
           {/* Main .tex file */}
           <div className="space-y-2">
-            <label className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            <label className="text-[11px] font-medium uppercase tracking-wider text-fg-3">
               Main .tex File
             </label>
             <input
@@ -220,16 +220,16 @@ export default function CompileSettingsModal({
               value={mainFile}
               onChange={(e) => setMainFile(e.target.value)}
               placeholder="resume.tex"
-              className="w-full rounded-lg border border-white/[0.08] bg-[#141414] px-3 py-2 font-mono text-[12px] text-zinc-200 outline-none focus:border-violet-500/40 focus:ring-1 focus:ring-violet-500/20"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 font-mono text-[12px] text-fg outline-none focus:border-accent focus:ring-1 focus:ring-accent"
             />
-            <p className="text-[10px] text-zinc-600">
+            <p className="text-[10px] text-fg-3">
               Only alphanumeric, underscores, hyphens + .tex extension allowed
             </p>
           </div>
 
           {/* Extra packages */}
           <div className="space-y-2">
-            <label className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            <label className="text-[11px] font-medium uppercase tracking-wider text-fg-3">
               Extra Packages
             </label>
             <input
@@ -237,16 +237,16 @@ export default function CompileSettingsModal({
               value={packagesInput}
               onChange={(e) => setPackagesInput(e.target.value)}
               placeholder="xcolor, multicol, fontawesome5"
-              className="w-full rounded-lg border border-white/[0.08] bg-[#141414] px-3 py-2 font-mono text-[12px] text-zinc-200 outline-none focus:border-violet-500/40 focus:ring-1 focus:ring-violet-500/20"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 font-mono text-[12px] text-fg outline-none focus:border-accent focus:ring-1 focus:ring-accent"
             />
-            <p className="text-[10px] text-zinc-600">
+            <p className="text-[10px] text-fg-3">
               Comma-separated. Injected via \usepackage if not already in source.
             </p>
           </div>
 
           {/* Custom flags */}
           <div className="space-y-2">
-            <label className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            <label className="text-[11px] font-medium uppercase tracking-wider text-fg-3">
               Compiler Flags
             </label>
             <div className="space-y-1.5">
@@ -255,10 +255,10 @@ export default function CompileSettingsModal({
                 return (
                   <label
                     key={flag}
-                    className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 ${
+                    className={`flex items-center gap-2.5 rounded-[var(--radius-md)] border px-3 py-2 ${
                       isHardcoded
-                        ? 'cursor-not-allowed border-white/[0.04] opacity-50'
-                        : 'cursor-pointer border-white/[0.07] hover:border-white/[0.12]'
+                        ? 'cursor-not-allowed border-line opacity-50'
+                        : 'cursor-pointer border-line hover:border-line-2'
                     }`}
                   >
                     <input
@@ -266,14 +266,14 @@ export default function CompileSettingsModal({
                       checked={isHardcoded || flags.has(flag)}
                       disabled={isHardcoded}
                       onChange={() => !isHardcoded && toggleFlag(flag)}
-                      className="h-3 w-3 rounded accent-violet-500"
+                      className="h-3 w-3 rounded accent-accent"
                     />
                     <div className="flex flex-1 items-center justify-between gap-2">
-                      <code className="text-[11px] text-zinc-300">{flag}</code>
-                      <span className="text-[10px] text-zinc-600">{FLAG_LABELS[flag]}</span>
+                      <code className="text-[11px] text-fg-2">{flag}</code>
+                      <span className="text-[10px] text-fg-3">{FLAG_LABELS[flag]}</span>
                     </div>
                     {isHardcoded && (
-                      <span className="text-[9px] text-zinc-600 ml-1">(always on)</span>
+                      <span className="text-[9px] text-fg-3 ml-1">(always on)</span>
                     )}
                   </label>
                 )
@@ -283,10 +283,10 @@ export default function CompileSettingsModal({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between border-t border-white/[0.06] px-5 py-4">
+        <div className="flex items-center justify-between border-t border-line px-5 py-4">
           <button
             onClick={handleReset}
-            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.04] hover:text-zinc-300"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-3 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <RotateCcw size={11} />
             Reset to Defaults
@@ -294,7 +294,7 @@ export default function CompileSettingsModal({
           <button
             onClick={handleSave}
             disabled={saving}
-            className="flex items-center gap-1.5 rounded-lg bg-violet-600/80 px-4 py-1.5 text-[11px] font-semibold text-white ring-1 ring-violet-500/30 transition hover:bg-violet-600 disabled:opacity-40"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-accent px-4 py-1.5 text-[11px] font-semibold text-accent-fg ring-1 ring-accent transition hover:brightness-110 disabled:opacity-40"
           >
             {saving ? <Loader2 size={11} className="animate-spin" /> : <Save size={11} />}
             {saving ? 'Saving…' : 'Save Settings'}

--- a/frontend/src/components/DiffViewerModal.tsx
+++ b/frontend/src/components/DiffViewerModal.tsx
@@ -180,22 +180,22 @@ export default function DiffViewerModal({
   if (!checkpointA && !isParentDiffMode) return null
 
   const modalClasses = isFullscreen
-    ? 'relative flex h-screen w-screen flex-col bg-zinc-950'
-    : 'relative flex h-[85vh] w-[95vw] max-w-7xl flex-col rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl'
+    ? 'relative flex h-screen w-screen flex-col bg-bg'
+    : 'relative flex h-[85vh] w-[95vw] max-w-7xl flex-col rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]'
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] backdrop-blur-sm">
       <div className={modalClasses}>
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/10 px-5 py-3">
+        <div className="flex items-center justify-between border-b border-line px-5 py-3">
           <div className="flex items-center gap-3">
-            <h2 className="text-sm font-semibold text-white">Compare Versions</h2>
+            <h2 className="text-sm font-semibold text-fg">Compare Versions</h2>
             {diffStats && (
               <div className="flex items-center gap-2 text-[11px]">
-                <span className="text-emerald-400">+{diffStats.added}</span>
-                <span className="text-rose-400">−{diffStats.removed}</span>
-                <span className="text-zinc-600">·</span>
-                <span className="text-zinc-500">{diffStats.changed} section{diffStats.changed !== 1 ? 's' : ''} changed</span>
+                <span className="text-ok">+{diffStats.added}</span>
+                <span className="text-err">−{diffStats.removed}</span>
+                <span className="text-fg-3">·</span>
+                <span className="text-fg-3">{diffStats.changed} section{diffStats.changed !== 1 ? 's' : ''} changed</span>
               </div>
             )}
           </div>
@@ -203,7 +203,7 @@ export default function DiffViewerModal({
             <button
               onClick={handleRestoreLeft}
               disabled={!leftLatex}
-              className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-1.5 text-xs text-zinc-300 transition hover:border-white/20 hover:text-white disabled:opacity-40"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs text-fg-2 transition hover:border-line-2 hover:text-fg disabled:opacity-40"
             >
               <RotateCcw size={12} />
               {isParentDiffMode ? 'Restore to Parent' : 'Restore Left'}
@@ -211,7 +211,7 @@ export default function DiffViewerModal({
             <button
               onClick={handleRestoreRight}
               disabled={!rightLatex || (!checkpointB && !isParentDiffMode)}
-              className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-1.5 text-xs text-zinc-300 transition hover:border-white/20 hover:text-white disabled:opacity-40"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs text-fg-2 transition hover:border-line-2 hover:text-fg disabled:opacity-40"
             >
               <RotateCcw size={12} />
               {isParentDiffMode ? 'Keep Variant' : 'Restore Right'}
@@ -219,7 +219,7 @@ export default function DiffViewerModal({
             <button
               type="button"
               onClick={() => setIsFullscreen((v) => !v)}
-              className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-white"
+              className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg"
               title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
               aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
             >
@@ -227,7 +227,7 @@ export default function DiffViewerModal({
             </button>
             <button
               onClick={onClose}
-              className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-white"
+              className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg"
             >
               <X size={16} />
             </button>
@@ -235,11 +235,11 @@ export default function DiffViewerModal({
         </div>
 
         {/* Labels */}
-        <div className="grid grid-cols-2 border-b border-white/5 text-[11px]">
-          <div className="truncate border-r border-white/5 px-4 py-1.5 text-zinc-500">
+        <div className="grid grid-cols-2 border-b border-line text-[11px]">
+          <div className="truncate border-r border-line px-4 py-1.5 text-fg-3">
             {leftLabel}
           </div>
-          <div className="truncate px-4 py-1.5 text-zinc-500">
+          <div className="truncate px-4 py-1.5 text-fg-3">
             {rightLabel}
           </div>
         </div>
@@ -248,14 +248,14 @@ export default function DiffViewerModal({
         <div className="relative flex-1 overflow-hidden">
           {loading ? (
             <div className="flex h-full items-center justify-center">
-              <div className="flex items-center gap-2 text-xs text-zinc-500">
-                <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-700 border-t-orange-300" />
+              <div className="flex items-center gap-2 text-xs text-fg-3">
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-line-2 border-t-accent" />
                 Loading versions…
               </div>
             </div>
           ) : error ? (
             <div className="flex h-full items-center justify-center">
-              <p className="text-xs text-rose-400">Failed to load version content. Please close and try again.</p>
+              <p className="text-xs text-err">Failed to load version content. Please close and try again.</p>
             </div>
           ) : (
             <DiffEditor
@@ -282,22 +282,22 @@ export default function DiffViewerModal({
 
           {/* Restore confirmation overlay */}
           {confirmRestore !== null && (
-            <div role="dialog" aria-modal="true" aria-labelledby="confirm-restore-title" className="absolute inset-0 z-10 flex items-center justify-center bg-black/60 backdrop-blur-[2px]">
-              <div className="w-80 rounded-xl border border-white/10 bg-zinc-900 p-5 shadow-2xl">
-                <p id="confirm-restore-title" className="text-sm font-semibold text-zinc-100">Restore this version?</p>
-                <p className="mt-1.5 text-xs text-zinc-500">
+            <div role="dialog" aria-modal="true" aria-labelledby="confirm-restore-title" className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--overlay)] backdrop-blur-[2px]">
+              <div className="w-80 rounded-[var(--radius-lg)] border border-line bg-surface p-5 shadow-[var(--shadow-2)]">
+                <p id="confirm-restore-title" className="text-sm font-semibold text-fg">Restore this version?</p>
+                <p className="mt-1.5 text-xs text-fg-3">
                   This will replace your current editor content. You can undo after closing.
                 </p>
                 <div className="mt-4 flex justify-end gap-2">
                   <button
                     onClick={() => setConfirmRestore(null)}
-                    className="rounded-lg border border-white/10 px-3 py-1.5 text-xs text-zinc-400 transition hover:border-white/20 hover:text-white"
+                    className="rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs text-fg-2 transition hover:border-line-2 hover:text-fg"
                   >
                     Cancel
                   </button>
                   <button
                     onClick={confirmAndRestore}
-                    className="rounded-lg bg-orange-500/20 px-3 py-1.5 text-xs font-semibold text-orange-200 ring-1 ring-orange-400/20 transition hover:bg-orange-500/30"
+                    className="rounded-[var(--radius-md)] bg-accent-soft px-3 py-1.5 text-xs font-semibold text-accent-strong ring-1 ring-accent transition hover:brightness-110"
                   >
                     Restore
                   </button>

--- a/frontend/src/components/GenerateReferencesModal.tsx
+++ b/frontend/src/components/GenerateReferencesModal.tsx
@@ -95,32 +95,32 @@ export default function GenerateReferencesModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full max-w-xl rounded-xl border border-white/[0.08] bg-[#0d0d0d] shadow-2xl">
+      <div className="w-full max-w-xl rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-3">
+        <div className="flex items-center justify-between border-b border-line px-4 py-3">
           <div className="flex items-center gap-2">
-            <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-violet-500/15">
-              <BookUser size={13} className="text-violet-300" />
+            <div className="flex h-6 w-6 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+              <BookUser size={13} className="text-accent-strong" />
             </div>
             <div>
-              <h2 className="text-sm font-semibold text-zinc-100">Generate References Page</h2>
-              <p className="text-[10px] text-zinc-600">{resumeTitle}</p>
+              <h2 className="text-sm font-semibold text-fg">Generate References Page</h2>
+              <p className="text-[10px] text-fg-3">{resumeTitle}</p>
             </div>
           </div>
           <button
             onClick={onClose}
             aria-label="Close"
-            className="rounded-lg p-1.5 text-zinc-600 transition hover:bg-white/[0.06] hover:text-zinc-300"
+            className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <X size={14} />
           </button>
         </div>
 
         <div className="max-h-[70vh] overflow-y-auto p-4">
-          <p className="mb-4 text-[12px] text-zinc-500">
+          <p className="mb-4 text-[12px] text-fg-3">
             Add up to 5 references. The LaTeX will match your resume&apos;s document class and style.
           </p>
 
@@ -128,16 +128,16 @@ export default function GenerateReferencesModal({
             {refs.map((ref, idx) => (
               <div
                 key={idx}
-                className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3"
+                className="rounded-[var(--radius-md)] border border-line bg-surface p-3"
               >
                 <div className="mb-2 flex items-center justify-between">
-                  <span className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">
+                  <span className="text-[11px] font-semibold uppercase tracking-wider text-fg-3">
                     Reference {idx + 1}
                   </span>
                   {refs.length > 1 && (
                     <button
                       onClick={() => handleRemove(idx)}
-                      className="rounded p-1 text-zinc-700 transition hover:bg-white/[0.06] hover:text-rose-400"
+                      className="rounded p-1 text-fg-3 transition hover:bg-surface-2 hover:text-err"
                     >
                       <Trash2 size={12} />
                     </button>
@@ -151,7 +151,7 @@ export default function GenerateReferencesModal({
                       placeholder="Full name *"
                       value={ref.name}
                       onChange={(e) => handleChange(idx, 'name', e.target.value)}
-                      className="w-full rounded-md border border-white/[0.08] bg-black/30 px-2.5 py-1.5 text-[12px] text-zinc-200 placeholder-zinc-700 outline-none transition focus:border-white/[0.15]"
+                      className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-2.5 py-1.5 text-[12px] text-fg placeholder-fg-3 outline-none transition focus:border-line-2"
                     />
                   </div>
                   <input
@@ -159,35 +159,35 @@ export default function GenerateReferencesModal({
                     placeholder="Job title *"
                     value={ref.title}
                     onChange={(e) => handleChange(idx, 'title', e.target.value)}
-                    className="rounded-md border border-white/[0.08] bg-black/30 px-2.5 py-1.5 text-[12px] text-zinc-200 placeholder-zinc-700 outline-none transition focus:border-white/[0.15]"
+                    className="rounded-[var(--radius-md)] border border-line bg-bg px-2.5 py-1.5 text-[12px] text-fg placeholder-fg-3 outline-none transition focus:border-line-2"
                   />
                   <input
                     type="text"
                     placeholder="Company *"
                     value={ref.company}
                     onChange={(e) => handleChange(idx, 'company', e.target.value)}
-                    className="rounded-md border border-white/[0.08] bg-black/30 px-2.5 py-1.5 text-[12px] text-zinc-200 placeholder-zinc-700 outline-none transition focus:border-white/[0.15]"
+                    className="rounded-[var(--radius-md)] border border-line bg-bg px-2.5 py-1.5 text-[12px] text-fg placeholder-fg-3 outline-none transition focus:border-line-2"
                   />
                   <input
                     type="text"
                     placeholder="Relationship (e.g. Direct Manager) *"
                     value={ref.relationship}
                     onChange={(e) => handleChange(idx, 'relationship', e.target.value)}
-                    className="col-span-2 rounded-md border border-white/[0.08] bg-black/30 px-2.5 py-1.5 text-[12px] text-zinc-200 placeholder-zinc-700 outline-none transition focus:border-white/[0.15]"
+                    className="col-span-2 rounded-[var(--radius-md)] border border-line bg-bg px-2.5 py-1.5 text-[12px] text-fg placeholder-fg-3 outline-none transition focus:border-line-2"
                   />
                   <input
                     type="email"
                     placeholder="Email (optional)"
                     value={ref.email ?? ''}
                     onChange={(e) => handleChange(idx, 'email', e.target.value)}
-                    className="rounded-md border border-white/[0.08] bg-black/30 px-2.5 py-1.5 text-[12px] text-zinc-200 placeholder-zinc-700 outline-none transition focus:border-white/[0.15]"
+                    className="rounded-[var(--radius-md)] border border-line bg-bg px-2.5 py-1.5 text-[12px] text-fg placeholder-fg-3 outline-none transition focus:border-line-2"
                   />
                   <input
                     type="tel"
                     placeholder="Phone (optional)"
                     value={ref.phone ?? ''}
                     onChange={(e) => handleChange(idx, 'phone', e.target.value)}
-                    className="rounded-md border border-white/[0.08] bg-black/30 px-2.5 py-1.5 text-[12px] text-zinc-200 placeholder-zinc-700 outline-none transition focus:border-white/[0.15]"
+                    className="rounded-[var(--radius-md)] border border-line bg-bg px-2.5 py-1.5 text-[12px] text-fg placeholder-fg-3 outline-none transition focus:border-line-2"
                   />
                 </div>
               </div>
@@ -197,7 +197,7 @@ export default function GenerateReferencesModal({
           {refs.length < 5 && (
             <button
               onClick={handleAdd}
-              className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-white/[0.08] py-2 text-xs font-medium text-zinc-600 transition hover:border-white/[0.14] hover:text-zinc-400"
+              className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-dashed border-line py-2 text-xs font-medium text-fg-3 transition hover:border-line-2 hover:text-fg-2"
             >
               <Plus size={12} />
               Add reference
@@ -206,17 +206,17 @@ export default function GenerateReferencesModal({
         </div>
 
         {/* Footer */}
-        <div className="flex gap-2 border-t border-white/[0.06] px-4 py-3">
+        <div className="flex gap-2 border-t border-line px-4 py-3">
           <button
             onClick={onClose}
-            className="flex-1 rounded-lg border border-white/[0.06] py-2 text-xs font-semibold text-zinc-500 transition hover:text-zinc-300"
+            className="flex-1 rounded-[var(--radius-md)] border border-line py-2 text-xs font-semibold text-fg-3 transition hover:text-fg-2"
           >
             Cancel
           </button>
           <button
             onClick={handleGenerate}
             disabled={loading}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-violet-500/20 py-2 text-xs font-semibold text-violet-200 ring-1 ring-violet-400/20 transition hover:bg-violet-500/30 disabled:opacity-50"
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-[var(--radius-md)] bg-accent-soft py-2 text-xs font-semibold text-accent-strong ring-1 ring-accent transition hover:brightness-110 disabled:opacity-50"
           >
             {loading ? (
               <><Loader2 size={12} className="animate-spin" /> Generating…</>

--- a/frontend/src/components/ImportProjectsModal.tsx
+++ b/frontend/src/components/ImportProjectsModal.tsx
@@ -228,36 +228,36 @@ export default function ImportProjectsModal({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] p-4 backdrop-blur-sm"
         onClick={onClose}
       >
         <motion.div
           initial={{ opacity: 0, scale: 0.97, y: 8 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.97 }}
-          className="flex max-h-[88vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl"
+          className="flex max-h-[88vh] w-full max-w-2xl flex-col overflow-hidden rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="flex items-center justify-between border-b border-white/10 px-5 py-4">
+          <div className="flex items-center justify-between border-b border-line px-5 py-4">
             <div>
-              <h2 className="text-sm font-semibold text-zinc-100">Import projects</h2>
-              <p className="mt-0.5 text-[11px] text-zinc-500">
+              <h2 className="text-sm font-semibold text-fg">Import projects</h2>
+              <p className="mt-0.5 text-[11px] text-fg-3">
                 Pull projects from a source, review them, and insert the ones you pick.
               </p>
             </div>
-            <button onClick={onClose} className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/5 hover:text-zinc-200">
+            <button onClick={onClose} className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg">
               <X size={16} />
             </button>
           </div>
 
           {/* Source tabs */}
-          <div className="flex gap-1 border-b border-white/5 px-4 py-2">
+          <div className="flex gap-1 border-b border-line px-4 py-2">
             {SOURCES.map((s) => (
               <button
                 key={s.key}
                 onClick={() => switchSource(s.key)}
-                className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition ${
-                  source === s.key ? 'bg-white/[0.07] text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'
+                className={`flex items-center gap-1.5 rounded-[var(--radius-md)] px-3 py-1.5 text-xs font-medium transition ${
+                  source === s.key ? 'bg-surface-2 text-fg' : 'text-fg-3 hover:text-fg-2'
                 }`}
               >
                 {s.icon}
@@ -270,7 +270,7 @@ export default function ImportProjectsModal({
             {/* Per-source input (only before results are ready) */}
             {phase === 'input' && source === 'url' && (
               <div className="py-6">
-                <label className="text-[11px] font-semibold uppercase tracking-[0.14em] text-zinc-400">Portfolio / project URL</label>
+                <label className="text-[11px] font-semibold uppercase tracking-[0.14em] text-fg-2">Portfolio / project URL</label>
                 <div className="mt-2 flex gap-2">
                   <input
                     type="url"
@@ -278,13 +278,13 @@ export default function ImportProjectsModal({
                     onChange={(e) => setUrlInput(e.target.value)}
                     onKeyDown={(e) => { if (e.key === 'Enter') runUrlImport() }}
                     placeholder="https://yoursite.com/projects"
-                    className="flex-1 rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition placeholder:text-zinc-600 focus:border-orange-300/40"
+                    className="flex-1 rounded-[var(--radius-md)] border border-line bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-fg-3 focus:border-accent"
                   />
-                  <button onClick={runUrlImport} disabled={!urlInput.trim()} className="btn-accent px-4 py-2 text-xs font-semibold disabled:opacity-40">
+                  <button onClick={runUrlImport} disabled={!urlInput.trim()} className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg hover:brightness-110 disabled:opacity-40">
                     Import
                   </button>
                 </div>
-                <p className="mt-2 text-[10px] text-zinc-600">Public pages only. We fetch the page once (no scripts) and summarize it.</p>
+                <p className="mt-2 text-[10px] text-fg-3">Public pages only. We fetch the page once (no scripts) and summarize it.</p>
               </div>
             )}
 
@@ -302,13 +302,13 @@ export default function ImportProjectsModal({
                 />
                 <button
                   onClick={() => fileRef.current?.click()}
-                  className="mx-auto flex flex-col items-center gap-2 rounded-xl border border-dashed border-white/15 bg-white/[0.02] px-8 py-8 text-zinc-400 transition hover:border-orange-300/30 hover:text-zinc-200"
+                  className="mx-auto flex flex-col items-center gap-2 rounded-[var(--radius-lg)] border border-dashed border-line-2 bg-surface px-8 py-8 text-fg-2 transition hover:border-accent hover:text-fg"
                 >
                   <FileUp size={22} />
                   <span className="text-sm font-medium">Upload LinkedIn export or resume</span>
-                  <span className="text-[10px] text-zinc-600">.zip (LinkedIn “Get a copy of your data”) · .pdf · .docx</span>
+                  <span className="text-[10px] text-fg-3">.zip (LinkedIn “Get a copy of your data”) · .pdf · .docx</span>
                 </button>
-                <p className="mx-auto mt-3 max-w-sm text-[10px] leading-relaxed text-zinc-600">
+                <p className="mx-auto mt-3 max-w-sm text-[10px] leading-relaxed text-fg-3">
                   Compliant by design — we never scrape LinkedIn. Your file is parsed in the request and not stored.
                 </p>
               </div>
@@ -316,34 +316,34 @@ export default function ImportProjectsModal({
 
             {/* Shared status states */}
             {phase === 'checking' && (
-              <div className="flex items-center justify-center gap-2 py-16 text-sm text-zinc-500">
+              <div className="flex items-center justify-center gap-2 py-16 text-sm text-fg-3">
                 <Loader2 size={16} className="animate-spin" /> Checking GitHub connection…
               </div>
             )}
             {phase === 'importing' && (
               <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
-                <Loader2 size={20} className="animate-spin text-orange-300" />
-                <p className="text-sm text-zinc-300">Fetching and summarizing…</p>
-                <p className="text-[11px] text-zinc-600">This can take up to a minute.</p>
+                <Loader2 size={20} className="animate-spin text-accent-strong" />
+                <p className="text-sm text-fg-2">Fetching and summarizing…</p>
+                <p className="text-[11px] text-fg-3">This can take up to a minute.</p>
               </div>
             )}
             {phase === 'disconnected' && (
               <div className="py-12 text-center">
-                <p className="text-sm text-zinc-300">GitHub isn&apos;t connected yet.</p>
-                <p className="mx-auto mt-1 max-w-sm text-[11px] text-zinc-500">
+                <p className="text-sm text-fg-2">GitHub isn&apos;t connected yet.</p>
+                <p className="mx-auto mt-1 max-w-sm text-[11px] text-fg-3">
                   Connect your account in Settings → GitHub Integration, then reopen this import.
                 </p>
-                <a href="/settings" className="mt-4 inline-block rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold text-zinc-200 transition hover:bg-white/10">
+                <a href="/settings" className="mt-4 inline-block rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs font-semibold text-fg transition hover:bg-surface-2">
                   Go to Settings
                 </a>
               </div>
             )}
             {phase === 'error' && (
               <div className="py-12 text-center">
-                <div className="mx-auto max-w-md rounded-lg border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+                <div className="mx-auto max-w-md rounded-[var(--radius-md)] border border-err/20 bg-err/10 px-4 py-3 text-sm text-err">
                   {error || 'Something went wrong.'}
                 </div>
-                <button onClick={reset} className="mt-4 rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold text-zinc-200 transition hover:bg-white/10">
+                <button onClick={reset} className="mt-4 rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs font-semibold text-fg transition hover:bg-surface-2">
                   Try again
                 </button>
               </div>
@@ -358,35 +358,35 @@ export default function ImportProjectsModal({
                   return (
                     <li
                       key={`${p.title}-${i}`}
-                      className={`rounded-xl border p-3 transition ${
-                        sel.included ? 'border-white/10 bg-white/[0.02]' : 'border-white/5 opacity-55'
+                      className={`rounded-[var(--radius-lg)] border p-3 transition ${
+                        sel.included ? 'border-line bg-surface' : 'border-line opacity-55'
                       }`}
                     >
                       <div className="flex items-start gap-2.5">
-                        <input type="checkbox" checked={sel.included} onChange={() => toggleProject(i)} className="mt-1 h-3.5 w-3.5 accent-orange-400" />
+                        <input type="checkbox" checked={sel.included} onChange={() => toggleProject(i)} className="mt-1 h-3.5 w-3.5 accent-accent" />
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center gap-2">
-                            <p className="truncate text-sm font-semibold text-zinc-100">{p.title}</p>
+                            <p className="truncate text-sm font-semibold text-fg">{p.title}</p>
                             {p.metrics?.stars > 0 && (
-                              <span className="flex items-center gap-0.5 text-[10px] text-zinc-500"><Star size={10} /> {p.metrics.stars}</span>
+                              <span className="flex items-center gap-0.5 text-[10px] text-fg-3"><Star size={10} /> {p.metrics.stars}</span>
                             )}
                             {p.url && (
-                              <a href={p.url} target="_blank" rel="noopener noreferrer" className="text-zinc-500 hover:text-zinc-300"><ExternalLink size={11} /></a>
+                              <a href={p.url} target="_blank" rel="noopener noreferrer" className="text-fg-3 hover:text-fg-2"><ExternalLink size={11} /></a>
                             )}
                           </div>
-                          {p.description && <p className="mt-0.5 text-[11px] leading-relaxed text-zinc-400">{p.description}</p>}
+                          {p.description && <p className="mt-0.5 text-[11px] leading-relaxed text-fg-2">{p.description}</p>}
                           {p.tech?.length > 0 && (
                             <div className="mt-1 flex flex-wrap gap-1">
                               {p.tech.slice(0, 8).map((t) => (
-                                <span key={t} className="rounded bg-white/[0.05] px-1.5 py-0.5 text-[9px] text-zinc-400">{t}</span>
+                                <span key={t} className="rounded bg-surface-2 px-1.5 py-0.5 text-[9px] text-fg-2">{t}</span>
                               ))}
                             </div>
                           )}
                           {sel.included && p.suggested_bullets.length > 0 && (
                             <div className="mt-2 space-y-1">
                               {p.suggested_bullets.map((b, bi) => (
-                                <label key={bi} className="flex cursor-pointer items-start gap-2 text-[11px] text-zinc-300">
-                                  <input type="checkbox" checked={sel.bullets.has(bi)} onChange={() => toggleBullet(i, bi)} className="mt-0.5 h-3 w-3 accent-emerald-400" />
+                                <label key={bi} className="flex cursor-pointer items-start gap-2 text-[11px] text-fg-2">
+                                  <input type="checkbox" checked={sel.bullets.has(bi)} onChange={() => toggleBullet(i, bi)} className="mt-0.5 h-3 w-3 accent-accent" />
                                   <span className="leading-relaxed">{b}</span>
                                 </label>
                               ))}
@@ -401,16 +401,16 @@ export default function ImportProjectsModal({
             )}
           </div>
 
-          <div className="flex items-center justify-between gap-3 border-t border-white/10 px-5 py-3.5">
-            <span className="text-[11px] text-zinc-500">
+          <div className="flex items-center justify-between gap-3 border-t border-line px-5 py-3.5">
+            <span className="text-[11px] text-fg-3">
               {phase === 'ready' ? `${selectedCount} of ${projects.length} selected` : ''}
             </span>
             <div className="flex items-center gap-3">
-              <button onClick={onClose} className="text-xs font-semibold text-zinc-400 transition hover:text-zinc-200">Cancel</button>
+              <button onClick={onClose} className="text-xs font-semibold text-fg-2 transition hover:text-fg">Cancel</button>
               <button
                 onClick={handleInsert}
                 disabled={phase !== 'ready' || selectedCount === 0}
-                className="btn-accent px-4 py-2 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Insert into resume
               </button>

--- a/frontend/src/components/QuickTailorModal.tsx
+++ b/frontend/src/components/QuickTailorModal.tsx
@@ -106,29 +106,29 @@ export default function QuickTailorModal({ resumeId, resumeTitle, onClose, onDon
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] backdrop-blur-sm"
       onClick={handleDismiss}
     >
       <div
-        className="w-full max-w-lg rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl"
+        className="w-full max-w-lg rounded-[var(--radius-lg)] border border-line bg-bg p-6 shadow-[var(--shadow-2)]"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="mb-5 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Zap size={16} className="text-amber-400" />
-            <h3 className="text-base font-semibold text-white">Quick Tailor</h3>
+            <Zap size={16} className="text-accent-strong" />
+            <h3 className="text-base font-semibold text-fg">Quick Tailor</h3>
           </div>
           <button
             onClick={handleDismiss}
-            className="rounded-md p-1.5 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-300"
+            className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <X size={16} />
           </button>
         </div>
-        <p className="mb-5 text-xs text-zinc-500">
+        <p className="mb-5 text-xs text-fg-3">
           A tailored copy of{' '}
-          <span className="text-zinc-300">&ldquo;{resumeTitle}&rdquo;</span> will be created and
+          <span className="text-fg-2">&ldquo;{resumeTitle}&rdquo;</span> will be created and
           optimized for the job description. The original is never modified.
         </p>
 
@@ -137,8 +137,8 @@ export default function QuickTailorModal({ resumeId, resumeTitle, onClose, onDon
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="mb-1.5 block text-xs font-medium text-zinc-400">
-                  Company <span className="text-zinc-600">(optional)</span>
+                <label className="mb-1.5 block text-xs font-medium text-fg-2">
+                  Company <span className="text-fg-3">(optional)</span>
                 </label>
                 <input
                   type="text"
@@ -146,12 +146,12 @@ export default function QuickTailorModal({ resumeId, resumeTitle, onClose, onDon
                   onChange={(e) => setCompanyName(e.target.value)}
                   placeholder="e.g. Google"
                   maxLength={200}
-                  className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-amber-300/40"
+                  className="w-full rounded-[var(--radius-md)] border border-line bg-surface px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
                 />
               </div>
               <div>
-                <label className="mb-1.5 block text-xs font-medium text-zinc-400">
-                  Role <span className="text-zinc-600">(optional)</span>
+                <label className="mb-1.5 block text-xs font-medium text-fg-2">
+                  Role <span className="text-fg-3">(optional)</span>
                 </label>
                 <input
                   type="text"
@@ -159,13 +159,13 @@ export default function QuickTailorModal({ resumeId, resumeTitle, onClose, onDon
                   onChange={(e) => setRoleTitle(e.target.value)}
                   placeholder="e.g. Senior SWE"
                   maxLength={200}
-                  className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-amber-300/40"
+                  className="w-full rounded-[var(--radius-md)] border border-line bg-surface px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
                 />
               </div>
             </div>
             <div>
-              <label className="mb-1.5 block text-xs font-medium text-zinc-400">
-                Job Description <span className="text-rose-400">*</span>
+              <label className="mb-1.5 block text-xs font-medium text-fg-2">
+                Job Description <span className="text-err">*</span>
               </label>
               <textarea
                 value={jobDescription}
@@ -174,23 +174,23 @@ export default function QuickTailorModal({ resumeId, resumeTitle, onClose, onDon
                 rows={9}
                 maxLength={10000}
                 autoFocus
-                className="w-full resize-none rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-amber-300/40"
+                className="w-full resize-none rounded-[var(--radius-md)] border border-line bg-surface px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
               />
-              <p className="mt-1 text-right text-[10px] text-zinc-600">
+              <p className="mt-1 text-right text-[10px] text-fg-3">
                 {jobDescription.length}/10000
               </p>
             </div>
             <div className="flex justify-end gap-2">
               <button
                 onClick={onClose}
-                className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 transition hover:text-zinc-200"
+                className="rounded-[var(--radius-md)] border border-line px-4 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSubmit}
                 disabled={jobDescription.trim().length < 10 || isSubmitting}
-                className="flex items-center gap-1.5 rounded-lg bg-amber-500/20 px-4 py-2 text-xs font-semibold text-amber-300 ring-1 ring-amber-400/30 transition hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-accent-soft px-4 py-2 text-xs font-semibold text-accent-strong ring-1 ring-accent transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isSubmitting ? (
                   <Loader2 size={13} className="animate-spin" />
@@ -206,30 +206,30 @@ export default function QuickTailorModal({ resumeId, resumeTitle, onClose, onDon
         {/* Step 2: Progress */}
         {step === 'progress' && (
           <div className="space-y-5">
-            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+            <div className="rounded-[var(--radius-md)] border border-line bg-surface p-4">
               <div className="mb-2 flex items-center justify-between">
-                <span className="text-xs font-medium text-zinc-300">
+                <span className="text-xs font-medium text-fg-2">
                   {state.stage || 'Initializing...'}
                 </span>
-                <span className="text-xs tabular-nums text-zinc-500">{state.percent}%</span>
+                <span className="text-xs tabular-nums text-fg-3">{state.percent}%</span>
               </div>
-              <div className="h-1.5 overflow-hidden rounded-full bg-white/10">
+              <div className="h-1.5 overflow-hidden rounded-full bg-surface-2">
                 <div
-                  className="h-full rounded-full bg-amber-400 transition-all duration-500"
+                  className="h-full rounded-full bg-accent transition-all duration-500"
                   style={{ width: `${state.percent}%` }}
                 />
               </div>
               {state.message && (
-                <p className="mt-2 text-xs text-zinc-500">{state.message}</p>
+                <p className="mt-2 text-xs text-fg-3">{state.message}</p>
               )}
             </div>
-            <p className="text-center text-xs text-zinc-600">
+            <p className="text-center text-xs text-fg-3">
               This typically takes 30–90 seconds. Don&apos;t close this window.
             </p>
             <div className="flex justify-end">
               <button
                 onClick={handleCancel}
-                className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 transition hover:text-zinc-200"
+                className="rounded-[var(--radius-md)] border border-line px-4 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg"
               >
                 Cancel
               </button>
@@ -241,22 +241,22 @@ export default function QuickTailorModal({ resumeId, resumeTitle, onClose, onDon
         {step === 'done' && (
           <div className="space-y-5">
             <div className="flex flex-col items-center gap-3 py-4">
-              <CheckCircle size={40} className="text-emerald-400" />
-              <p className="text-base font-semibold text-white">Tailored resume created!</p>
-              <p className="text-center text-xs text-zinc-400">
+              <CheckCircle size={40} className="text-ok" />
+              <p className="text-base font-semibold text-fg">Tailored resume created!</p>
+              <p className="text-center text-xs text-fg-2">
                 The optimized version has been saved as a new variant.
               </p>
             </div>
             <div className="flex justify-end gap-2">
               <button
                 onClick={onClose}
-                className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 transition hover:text-zinc-200"
+                className="rounded-[var(--radius-md)] border border-line px-4 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg"
               >
                 Close
               </button>
               <button
                 onClick={() => forkId && router.push(`/workspace/${forkId}/edit`)}
-                className="flex items-center gap-1.5 rounded-lg bg-emerald-500/20 px-4 py-2 text-xs font-semibold text-emerald-300 ring-1 ring-emerald-400/30 transition hover:bg-emerald-500/30"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg transition hover:brightness-110"
               >
                 Open Tailored Resume
                 <ArrowRight size={13} />
@@ -269,20 +269,20 @@ export default function QuickTailorModal({ resumeId, resumeTitle, onClose, onDon
         {step === 'error' && (
           <div className="space-y-5">
             <div className="flex flex-col items-center gap-3 py-4">
-              <AlertCircle size={40} className="text-rose-400" />
-              <p className="text-base font-semibold text-white">Tailoring failed</p>
-              <p className="text-center text-xs text-zinc-400">{errorMessage}</p>
+              <AlertCircle size={40} className="text-err" />
+              <p className="text-base font-semibold text-fg">Tailoring failed</p>
+              <p className="text-center text-xs text-fg-2">{errorMessage}</p>
             </div>
             <div className="flex justify-end gap-2">
               <button
                 onClick={onClose}
-                className="rounded-lg border border-white/10 px-4 py-2 text-xs font-semibold text-zinc-400 transition hover:text-zinc-200"
+                className="rounded-[var(--radius-md)] border border-line px-4 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg"
               >
                 Close
               </button>
               <button
                 onClick={handleTryAgain}
-                className="rounded-lg border border-amber-400/20 bg-amber-500/10 px-4 py-2 text-xs font-semibold text-amber-300 transition hover:bg-amber-500/20"
+                className="rounded-[var(--radius-md)] border border-accent bg-accent-soft px-4 py-2 text-xs font-semibold text-accent-strong transition hover:brightness-110"
               >
                 Try Again
               </button>

--- a/frontend/src/components/ShareResumeModal.tsx
+++ b/frontend/src/components/ShareResumeModal.tsx
@@ -23,7 +23,7 @@ function Sparkline({ data }: { data: { date: string; count: number }[] }) {
   const W = 220
   const H = 36
   if (data.length === 0) {
-    return <div className="h-9 flex items-center justify-center text-[10px] text-zinc-600">No data yet</div>
+    return <div className="h-9 flex items-center justify-center text-[10px] text-fg-3">No data yet</div>
   }
   const max = Math.max(...data.map((d) => d.count), 1)
   const pts = data.map((d, i) => {
@@ -36,8 +36,8 @@ function Sparkline({ data }: { data: { date: string; count: number }[] }) {
   const fill = `${pts[0].split(',')[0]},${H} ${polyline} ${pts[pts.length - 1].split(',')[0]},${H}`
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-9" preserveAspectRatio="none">
-      <polygon points={fill} fill="rgba(56,189,248,0.12)" />
-      <polyline points={polyline} fill="none" stroke="rgb(56,189,248)" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+      <polygon points={fill} fill="var(--accent)" fillOpacity={0.12} />
+      <polyline points={polyline} fill="none" stroke="var(--accent)" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
     </svg>
   )
 }
@@ -83,12 +83,12 @@ function AnalyticsPanel({ resumeId }: { resumeId: string }) {
   if (loading) {
     return (
       <div className="flex h-48 items-center justify-center">
-        <Loader2 size={16} className="animate-spin text-zinc-600" />
+        <Loader2 size={16} className="animate-spin text-fg-3" />
       </div>
     )
   }
   if (error) {
-    return <p className="py-4 text-center text-[11px] text-rose-400">{error}</p>
+    return <p className="py-4 text-center text-[11px] text-err">{error}</p>
   }
   if (!analytics) return null
 
@@ -105,17 +105,17 @@ function AnalyticsPanel({ resumeId }: { resumeId: string }) {
           { label: 'Last 7d', value: analytics.views_last_7_days },
           { label: 'Last 30d', value: analytics.views_last_30_days },
         ].map(({ label, value }) => (
-          <div key={label} className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-2 py-2 text-center">
-            <p className="text-base font-semibold text-sky-300">{value}</p>
-            <p className="text-[9px] uppercase tracking-wider text-zinc-600">{label}</p>
+          <div key={label} className="rounded-[var(--radius-md)] border border-line bg-surface-2 px-2 py-2 text-center">
+            <p className="text-base font-semibold text-accent-strong">{value}</p>
+            <p className="text-[9px] uppercase tracking-wider text-fg-3">{label}</p>
           </div>
         ))}
       </div>
 
       {/* Sparkline */}
       <div>
-        <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Last 30 days</p>
-        <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+        <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-fg-3">Last 30 days</p>
+        <div className="rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2">
           <Sparkline data={analytics.views_by_day} />
         </div>
       </div>
@@ -123,13 +123,13 @@ function AnalyticsPanel({ resumeId }: { resumeId: string }) {
       {/* Countries */}
       {analytics.views_by_country.length > 0 && (
         <div>
-          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Top countries</p>
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-fg-3">Top countries</p>
           <div className="space-y-1">
             {analytics.views_by_country.slice(0, 5).map((c, i) => (
               <div key={i} className="flex items-center gap-2">
                 <span className="text-sm leading-none">{countryFlag(c.country_code)}</span>
-                <span className="flex-1 text-[11px] text-zinc-400">{c.country_code ?? 'Unknown'}</span>
-                <span className="text-[11px] font-semibold text-zinc-300">{c.count}</span>
+                <span className="flex-1 text-[11px] text-fg-2">{c.country_code ?? 'Unknown'}</span>
+                <span className="text-[11px] font-semibold text-fg-2">{c.count}</span>
               </div>
             ))}
           </div>
@@ -139,12 +139,12 @@ function AnalyticsPanel({ resumeId }: { resumeId: string }) {
       {/* Referrers */}
       {analytics.views_by_referrer.length > 0 && (
         <div>
-          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Top referrers</p>
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-fg-3">Top referrers</p>
           <div className="space-y-1">
             {analytics.views_by_referrer.slice(0, 5).map((r, i) => (
               <div key={i} className="flex items-center gap-2">
-                <span className="flex-1 truncate text-[11px] text-zinc-400">{displayReferrer(r.referrer)}</span>
-                <span className="text-[11px] font-semibold text-zinc-300">{r.count}</span>
+                <span className="flex-1 truncate text-[11px] text-fg-2">{displayReferrer(r.referrer)}</span>
+                <span className="text-[11px] font-semibold text-fg-2">{r.count}</span>
               </div>
             ))}
           </div>
@@ -152,11 +152,11 @@ function AnalyticsPanel({ resumeId }: { resumeId: string }) {
       )}
 
       {analytics.total_views === 0 && (
-        <p className="text-center text-[11px] text-zinc-600">No views recorded yet. Share your link to start tracking.</p>
+        <p className="text-center text-[11px] text-fg-3">No views recorded yet. Share your link to start tracking.</p>
       )}
 
       {lastViewed && (
-        <p className="text-[10px] text-zinc-600">Last viewed {lastViewed}</p>
+        <p className="text-[10px] text-fg-3">Last viewed {lastViewed}</p>
       )}
     </div>
   )
@@ -249,24 +249,24 @@ export default function ShareResumeModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] p-4 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full max-w-md rounded-xl border border-white/[0.08] bg-[#111] shadow-2xl">
+      <div className="w-full max-w-md rounded-[var(--radius-lg)] border border-line bg-surface shadow-[var(--shadow-2)]">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/[0.06] px-5 py-4">
+        <div className="flex items-center justify-between border-b border-line px-5 py-4">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-sky-500/15 ring-1 ring-sky-400/20">
-              <Link size={13} className="text-sky-300" />
+            <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft ring-1 ring-accent">
+              <Link size={13} className="text-accent-strong" />
             </div>
             <div>
-              <h2 className="text-sm font-semibold text-white">Share Resume</h2>
-              <p className="text-[11px] text-zinc-500">{resumeTitle}</p>
+              <h2 className="text-sm font-semibold text-fg">Share Resume</h2>
+              <p className="text-[11px] text-fg-3">{resumeTitle}</p>
             </div>
           </div>
           <button
             onClick={onClose}
-            className="rounded-md p-1 text-zinc-600 transition hover:bg-white/[0.05] hover:text-zinc-300"
+            className="rounded-[var(--radius-md)] p-1 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <X size={14} />
           </button>
@@ -274,15 +274,15 @@ export default function ShareResumeModal({
 
         {/* Tab bar — only when link exists */}
         {shareData && (
-          <div className="flex border-b border-white/[0.06] px-5">
+          <div className="flex border-b border-line px-5">
             {tabs.map(({ id, label, icon }) => (
               <button
                 key={id}
                 onClick={() => setTab(id)}
                 className={`flex items-center gap-1.5 border-b-2 px-3 py-2.5 text-[11px] font-medium transition ${
                   tab === id
-                    ? 'border-sky-400 text-sky-300'
-                    : 'border-transparent text-zinc-500 hover:text-zinc-300'
+                    ? 'border-accent text-accent-strong'
+                    : 'border-transparent text-fg-3 hover:text-fg-2'
                 }`}
               >
                 {icon}
@@ -297,22 +297,22 @@ export default function ShareResumeModal({
           {!shareData ? (
             // No link yet — always show the generate UI
             <div className="space-y-4">
-              <p className="text-sm text-zinc-400">
+              <p className="text-sm text-fg-2">
                 Generate a public link so anyone can view the compiled PDF — no login needed.
               </p>
-              <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
-                <p className="text-[11px] text-zinc-500">
+              <div className="rounded-[var(--radius-md)] border border-line bg-surface-2 p-3">
+                <p className="text-[11px] text-fg-3">
                   Viewers can read the PDF but cannot edit or access your LaTeX source.
                 </p>
               </div>
 
               {/* Anonymous mode toggle */}
-              <div className="flex items-center justify-between rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5">
+              <div className="flex items-center justify-between rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2.5">
                 <div className="flex items-center gap-2">
-                  <EyeOff size={13} className="text-zinc-500" />
+                  <EyeOff size={13} className="text-fg-3" />
                   <div>
-                    <p className="text-[12px] font-medium text-zinc-300">Anonymous Mode</p>
-                    <p className="text-[10px] text-zinc-600">Hides name, email, phone &amp; social profiles</p>
+                    <p className="text-[12px] font-medium text-fg-2">Anonymous Mode</p>
+                    <p className="text-[10px] text-fg-3">Hides name, email, phone &amp; social profiles</p>
                   </div>
                 </div>
                 <button
@@ -321,7 +321,7 @@ export default function ShareResumeModal({
                   aria-checked={anonymous}
                   onClick={() => setAnonymous(a => !a)}
                   className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
-                    anonymous ? 'bg-amber-500' : 'bg-zinc-700'
+                    anonymous ? 'bg-warn' : 'bg-surface-2'
                   }`}
                 >
                   <span
@@ -335,7 +335,7 @@ export default function ShareResumeModal({
               <button
                 onClick={handleGenerate}
                 disabled={isGenerating}
-                className="flex w-full items-center justify-center gap-2 rounded-lg border border-sky-400/25 bg-sky-500/15 py-2.5 text-sm font-semibold text-sky-200 transition hover:bg-sky-500/25 disabled:opacity-50"
+                className="flex w-full items-center justify-center gap-2 rounded-[var(--radius-md)] border border-accent bg-accent-soft py-2.5 text-sm font-semibold text-accent-strong transition hover:brightness-110 disabled:opacity-50"
               >
                 {isGenerating ? (
                   <><Loader2 size={13} className="animate-spin" /> Generating…</>
@@ -348,80 +348,80 @@ export default function ShareResumeModal({
             // Share tab
             <div className="space-y-4">
               {shareData.anonymous && (
-                <div className="flex items-center gap-1.5 rounded-md border border-amber-400/20 bg-amber-500/10 px-3 py-1.5">
-                  <EyeOff size={11} className="text-amber-400" />
-                  <p className="text-[11px] text-amber-300">Anonymous mode — PII redacted in shared view</p>
+                <div className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-warn bg-surface-2 px-3 py-1.5">
+                  <EyeOff size={11} className="text-warn" />
+                  <p className="text-[11px] text-warn">Anonymous mode — PII redacted in shared view</p>
                 </div>
               )}
               {/* URL display */}
               <div>
-                <p className="mb-2 text-xs font-medium text-zinc-400">Shareable link</p>
-                <div className="flex items-center gap-2 rounded-lg border border-white/[0.08] bg-black/40 px-3 py-2">
-                  <span className="flex-1 truncate text-xs font-mono text-sky-300">
+                <p className="mb-2 text-xs font-medium text-fg-2">Shareable link</p>
+                <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2">
+                  <span className="flex-1 truncate text-xs font-mono text-accent-strong">
                     {shareData.share_url}
                   </span>
                   <button
                     onClick={handleCopy}
-                    className="shrink-0 rounded-md p-1 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-200"
+                    className="shrink-0 rounded-[var(--radius-md)] p-1 text-fg-3 transition hover:bg-surface-2 hover:text-fg"
                     title="Copy link"
                   >
                     {copied ? (
-                      <Check size={13} className="text-emerald-400" />
+                      <Check size={13} className="text-ok" />
                     ) : (
                       <Copy size={13} />
                     )}
                   </button>
                 </div>
                 {createdAt && (
-                  <p className="mt-1.5 text-[11px] text-zinc-600">Link created {createdAt}</p>
+                  <p className="mt-1.5 text-[11px] text-fg-3">Link created {createdAt}</p>
                 )}
               </div>
 
               {/* Copy button (full-width) */}
               <button
                 onClick={handleCopy}
-                className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/[0.08] bg-white/[0.04] py-2 text-xs font-semibold text-zinc-300 transition hover:bg-white/[0.08]"
+                className="flex w-full items-center justify-center gap-2 rounded-[var(--radius-md)] border border-line-2 bg-surface-2 py-2 text-xs font-semibold text-fg-2 transition hover:bg-surface-2"
               >
                 {copied ? (
-                  <><Check size={12} className="text-emerald-400" /> Copied!</>
+                  <><Check size={12} className="text-ok" /> Copied!</>
                 ) : (
                   <><Copy size={12} /> Copy link</>
                 )}
               </button>
 
               {/* Info */}
-              <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
-                <p className="text-[11px] text-zinc-500">
+              <div className="rounded-[var(--radius-md)] border border-line bg-surface-2 p-3">
+                <p className="text-[11px] text-fg-3">
                   Anyone with this link can view the PDF. They cannot edit the resume.
                 </p>
               </div>
 
               {/* Revoke section */}
-              <div className="border-t border-white/[0.06] pt-4">
+              <div className="border-t border-line pt-4">
                 {!showRevokeConfirm ? (
                   <button
                     onClick={() => setShowRevokeConfirm(true)}
-                    className="flex items-center gap-1.5 text-[11px] text-zinc-600 transition hover:text-rose-400"
+                    className="flex items-center gap-1.5 text-[11px] text-fg-3 transition hover:text-err"
                   >
                     <Trash2 size={11} />
                     Revoke link
                   </button>
                 ) : (
                   <div className="space-y-2">
-                    <p className="text-[11px] text-zinc-400">
+                    <p className="text-[11px] text-fg-2">
                       Revoking this link will immediately break all shared URLs. Are you sure?
                     </p>
                     <div className="flex gap-2">
                       <button
                         onClick={() => setShowRevokeConfirm(false)}
-                        className="flex-1 rounded-md border border-white/[0.08] py-1.5 text-[11px] text-zinc-500 transition hover:text-zinc-300"
+                        className="flex-1 rounded-[var(--radius-md)] border border-line-2 py-1.5 text-[11px] text-fg-3 transition hover:text-fg-2"
                       >
                         Cancel
                       </button>
                       <button
                         onClick={handleRevoke}
                         disabled={isRevoking}
-                        className="flex flex-1 items-center justify-center gap-1.5 rounded-md border border-rose-400/20 bg-rose-500/10 py-1.5 text-[11px] font-semibold text-rose-300 transition hover:bg-rose-500/20 disabled:opacity-50"
+                        className="flex flex-1 items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-err bg-surface-2 py-1.5 text-[11px] font-semibold text-err transition hover:brightness-110 disabled:opacity-50"
                       >
                         {isRevoking ? (
                           <><Loader2 size={10} className="animate-spin" /> Revoking…</>

--- a/frontend/src/components/SnippetPreviewModal.tsx
+++ b/frontend/src/components/SnippetPreviewModal.tsx
@@ -33,24 +33,24 @@ export default function SnippetPreviewModal({
   return (
     <div
       ref={backdropRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] p-4"
       onClick={(e) => {
         if (e.target === backdropRef.current) onClose()
       }}
     >
-      <div className="flex w-full max-w-2xl flex-col rounded-xl border border-white/[0.08] bg-[#0d0d0d] shadow-2xl">
+      <div className="flex w-full max-w-2xl flex-col rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)]">
         {/* Header */}
-        <div className="flex items-start justify-between border-b border-white/[0.06] p-4">
+        <div className="flex items-start justify-between border-b border-line p-4">
           <div className="flex-1">
             <div className="flex items-center gap-2">
               {snippet.is_official && (
-                <Star size={12} className="text-amber-400" fill="currentColor" />
+                <Star size={12} className="text-warn" fill="currentColor" />
               )}
-              <h2 className="text-[13px] font-bold text-zinc-100">{snippet.title}</h2>
+              <h2 className="text-[13px] font-bold text-fg">{snippet.title}</h2>
             </div>
-            <p className="mt-0.5 text-[11px] text-zinc-500">{snippet.description}</p>
-            <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-zinc-600">
-              <span className="rounded bg-white/[0.05] px-1.5 py-0.5 capitalize">{snippet.category}</span>
+            <p className="mt-0.5 text-[11px] text-fg-3">{snippet.description}</p>
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-fg-3">
+              <span className="rounded bg-surface-2 px-1.5 py-0.5 capitalize">{snippet.category}</span>
               <span className="flex items-center gap-0.5">
                 <Download size={9} />
                 {snippet.installs_count}
@@ -68,7 +68,7 @@ export default function SnippetPreviewModal({
                 {snippet.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="rounded bg-violet-500/10 px-1.5 py-0.5 text-[9px] text-violet-400"
+                    className="rounded bg-accent-soft px-1.5 py-0.5 text-[9px] text-accent-strong"
                   >
                     #{tag}
                   </span>
@@ -78,7 +78,7 @@ export default function SnippetPreviewModal({
           </div>
           <button
             onClick={onClose}
-            className="ml-3 rounded p-1 text-zinc-600 transition hover:bg-white/[0.06] hover:text-zinc-300"
+            className="ml-3 rounded p-1 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <X size={14} />
           </button>
@@ -86,16 +86,16 @@ export default function SnippetPreviewModal({
 
         {/* Code preview */}
         <div className="min-h-0 flex-1 overflow-auto">
-          <pre className="p-4 text-[11px] leading-relaxed text-zinc-300 font-mono whitespace-pre-wrap break-words">
+          <pre className="p-4 text-[11px] leading-relaxed text-fg-2 font-mono whitespace-pre-wrap break-words">
             {snippet.content}
           </pre>
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-2 border-t border-white/[0.06] p-4">
+        <div className="flex items-center justify-end gap-2 border-t border-line p-4">
           <button
             onClick={onClose}
-            className="rounded-lg px-3 py-1.5 text-[11px] text-zinc-500 transition hover:text-zinc-300"
+            className="rounded-[var(--radius-md)] px-3 py-1.5 text-[11px] text-fg-3 transition hover:text-fg-2"
           >
             Cancel
           </button>
@@ -104,7 +104,7 @@ export default function SnippetPreviewModal({
               onInsert(snippet.content)
               onClose()
             }}
-            className="flex items-center gap-1.5 rounded-lg bg-violet-500/20 px-4 py-1.5 text-[11px] font-semibold text-violet-200 ring-1 ring-violet-400/30 transition hover:bg-violet-500/30"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-accent-soft px-4 py-1.5 text-[11px] font-semibold text-accent-strong ring-1 ring-accent transition hover:brightness-110"
           >
             <Package size={11} />
             Insert at Cursor

--- a/frontend/src/components/TemplatePreviewModal.tsx
+++ b/frontend/src/components/TemplatePreviewModal.tsx
@@ -9,22 +9,24 @@ import type { TemplateDetailResponse } from '@/lib/api-client'
 //  Category label map                                                 //
 // ------------------------------------------------------------------ //
 
+const ACCENT_CHIP = { bg: 'bg-accent-soft', text: 'text-accent-strong', border: 'border-accent' }
+
 const CATEGORY_STYLES: Record<string, { bg: string; text: string; border: string }> = {
-  software_engineering: { bg: 'bg-blue-500/10',    text: 'text-blue-300',    border: 'border-blue-500/20' },
-  finance:              { bg: 'bg-emerald-500/10',  text: 'text-emerald-300', border: 'border-emerald-500/20' },
-  academic:             { bg: 'bg-violet-500/10',   text: 'text-violet-300',  border: 'border-violet-500/20' },
-  creative:             { bg: 'bg-pink-500/10',     text: 'text-pink-300',    border: 'border-pink-500/20' },
-  minimal:              { bg: 'bg-zinc-500/10',     text: 'text-zinc-300',    border: 'border-zinc-500/20' },
-  ats_safe:             { bg: 'bg-green-500/10',    text: 'text-green-300',   border: 'border-green-500/20' },
-  two_column:           { bg: 'bg-cyan-500/10',     text: 'text-cyan-300',    border: 'border-cyan-500/20' },
-  executive:            { bg: 'bg-amber-500/10',    text: 'text-amber-300',   border: 'border-amber-500/20' },
-  marketing:            { bg: 'bg-orange-500/10',   text: 'text-orange-300',  border: 'border-orange-500/20' },
-  medical:              { bg: 'bg-red-500/10',      text: 'text-red-300',     border: 'border-red-500/20' },
-  legal:                { bg: 'bg-indigo-500/10',   text: 'text-indigo-300',  border: 'border-indigo-500/20' },
-  graduate:             { bg: 'bg-teal-500/10',     text: 'text-teal-300',    border: 'border-teal-500/20' },
+  software_engineering: ACCENT_CHIP,
+  finance:              ACCENT_CHIP,
+  academic:             ACCENT_CHIP,
+  creative:             ACCENT_CHIP,
+  minimal:              ACCENT_CHIP,
+  ats_safe:             ACCENT_CHIP,
+  two_column:           ACCENT_CHIP,
+  executive:            ACCENT_CHIP,
+  marketing:            ACCENT_CHIP,
+  medical:              ACCENT_CHIP,
+  legal:                ACCENT_CHIP,
+  graduate:             ACCENT_CHIP,
 }
 
-const DEFAULT_STYLE = { bg: 'bg-zinc-500/10', text: 'text-zinc-300', border: 'border-zinc-500/20' }
+const DEFAULT_STYLE = ACCENT_CHIP
 
 type ViewMode = 'pdf' | 'latex'
 
@@ -120,21 +122,21 @@ export default function TemplatePreviewModal({
   return (
     /* Backdrop */
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] p-4 backdrop-blur-sm"
       onClick={onClose}
     >
       {/* Modal */}
       <div
-        className="relative flex w-full max-w-3xl flex-col rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl h-[85vh]"
+        className="relative flex w-full max-w-3xl flex-col rounded-[var(--radius-lg)] border border-line bg-bg shadow-[var(--shadow-2)] h-[85vh]"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-start justify-between gap-4 border-b border-white/8 px-6 py-5">
+        <div className="flex items-start justify-between gap-4 border-b border-line px-6 py-5">
           {loading ? (
-            <div className="h-5 w-48 animate-pulse rounded bg-white/10" />
+            <div className="h-5 w-48 animate-pulse rounded bg-surface-2" />
           ) : (
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold text-white leading-snug">
+              <h2 className="text-lg font-semibold text-fg leading-snug">
                 {template?.name ?? '—'}
               </h2>
               {template && (
@@ -147,7 +149,7 @@ export default function TemplatePreviewModal({
           <button
             onClick={onClose}
             aria-label="Close preview"
-            className="shrink-0 rounded-lg p-1.5 text-zinc-500 transition hover:bg-white/8 hover:text-zinc-300"
+            className="shrink-0 rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <X size={18} />
           </button>
@@ -157,32 +159,32 @@ export default function TemplatePreviewModal({
         <div className="flex flex-1 overflow-hidden">
           {loading ? (
             <div className="flex flex-1 items-center justify-center p-12">
-              <div className="flex flex-col items-center gap-3 text-zinc-500">
-                <div className="h-8 w-8 animate-spin rounded-full border-2 border-zinc-700 border-t-orange-300" />
+              <div className="flex flex-col items-center gap-3 text-fg-3">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-line border-t-accent" />
                 <span className="text-sm">Loading template…</span>
               </div>
             </div>
           ) : error ? (
             <div className="flex flex-1 items-center justify-center p-12">
-              <p className="text-sm text-rose-400">{error}</p>
+              <p className="text-sm text-err">{error}</p>
             </div>
           ) : template ? (
             <div className="flex flex-1 overflow-hidden">
               {/* Left: metadata */}
-              <div className="flex w-52 shrink-0 flex-col gap-5 border-r border-white/8 p-6">
+              <div className="flex w-52 shrink-0 flex-col gap-5 border-r border-line p-6">
                 {template.description && (
                   <div>
-                    <p className="mb-1.5 text-[10px] uppercase tracking-[0.12em] text-zinc-600">Description</p>
-                    <p className="text-xs text-zinc-400 leading-relaxed">{template.description}</p>
+                    <p className="mb-1.5 text-[10px] uppercase tracking-[0.12em] text-fg-3">Description</p>
+                    <p className="text-xs text-fg-2 leading-relaxed">{template.description}</p>
                   </div>
                 )}
 
                 {template.tags.length > 0 && (
                   <div>
-                    <p className="mb-1.5 text-[10px] uppercase tracking-[0.12em] text-zinc-600">Tags</p>
+                    <p className="mb-1.5 text-[10px] uppercase tracking-[0.12em] text-fg-3">Tags</p>
                     <div className="flex flex-wrap gap-1">
                       {template.tags.map(tag => (
-                        <span key={tag} className="rounded-md bg-white/5 px-2 py-0.5 text-[10px] text-zinc-400">
+                        <span key={tag} className="rounded-[var(--radius-md)] bg-surface-2 px-2 py-0.5 text-[10px] text-fg-2">
                           {tag}
                         </span>
                       ))}
@@ -191,8 +193,8 @@ export default function TemplatePreviewModal({
                 )}
 
                 <div>
-                  <p className="mb-1.5 text-[10px] uppercase tracking-[0.12em] text-zinc-600">Format</p>
-                  <div className="flex items-center gap-1.5 text-xs text-zinc-400">
+                  <p className="mb-1.5 text-[10px] uppercase tracking-[0.12em] text-fg-3">Format</p>
+                  <div className="flex items-center gap-1.5 text-xs text-fg-2">
                     <FileText size={12} />
                     LaTeX (pdflatex)
                   </div>
@@ -202,16 +204,16 @@ export default function TemplatePreviewModal({
               {/* Right: preview area with toggle */}
               <div className="flex flex-1 flex-col overflow-hidden">
                 {/* View mode toggle */}
-                <div className="flex items-center gap-1 border-b border-white/8 px-4 py-2">
+                <div className="flex items-center gap-1 border-b border-line px-4 py-2">
                   <button
                     onClick={() => !pdfFailed && setViewMode('pdf')}
                     disabled={pdfFailed}
-                    className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition ${
+                    className={`flex items-center gap-1.5 rounded-[var(--radius-md)] px-3 py-1.5 text-xs font-medium transition ${
                       effectiveView === 'pdf'
-                        ? 'bg-white/10 text-white'
+                        ? 'bg-surface-2 text-fg'
                         : pdfFailed
-                        ? 'text-zinc-700 cursor-not-allowed'
-                        : 'text-zinc-500 hover:text-zinc-300'
+                        ? 'text-fg-3 cursor-not-allowed'
+                        : 'text-fg-3 hover:text-fg-2'
                     }`}
                   >
                     <FileText size={12} />
@@ -219,10 +221,10 @@ export default function TemplatePreviewModal({
                   </button>
                   <button
                     onClick={() => setViewMode('latex')}
-                    className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition ${
+                    className={`flex items-center gap-1.5 rounded-[var(--radius-md)] px-3 py-1.5 text-xs font-medium transition ${
                       effectiveView === 'latex'
-                        ? 'bg-white/10 text-white'
-                        : 'text-zinc-500 hover:text-zinc-300'
+                        ? 'bg-surface-2 text-fg'
+                        : 'text-fg-3 hover:text-fg-2'
                     }`}
                   >
                     <Code size={12} />
@@ -239,8 +241,8 @@ export default function TemplatePreviewModal({
                     onError={() => setPdfFailed(true)}
                   />
                 ) : (
-                  <div className="flex-1 overflow-auto bg-zinc-900/60 p-4">
-                    <pre className="text-[11px] leading-relaxed text-zinc-400 whitespace-pre-wrap break-all">
+                  <div className="flex-1 overflow-auto bg-surface p-4">
+                    <pre className="text-[11px] leading-relaxed text-fg-2 whitespace-pre-wrap break-all">
                       {template.latex_content}
                     </pre>
                   </div>
@@ -252,16 +254,16 @@ export default function TemplatePreviewModal({
 
         {/* Footer */}
         {!loading && !error && template && (
-          <div className="flex items-center justify-end gap-3 border-t border-white/8 px-6 py-4">
+          <div className="flex items-center justify-end gap-3 border-t border-line px-6 py-4">
             <button
               onClick={onClose}
-              className="rounded-lg border border-white/10 px-4 py-2 text-xs font-medium text-zinc-400 transition hover:border-white/20 hover:text-zinc-200"
+              className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs font-medium text-fg transition hover:bg-surface-2"
             >
               Cancel
             </button>
             <button
               onClick={() => { onUse(template.id); onClose() }}
-              className="btn-accent px-6 py-2 text-xs font-semibold"
+              className="rounded-[var(--radius-md)] bg-accent px-6 py-2 text-xs font-semibold text-accent-fg hover:brightness-110"
             >
               Use This Template
             </button>


### PR DESCRIPTION
Refs #1073. Phase 5 batch a — re-skins 12 modal components to the design-token system. Additive, zero functional regressions (493 tests pass, build compiles, no residue).

Surgical class-replacement only (via the `redesign-modals` workflow, 24 agents); each modal's review agent diffed against HEAD and confirmed **only classNames/colors changed — logicPreserved: true on all 12**. Status colors mapped to ok/warn/err, decorative rainbow collapsed to accent, modal scrims → `bg-[var(--overlay)]`, legacy `surface-*`/`btn-*` expanded to tokens.