### PR TITLE
Redesign Phase 5f: editors + last components (tokens)

### DIFF
--- a/frontend/src/components/ImportFromBuilderWizard.tsx
+++ b/frontend/src/components/ImportFromBuilderWizard.tsx
@@ -32,7 +32,7 @@ const PLATFORMS: Platform[] = [
       'Download and upload the .json file below',
     ],
     acceptedExtensions: ['.json'],
-    color: 'text-violet-400 bg-violet-500/10 border-violet-400/20',
+    color: 'text-accent-strong bg-accent-soft border-accent',
   },
   {
     id: 'resumeio',
@@ -46,7 +46,7 @@ const PLATFORMS: Platform[] = [
       'Upload the downloaded .json file below',
     ],
     acceptedExtensions: ['.json'],
-    color: 'text-blue-400 bg-blue-500/10 border-blue-400/20',
+    color: 'text-accent-strong bg-accent-soft border-accent',
   },
   {
     id: 'novoresume',
@@ -60,7 +60,7 @@ const PLATFORMS: Platform[] = [
       'Upload the downloaded .json file below',
     ],
     acceptedExtensions: ['.json'],
-    color: 'text-emerald-400 bg-emerald-500/10 border-emerald-400/20',
+    color: 'text-accent-strong bg-accent-soft border-accent',
   },
   {
     id: 'generic',
@@ -72,7 +72,7 @@ const PLATFORMS: Platform[] = [
       'Upload the file below',
     ],
     acceptedExtensions: ['.json', '.pdf', '.docx', '.doc'],
-    color: 'text-zinc-400 bg-zinc-500/10 border-zinc-400/20',
+    color: 'text-fg-2 bg-surface-2 border-line',
   },
 ]
 
@@ -83,10 +83,10 @@ function StepDot({ active, done, n }: { active: boolean; done: boolean; n: numbe
     <div
       className={`flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-bold transition-all ${
         done
-          ? 'bg-emerald-500/20 text-emerald-400 ring-1 ring-emerald-400/40'
+          ? 'bg-ok/20 text-ok ring-1 ring-ok/40'
           : active
-            ? 'bg-orange-400/20 text-orange-300 ring-1 ring-orange-300/40'
-            : 'bg-white/[0.04] text-zinc-600'
+            ? 'bg-accent-soft text-accent-strong ring-1 ring-accent'
+            : 'bg-surface-2 text-fg-3'
       }`}
     >
       {done ? <Check className="h-3 w-3" /> : n}
@@ -107,23 +107,23 @@ function PlatformCard({
     <button
       type="button"
       onClick={onClick}
-      className={`flex items-start gap-3 rounded-xl border p-4 text-left transition hover:brightness-110 ${
+      className={`flex items-start gap-3 rounded-[var(--radius-lg)] border p-4 text-left transition hover:brightness-110 ${
         selected
           ? `${platform.color} ring-1 ring-current/30`
-          : 'border-white/[0.07] bg-white/[0.02] hover:bg-white/[0.04]'
+          : 'border-line bg-surface hover:bg-surface-2'
       }`}
     >
-      <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-xs font-bold ${selected ? platform.color : 'bg-white/[0.05] text-zinc-500'}`}>
+      <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-md)] text-xs font-bold ${selected ? platform.color : 'bg-surface-2 text-fg-3'}`}>
         {platform.name[0]}
       </div>
       <div>
-        <p className="text-sm font-semibold text-white">{platform.name}</p>
-        <p className="mt-0.5 text-xs text-zinc-500">{platform.description}</p>
-        <p className={`mt-1 text-[10px] font-medium ${selected ? '' : 'text-zinc-600'}`}>
+        <p className="text-sm font-semibold text-fg">{platform.name}</p>
+        <p className="mt-0.5 text-xs text-fg-3">{platform.description}</p>
+        <p className={`mt-1 text-[10px] font-medium ${selected ? '' : 'text-fg-3'}`}>
           {platform.exportFormat}
         </p>
       </div>
-      {selected && <Check className="ml-auto mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />}
+      {selected && <Check className="ml-auto mt-0.5 h-4 w-4 shrink-0 text-ok" />}
     </button>
   )
 }
@@ -204,12 +204,12 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
           <div key={label} className="flex items-center gap-2">
             <div className="flex items-center gap-1.5">
               <StepDot active={step === i + 1} done={step > i + 1} n={i + 1} />
-              <span className={`hidden text-[11px] sm:inline ${step === i + 1 ? 'text-zinc-300' : step > i + 1 ? 'text-emerald-400/70' : 'text-zinc-600'}`}>
+              <span className={`hidden text-[11px] sm:inline ${step === i + 1 ? 'text-fg-2' : step > i + 1 ? 'text-ok' : 'text-fg-3'}`}>
                 {label}
               </span>
             </div>
             {i < STEPS.length - 1 && (
-              <div className={`h-px w-6 rounded ${step > i + 1 ? 'bg-emerald-400/30' : 'bg-white/[0.06]'}`} />
+              <div className={`h-px w-6 rounded ${step > i + 1 ? 'bg-ok/30' : 'bg-surface-2'}`} />
             )}
           </div>
         ))}
@@ -218,7 +218,7 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
       {/* ── Step 1: Platform selector ── */}
       {step === 1 && (
         <div className="space-y-4">
-          <p className="text-xs text-zinc-500">Which resume builder are you importing from?</p>
+          <p className="text-xs text-fg-3">Which resume builder are you importing from?</p>
           <div className="grid gap-3 sm:grid-cols-2">
             {PLATFORMS.map((p) => (
               <PlatformCard
@@ -234,7 +234,7 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
               type="button"
               disabled={!platform}
               onClick={() => setStep(2)}
-              className="flex items-center gap-1.5 rounded-lg bg-orange-400/10 px-4 py-2 text-xs font-medium text-orange-300 transition hover:bg-orange-400/20 disabled:opacity-40"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-accent-soft px-4 py-2 text-xs font-medium text-accent-strong transition hover:brightness-110 disabled:opacity-40"
             >
               Next <ChevronRight className="h-3.5 w-3.5" />
             </button>
@@ -245,13 +245,13 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
       {/* ── Step 2: Export instructions ── */}
       {step === 2 && platform && (
         <div className="space-y-4">
-          <div className={`rounded-xl border p-4 ${platform.color}`}>
+          <div className={`rounded-[var(--radius-lg)] border p-4 ${platform.color}`}>
             <p className="text-xs font-semibold uppercase tracking-[0.12em]">
               How to export from {platform.name}
             </p>
             <ol className="mt-3 space-y-2">
               {platform.steps.map((s, i) => (
-                <li key={i} className="flex items-start gap-2 text-xs text-zinc-300">
+                <li key={i} className="flex items-start gap-2 text-xs text-fg-2">
                   <span className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[10px] font-bold ${platform.color}`}>
                     {i + 1}
                   </span>
@@ -264,14 +264,14 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
             <button
               type="button"
               onClick={() => setStep(1)}
-              className="flex items-center gap-1.5 rounded-lg px-4 py-2 text-xs text-zinc-500 transition hover:text-zinc-300"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-4 py-2 text-xs text-fg-3 transition hover:text-fg-2"
             >
               <ChevronLeft className="h-3.5 w-3.5" /> Back
             </button>
             <button
               type="button"
               onClick={() => setStep(3)}
-              className="flex items-center gap-1.5 rounded-lg bg-orange-400/10 px-4 py-2 text-xs font-medium text-orange-300 transition hover:bg-orange-400/20"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-accent-soft px-4 py-2 text-xs font-medium text-accent-strong transition hover:brightness-110"
             >
               Next <ChevronRight className="h-3.5 w-3.5" />
             </button>
@@ -282,7 +282,7 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
       {/* ── Step 3: File upload ── */}
       {step === 3 && platform && (
         <div className="space-y-4">
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-fg-3">
             Drop your {platform.exportFormat} file below ({platform.acceptedExtensions.join(', ')})
           </p>
           <div
@@ -290,16 +290,16 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
             onDragLeave={() => setDragOver(false)}
             onDrop={handleDrop}
             onClick={() => fileInputRef.current?.click()}
-            className={`flex cursor-pointer flex-col items-center gap-3 rounded-xl border-2 border-dashed p-8 text-center transition ${
+            className={`flex cursor-pointer flex-col items-center gap-3 rounded-[var(--radius-lg)] border-2 border-dashed p-8 text-center transition ${
               dragOver
-                ? 'border-orange-300/50 bg-orange-300/[0.04]'
-                : 'border-white/[0.08] hover:border-white/20 hover:bg-white/[0.02]'
+                ? 'border-accent bg-accent-soft'
+                : 'border-line hover:border-line-2 hover:bg-surface-2'
             }`}
           >
-            <Upload className="h-8 w-8 text-zinc-600" />
+            <Upload className="h-8 w-8 text-fg-3" />
             <div>
-              <p className="text-sm font-medium text-zinc-300">Drop file here or click to browse</p>
-              <p className="mt-1 text-xs text-zinc-600">{platform.acceptedExtensions.join(', ')} · max 10 MB</p>
+              <p className="text-sm font-medium text-fg-2">Drop file here or click to browse</p>
+              <p className="mt-1 text-xs text-fg-3">{platform.acceptedExtensions.join(', ')} · max 10 MB</p>
             </div>
           </div>
           <input
@@ -316,7 +316,7 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
             <button
               type="button"
               onClick={() => setStep(2)}
-              className="flex items-center gap-1.5 rounded-lg px-4 py-2 text-xs text-zinc-500 transition hover:text-zinc-300"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-4 py-2 text-xs text-fg-3 transition hover:text-fg-2"
             >
               <ChevronLeft className="h-3.5 w-3.5" /> Back
             </button>
@@ -328,48 +328,48 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
       {step === 4 && file && (
         <div className="space-y-4">
           {previewLoading && (
-            <div className="flex items-center gap-2 text-xs text-zinc-500">
+            <div className="flex items-center gap-2 text-xs text-fg-3">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
               Parsing file…
             </div>
           )}
 
           {!previewLoading && previewError && (
-            <div className="flex items-start gap-2 rounded-lg border border-rose-400/20 bg-rose-400/[0.05] p-3 text-xs text-rose-300">
+            <div className="flex items-start gap-2 rounded-[var(--radius-md)] border border-err/20 bg-err/5 p-3 text-xs text-err">
               <AlertCircle className="mt-px h-3.5 w-3.5 shrink-0" />
               {previewError}
             </div>
           )}
 
           {!previewLoading && preview && (
-            <div className="rounded-xl border border-white/[0.07] bg-white/[0.02] p-4 space-y-3">
-              <p className="text-[10px] uppercase tracking-widest text-zinc-600">Parsed preview</p>
+            <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-4 space-y-3">
+              <p className="text-[10px] uppercase tracking-widest text-fg-3">Parsed preview</p>
               <div className="grid grid-cols-2 gap-2 text-xs">
                 {preview.name && (
                   <div>
-                    <span className="text-zinc-600">Name</span>
-                    <p className="mt-0.5 font-medium text-zinc-200">{preview.name}</p>
+                    <span className="text-fg-3">Name</span>
+                    <p className="mt-0.5 font-medium text-fg">{preview.name}</p>
                   </div>
                 )}
                 {preview.email && (
                   <div>
-                    <span className="text-zinc-600">Email</span>
-                    <p className="mt-0.5 font-medium text-zinc-200">{preview.email}</p>
+                    <span className="text-fg-3">Email</span>
+                    <p className="mt-0.5 font-medium text-fg">{preview.email}</p>
                   </div>
                 )}
                 <div>
-                  <span className="text-zinc-600">Experience</span>
-                  <p className="mt-0.5 font-medium text-zinc-200">{preview.experience_count} {preview.experience_count === 1 ? 'entry' : 'entries'}</p>
+                  <span className="text-fg-3">Experience</span>
+                  <p className="mt-0.5 font-medium text-fg">{preview.experience_count} {preview.experience_count === 1 ? 'entry' : 'entries'}</p>
                 </div>
                 <div>
-                  <span className="text-zinc-600">Education</span>
-                  <p className="mt-0.5 font-medium text-zinc-200">{preview.education_count} {preview.education_count === 1 ? 'entry' : 'entries'}</p>
+                  <span className="text-fg-3">Education</span>
+                  <p className="mt-0.5 font-medium text-fg">{preview.education_count} {preview.education_count === 1 ? 'entry' : 'entries'}</p>
                 </div>
               </div>
               {preview.skills.length > 0 && (
                 <div>
-                  <p className="text-[10px] text-zinc-600">Skills</p>
-                  <p className="mt-0.5 text-xs text-zinc-400">{preview.skills.join(', ')}</p>
+                  <p className="text-[10px] text-fg-3">Skills</p>
+                  <p className="mt-0.5 text-xs text-fg-2">{preview.skills.join(', ')}</p>
                 </div>
               )}
             </div>
@@ -377,13 +377,13 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
 
           {/* File info */}
           {!previewLoading && (
-            <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-xs text-zinc-400">
-              <Upload className="h-3.5 w-3.5 shrink-0 text-zinc-600" />
+            <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-line bg-surface px-3 py-2 text-xs text-fg-2">
+              <Upload className="h-3.5 w-3.5 shrink-0 text-fg-3" />
               <span className="flex-1 truncate">{file.name}</span>
               <button
                 type="button"
                 onClick={() => { setFile(null); setPreview(null); setPreviewError(null); setStep(3) }}
-                className="shrink-0 text-zinc-600 hover:text-zinc-300"
+                className="shrink-0 text-fg-3 hover:text-fg-2"
               >
                 <X className="h-3 w-3" />
               </button>
@@ -393,14 +393,14 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
           {/* Conversion progress */}
           {converting && (
             <div className="space-y-1.5">
-              <div className="flex items-center gap-2 text-xs text-zinc-400">
+              <div className="flex items-center gap-2 text-xs text-fg-2">
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 {status === 'uploading' ? 'Uploading…' : `Converting to LaTeX… ${progress}%`}
               </div>
               {status === 'converting' && (
-                <div className="h-1 w-full overflow-hidden rounded-full bg-white/[0.05]">
+                <div className="h-1 w-full overflow-hidden rounded-full bg-surface-2">
                   <div
-                    className="h-full rounded-full bg-orange-400/60 transition-all duration-500"
+                    className="h-full rounded-full bg-accent transition-all duration-500"
                     style={{ width: `${progress}%` }}
                   />
                 </div>
@@ -409,7 +409,7 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
           )}
 
           {conversionError && (
-            <div className="flex items-start gap-2 rounded-lg border border-rose-400/20 bg-rose-400/[0.05] p-3 text-xs text-rose-300">
+            <div className="flex items-start gap-2 rounded-[var(--radius-md)] border border-err/20 bg-err/5 p-3 text-xs text-err">
               <AlertCircle className="mt-px h-3.5 w-3.5 shrink-0" />
               {conversionError}
             </div>
@@ -420,7 +420,7 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
               type="button"
               onClick={() => { resetConversion(); setStep(3) }}
               disabled={converting}
-              className="flex items-center gap-1.5 rounded-lg px-4 py-2 text-xs text-zinc-500 transition hover:text-zinc-300 disabled:opacity-40"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-4 py-2 text-xs text-fg-3 transition hover:text-fg-2 disabled:opacity-40"
             >
               <ChevronLeft className="h-3.5 w-3.5" /> Back
             </button>
@@ -428,7 +428,7 @@ export default function ImportFromBuilderWizard({ onComplete }: ImportFromBuilde
               type="button"
               onClick={handleConvert}
               disabled={converting || previewLoading || !file}
-              className="flex items-center gap-1.5 rounded-lg bg-orange-400/10 px-4 py-2 text-xs font-medium text-orange-300 transition hover:bg-orange-400/20 disabled:opacity-40"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-accent-soft px-4 py-2 text-xs font-medium text-accent-strong transition hover:brightness-110 disabled:opacity-40"
             >
               {converting ? (
                 <><Loader2 className="h-3.5 w-3.5 animate-spin" /> Converting…</>

--- a/frontend/src/components/LaTeXEditor.tsx
+++ b/frontend/src/components/LaTeXEditor.tsx
@@ -20,7 +20,7 @@ import { classifyCollabClose } from '@/lib/collab-close'
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
   ssr: false,
-  loading: () => <div className="h-full w-full bg-[#07090f]" aria-hidden="true" />,
+  loading: () => <div className="h-full w-full bg-bg" aria-hidden="true" />,
 })
 
 type MonacoEditorInstance = import('monaco-editor').editor.IStandaloneCodeEditor
@@ -1649,14 +1649,14 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
       <div className="flex h-full flex-col">
         {!value ? (
           <div className="flex flex-1 flex-col items-center justify-center px-6 text-center">
-            <p className="text-sm uppercase tracking-[0.14em] text-zinc-600">Empty document</p>
-            <p className="mt-2 max-w-sm text-xs text-zinc-600">
+            <p className="text-sm uppercase tracking-[0.14em] text-fg-3">Empty document</p>
+            <p className="mt-2 max-w-sm text-xs text-fg-3">
               {hideEmptyAction ? 'Content will appear here once generated.' : 'Start writing or use a sample template.'}
             </p>
             {!hideEmptyAction && (
               <button
                 onClick={() => onChange(BLANK_RESUME_TEMPLATE)}
-                className="mt-4 rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-2 text-xs font-medium text-zinc-300 transition hover:bg-white/[0.08]"
+                className="mt-4 rounded-[var(--radius-md)] border border-line bg-surface px-4 py-2 text-xs font-medium text-fg-2 transition hover:bg-surface-2"
               >
                 Insert Sample Resume
               </button>
@@ -1722,18 +1722,18 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
         )}
 
         {/* Status bar */}
-        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-t border-white/[0.05] bg-[#07090f] px-3 py-1 text-[10px] uppercase tracking-[0.12em]">
-          <span className="text-zinc-700">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-t border-line bg-bg px-3 py-1 text-[10px] uppercase tracking-[0.12em]">
+          <span className="text-fg-3">
             {readOnly
               ? 'Read-only — job running'
               : collabReadOnly
                 ? 'Read-only — no edit access'
                 : 'LaTeX editor'}
           </span>
-          <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1 text-zinc-700">
+          <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1 text-fg-3">
             {onAutoCompile && (
-              <span className="flex items-center gap-1 text-[10px] text-orange-400/70">
-                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-orange-400/70" />
+              <span className="flex items-center gap-1 text-[10px] text-accent-strong">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
                 Auto
               </span>
             )}
@@ -1741,12 +1741,12 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
             {(pageCount !== null && pageCount !== undefined) ? (
               <span
                 title={`Resume is ${pageCount} page${pageCount === 1 ? '' : 's'}`}
-                className={`text-[10px] font-medium px-1.5 py-0.5 rounded-md ${
+                className={`text-[10px] font-medium px-1.5 py-0.5 rounded-[var(--radius-md)] ${
                   pageCount === 1
-                    ? 'text-emerald-400 bg-emerald-500/10'
+                    ? 'text-ok bg-ok/10'
                     : pageCount === 2
-                    ? 'text-amber-400 bg-amber-500/10'
-                    : 'text-rose-400 bg-rose-500/10 animate-pulse'
+                    ? 'text-warn bg-warn/10'
+                    : 'text-err bg-err/10 animate-pulse'
                 }`}
               >
                 {pageCount} {pageCount === 1 ? 'page' : 'pages'}{pageCount > 1 ? ' ⚠' : ''}
@@ -1754,7 +1754,7 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
             ) : estimatedPageCount !== null ? (
               <span
                 title="Estimated page count (compile for exact count)"
-                className="text-[10px] text-zinc-600 px-1.5"
+                className="text-[10px] text-fg-3 px-1.5"
               >
                 ~{estimatedPageCount} {estimatedPageCount === 1 ? 'page' : 'pages'}
               </span>
@@ -1765,13 +1765,13 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
                 title={spellCheckEnabled ? 'Spell check on — click to disable' : 'Spell check off — click to enable'}
                 className={`flex items-center gap-1 text-[10px] transition ${
                   spellCheckEnabled
-                    ? 'text-blue-400 hover:text-blue-300'
-                    : 'text-zinc-700 hover:text-zinc-400'
+                    ? 'text-accent-strong hover:text-accent'
+                    : 'text-fg-3 hover:text-fg-2'
                 }`}
               >
                 ABC{spellCheckEnabled ? ' ✓' : ''}
                 {spellCheckLoading && (
-                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-blue-400" />
+                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
                 )}
               </button>
             )}
@@ -1784,8 +1784,8 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
             )}
             {(confidenceScore !== undefined || confidenceScoreLoading) && (
               confidenceScoreLoading ? (
-                <span className="flex items-center gap-1 text-[10px] text-zinc-500">
-                  <span className="h-1.5 w-1.5 animate-spin rounded-full border border-zinc-500 border-t-transparent" />
+                <span className="flex items-center gap-1 text-[10px] text-fg-3">
+                  <span className="h-1.5 w-1.5 animate-spin rounded-full border border-line-2 border-t-transparent" />
                   Quality
                 </span>
               ) : confidenceScore != null ? (
@@ -1794,12 +1794,12 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
                     type="button"
                     onClick={onConfidenceBadgeClick}
                     title="Resume quality score — click to view details"
-                    className={`rounded-md px-1.5 py-0.5 text-[10px] font-medium transition-colors cursor-pointer hover:brightness-110 ${
+                    className={`rounded-[var(--radius-md)] px-1.5 py-0.5 text-[10px] font-medium transition-colors cursor-pointer hover:brightness-110 ${
                       confidenceScore >= 80
-                        ? 'text-emerald-400 bg-emerald-500/10'
+                        ? 'text-ok bg-ok/10'
                         : confidenceScore >= 60
-                          ? 'text-amber-400 bg-amber-500/10'
-                          : 'text-rose-400 bg-rose-500/10'
+                          ? 'text-warn bg-warn/10'
+                          : 'text-err bg-err/10'
                     }`}
                   >
                     Q {confidenceScore}
@@ -1807,12 +1807,12 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
                 ) : (
                   <span
                     title="Resume quality score"
-                    className={`rounded-md px-1.5 py-0.5 text-[10px] font-medium ${
+                    className={`rounded-[var(--radius-md)] px-1.5 py-0.5 text-[10px] font-medium ${
                       confidenceScore >= 80
-                        ? 'text-emerald-400 bg-emerald-500/10'
+                        ? 'text-ok bg-ok/10'
                         : confidenceScore >= 60
-                          ? 'text-amber-400 bg-amber-500/10'
-                          : 'text-rose-400 bg-rose-500/10'
+                          ? 'text-warn bg-warn/10'
+                          : 'text-err bg-err/10'
                     }`}
                   >
                     Q {confidenceScore}
@@ -1821,7 +1821,7 @@ const LaTeXEditor = forwardRef<LaTeXEditorRef, LaTeXEditorProps>(
               ) : null
             )}
             <span>{value.length.toLocaleString()} chars</span>
-            <span className="hidden text-zinc-800 sm:inline">
+            <span className="hidden text-fg-3 sm:inline">
               {[onSave && '⌘S save', onCompile && '⌘↵ compile', '⌘⇧H presets'].filter(Boolean).join(' · ')}
             </span>
           </div>

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -27,7 +27,7 @@ export default function LogViewer({
   if (lines.length === 0) {
     return (
       <div
-        className={`flex items-center justify-center rounded-lg bg-black/60 text-sm font-mono text-zinc-500 ${className}`}
+        className={`flex items-center justify-center rounded-[var(--radius-md)] bg-[var(--code-bg)] text-sm font-mono text-fg-3 ${className}`}
         style={{ minHeight: '80px' }}
       >
         No log output yet
@@ -37,7 +37,7 @@ export default function LogViewer({
 
   return (
     <div
-      className={`scrollbar-subtle overflow-y-auto rounded-lg bg-black/60 font-mono text-xs text-zinc-100 ${className}`}
+      className={`scrollbar-subtle overflow-y-auto rounded-[var(--radius-md)] bg-[var(--code-bg)] font-mono text-xs text-fg ${className}`}
       style={{ maxHeight }}
     >
       <div className="p-3 space-y-0.5">
@@ -45,11 +45,11 @@ export default function LogViewer({
           <div
             key={`${i}-${entry.source}-${entry.line?.substring(0, 20) ?? ''}`}
             className={`leading-5 whitespace-pre-wrap break-all ${
-              entry.is_error ? 'text-rose-300' : 'text-zinc-300'
+              entry.is_error ? 'text-err' : 'text-fg-2'
             }`}
           >
             {showLineNumbers && (
-              <span className="mr-2 inline-block w-8 select-none text-right text-zinc-600">
+              <span className="mr-2 inline-block w-8 select-none text-right text-fg-3">
                 {i + 1}
               </span>
             )}

--- a/frontend/src/components/MobileEditor.tsx
+++ b/frontend/src/components/MobileEditor.tsx
@@ -40,8 +40,8 @@ interface MobileEditorProps {
 const darkTheme = EditorView.theme(
   {
     '&': {
-      backgroundColor: '#09090b',
-      color: '#e4e4e7',
+      backgroundColor: 'var(--code-bg)',
+      color: 'var(--code-fg)',
       height: '100%',
       fontSize: '14px',
     },
@@ -50,7 +50,7 @@ const darkTheme = EditorView.theme(
       fontFamily: "ui-monospace, 'Cascadia Code', monospace",
     },
     '.cm-gutters': {
-      backgroundColor: '#09090b',
+      backgroundColor: 'var(--code-bg)',
       borderRight: '1px solid rgba(255,255,255,0.06)',
       color: '#52525b',
     },
@@ -58,14 +58,14 @@ const darkTheme = EditorView.theme(
       minWidth: '2.5em',
       paddingRight: '0.5em',
     },
-    '.cm-cursor': { borderLeftColor: '#a855f7' },
+    '.cm-cursor': { borderLeftColor: 'var(--accent)' },
     '.cm-selectionBackground': {
       backgroundColor: 'rgba(168,85,247,0.15) !important',
     },
     '.cm-activeLine': { backgroundColor: 'rgba(255,255,255,0.03)' },
     '.cm-activeLineGutter': { backgroundColor: 'rgba(168,85,247,0.08)' },
     '.cm-line': { padding: '0 8px' },
-    '&.cm-focused .cm-cursor': { borderLeftColor: '#a855f7' },
+    '&.cm-focused .cm-cursor': { borderLeftColor: 'var(--accent)' },
   },
   { dark: true },
 )
@@ -187,25 +187,25 @@ const MobileEditor = forwardRef<LaTeXEditorRef, MobileEditorProps>(
     )
 
     return (
-      <div className="flex h-full flex-col bg-[#09090b]">
+      <div className="flex h-full flex-col bg-bg">
         {/* Toolbar strip — sits above the virtual keyboard */}
-        <div className="flex shrink-0 items-center gap-1 border-b border-white/[0.06] bg-zinc-950 px-2 py-1.5">
+        <div className="flex shrink-0 items-center gap-1 border-b border-line bg-bg px-2 py-1.5">
           {TOOLBAR_ITEMS.map(({ icon: Icon, label, insert, cursorOffset }) => (
             <button
               key={label}
               title={label}
               onClick={() => insertSnippet(insert, cursorOffset)}
-              className="flex h-7 w-7 items-center justify-center rounded text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-200"
+              className="flex h-7 w-7 items-center justify-center rounded text-fg-3 transition hover:bg-surface-2 hover:text-fg"
             >
               <Icon size={14} />
             </button>
           ))}
-          <div className="mx-1 h-4 w-px bg-white/[0.08]" />
+          <div className="mx-1 h-4 w-px bg-line" />
           {onCompile && (
             <button
               title="Compile"
               onClick={onCompile}
-              className="flex h-7 items-center gap-1 rounded px-2 text-[11px] font-medium text-violet-400 transition hover:bg-violet-500/10"
+              className="flex h-7 items-center gap-1 rounded px-2 text-[11px] font-medium text-accent-strong transition hover:bg-accent-soft"
             >
               <Play size={12} />
               Compile
@@ -215,7 +215,7 @@ const MobileEditor = forwardRef<LaTeXEditorRef, MobileEditorProps>(
             <button
               title="Save"
               onClick={onSave}
-              className="flex h-7 items-center gap-1 rounded px-2 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+              className="flex h-7 items-center gap-1 rounded px-2 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
             >
               <Save size={12} />
               Save

--- a/frontend/src/components/PDFPreview.tsx
+++ b/frontend/src/components/PDFPreview.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect, useMemo, type MutableRefObject } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
-import { AlertTriangle, FileText, Download, ZoomIn, ZoomOut, MousePointer, Moon, Printer, Sun } from 'lucide-react'
+import { AlertTriangle, FileText, Download, ZoomIn, ZoomOut, MousePointer, Moon, Printer, Sun, Flame } from 'lucide-react'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 import 'react-pdf/dist/Page/TextLayer.css'
 import { parseSynctex, synctexReverse, synctexForward, type SynctexData } from '@/lib/synctex-parser'
@@ -298,27 +298,27 @@ export default function PDFPreview({
 
   if (isLoading) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-3 bg-[#1a1a1a]">
-        <div className="h-7 w-7 animate-spin rounded-full border-2 border-white/10 border-t-orange-400" />
-        <p className="text-xs text-zinc-600">Compiling…</p>
+      <div className="flex h-full flex-col items-center justify-center gap-3 bg-bg">
+        <div className="h-7 w-7 animate-spin rounded-full border-2 border-line border-t-accent" />
+        <p className="text-xs text-fg-3">Compiling…</p>
       </div>
     )
   }
 
   if (!pdfUrl) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-3 bg-[#1a1a1a]">
-        <FileText className="h-9 w-9 text-zinc-800" />
-        <p className="text-xs text-zinc-700">No preview yet</p>
-        <p className="text-[10px] text-zinc-800">Compile your LaTeX to see the PDF</p>
+      <div className="flex h-full flex-col items-center justify-center gap-3 bg-bg">
+        <FileText className="h-9 w-9 text-fg-3" />
+        <p className="text-xs text-fg-3">No preview yet</p>
+        <p className="text-[10px] text-fg-3">Compile your LaTeX to see the PDF</p>
       </div>
     )
   }
 
   return (
-    <div className="flex h-full flex-col bg-[#1a1a1a]">
+    <div className="flex h-full flex-col bg-bg">
       {/* Toolbar */}
-      <div className="flex shrink-0 items-center justify-between border-b border-white/[0.06] bg-[#111] px-2 py-1">
+      <div className="flex shrink-0 items-center justify-between border-b border-line bg-surface px-2 py-1">
         {/* Zoom */}
         <div className="flex items-center gap-0.5">
           <button
@@ -326,11 +326,11 @@ export default function PDFPreview({
             disabled={zoom <= 0.4}
             aria-label="Zoom out"
             title="Zoom out"
-            className="rounded p-1 text-zinc-500 transition hover:bg-white/10 hover:text-zinc-200 disabled:opacity-30"
+            className="rounded p-1 text-fg-3 transition hover:bg-surface-2 hover:text-fg disabled:opacity-30"
           >
             <ZoomOut size={13} />
           </button>
-          <span className="min-w-[3rem] text-center text-[11px] tabular-nums text-zinc-500">
+          <span className="min-w-[3rem] text-center text-[11px] tabular-nums text-fg-3">
             {Math.round(zoom * 100)}%
           </span>
           <button
@@ -338,7 +338,7 @@ export default function PDFPreview({
             disabled={zoom >= 3}
             aria-label="Zoom in"
             title="Zoom in"
-            className="rounded p-1 text-zinc-500 transition hover:bg-white/10 hover:text-zinc-200 disabled:opacity-30"
+            className="rounded p-1 text-fg-3 transition hover:bg-surface-2 hover:text-fg disabled:opacity-30"
           >
             <ZoomIn size={13} />
           </button>
@@ -348,7 +348,7 @@ export default function PDFPreview({
         {synctexReady && (
           <div
             className={`flex items-center gap-1 text-[10px] transition ${
-              syncHint ? 'text-amber-400' : 'text-zinc-700'
+              syncHint ? 'text-warn' : 'text-fg-3'
             }`}
             title="SyncTeX enabled — Ctrl+click PDF to jump to source"
           >
@@ -362,18 +362,18 @@ export default function PDFPreview({
           <button
             onClick={() => setShowHeatmap((p) => !p)}
             title="Shows predicted areas recruiters focus on (based on eye-tracking research)"
-            className={`flex items-center gap-1 rounded px-2 py-1 text-[11px] transition hover:bg-white/10 ${
-              showHeatmap ? 'text-orange-300' : 'text-zinc-600 hover:text-zinc-200'
+            className={`flex items-center gap-1 rounded px-2 py-1 text-[11px] transition hover:bg-surface-2 ${
+              showHeatmap ? 'text-accent-strong' : 'text-fg-3 hover:text-fg'
             }`}
           >
-            🔥 Heatmap
+            <Flame size={12} /> Heatmap
           </button>
           <button
             onClick={toggleDarkPdf}
             aria-label={darkPdf ? 'Light PDF preview' : 'Dark PDF preview'}
             title={darkPdf ? 'Switch to light preview' : 'Switch to dark preview'}
-            className={`flex items-center gap-1 rounded px-2 py-1 text-[11px] transition hover:bg-white/10 ${
-              darkPdf ? 'text-orange-300' : 'text-zinc-600 hover:text-zinc-200'
+            className={`flex items-center gap-1 rounded px-2 py-1 text-[11px] transition hover:bg-surface-2 ${
+              darkPdf ? 'text-accent-strong' : 'text-fg-3 hover:text-fg'
             }`}
           >
             {darkPdf ? <Sun size={12} /> : <Moon size={12} />}
@@ -382,8 +382,8 @@ export default function PDFPreview({
             onClick={togglePrintPreview}
             aria-label={printPreview ? 'Exit print preview' : 'B&W print preview'}
             title={printPreview ? 'Exit B&W print preview' : 'Preview as B&W printed page'}
-            className={`flex items-center gap-1 rounded px-2 py-1 text-[11px] transition hover:bg-white/10 ${
-              printPreview ? 'text-amber-300' : 'text-zinc-600 hover:text-zinc-200'
+            className={`flex items-center gap-1 rounded px-2 py-1 text-[11px] transition hover:bg-surface-2 ${
+              printPreview ? 'text-warn' : 'text-fg-3 hover:text-fg'
             }`}
           >
             <Printer size={12} />
@@ -392,7 +392,7 @@ export default function PDFPreview({
           {onDownload && (
             <button
               onClick={onDownload}
-              className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-zinc-600 transition hover:bg-white/10 hover:text-zinc-200"
+              className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-fg-3 transition hover:bg-surface-2 hover:text-fg"
             >
               <Download size={12} />
               PDF
@@ -403,9 +403,9 @@ export default function PDFPreview({
 
       {/* Print preview banner */}
       {printPreview && (
-        <div className="flex shrink-0 items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5">
-          <Printer size={12} className="shrink-0 text-amber-400" />
-          <span className="text-[11px] text-amber-300">
+        <div className="flex shrink-0 items-center gap-2 border-b border-warn/30 bg-warn/10 px-3 py-1.5">
+          <Printer size={12} className="shrink-0 text-warn" />
+          <span className="text-[11px] text-warn">
             Print Preview — showing how this looks on a B&W printer
           </span>
         </div>
@@ -416,15 +416,15 @@ export default function PDFPreview({
         ref={containerRef}
         className="flex-1 overflow-auto"
         style={{
-          background: darkPdf ? '#1e1e1e' : '#2a2a2a',
+          background: darkPdf ? 'var(--bg)' : 'var(--surface-2)',
         }}
       >
         {renderError ? (
           <div className="flex h-full flex-col items-center justify-center gap-2">
-            <FileText className="h-9 w-9 text-zinc-700" />
-            <p className="text-xs text-zinc-600">Failed to render PDF</p>
+            <FileText className="h-9 w-9 text-fg-3" />
+            <p className="text-xs text-fg-3">Failed to render PDF</p>
             {onDownload && (
-              <button onClick={onDownload} className="text-[11px] text-orange-400 hover:underline">
+              <button onClick={onDownload} className="text-[11px] text-accent-strong hover:underline">
                 Download to view
               </button>
             )}
@@ -436,7 +436,7 @@ export default function PDFPreview({
             onLoadError={() => setRenderError(true)}
             loading={
               <div className="flex h-32 items-center justify-center">
-                <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/10 border-t-orange-400" />
+                <div className="h-6 w-6 animate-spin rounded-full border-2 border-line border-t-accent" />
               </div>
             }
             className="flex min-w-max flex-col items-center gap-5 px-4 py-6"
@@ -445,7 +445,7 @@ export default function PDFPreview({
               <div
                 key={pageNum}
                 ref={(el) => { pageRefs.current[pageNum] = el }}
-                className="shadow-[0_4px_24px_rgba(0,0,0,0.5)] select-text"
+                className="shadow-[var(--shadow-2)] select-text"
                 style={{ lineHeight: 0, position: 'relative' }}
                 onClick={(e) => handlePageClick(e, pageNum)}
               >
@@ -476,10 +476,10 @@ export default function PDFPreview({
 
         {/* Color-dependency warnings (Feature 89B) */}
         {printPreview && colorWarnings.length > 0 && (
-          <div className="shrink-0 border-t border-amber-500/20 bg-[#111] px-4 py-3">
+          <div className="shrink-0 border-t border-warn/20 bg-surface px-4 py-3">
             <div className="mb-2 flex items-center gap-2">
-              <AlertTriangle size={13} className="text-amber-400" />
-              <span className="text-[11px] font-semibold text-amber-300">
+              <AlertTriangle size={13} className="text-warn" />
+              <span className="text-[11px] font-semibold text-warn">
                 Color-dependent elements detected — these may become invisible or lose meaning in grayscale print:
               </span>
             </div>
@@ -488,13 +488,13 @@ export default function PDFPreview({
                 <li key={i} className="flex items-baseline gap-2 text-[11px]">
                   <button
                     onClick={() => onJumpToLine?.(w.line)}
-                    className="shrink-0 rounded bg-amber-500/20 px-1.5 py-0.5 font-mono text-[10px] text-amber-400 hover:bg-amber-500/30 transition"
+                    className="shrink-0 rounded bg-warn/20 px-1.5 py-0.5 font-mono text-[10px] text-warn hover:bg-warn/30 transition"
                     title={`Jump to line ${w.line} in editor`}
                   >
                     L{w.line}
                   </button>
-                  <code className="font-mono text-amber-200">{w.command}</code>
-                  <span className="truncate text-zinc-500" title={w.context}>{w.context}</span>
+                  <code className="font-mono text-warn">{w.command}</code>
+                  <span className="truncate text-fg-3" title={w.context}>{w.context}</span>
                 </li>
               ))}
             </ul>

--- a/frontend/src/components/QrCodeInserter.tsx
+++ b/frontend/src/components/QrCodeInserter.tsx
@@ -109,22 +109,22 @@ export default function QrCodeInserter({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)]"
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full max-w-sm rounded-xl border border-white/[0.08] bg-[#0d0d0d] shadow-2xl">
+      <div className="w-full max-w-sm rounded-[var(--radius-lg)] border border-line bg-surface shadow-[var(--shadow-2)]">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-3">
+        <div className="flex items-center justify-between border-b border-line px-4 py-3">
           <div className="flex items-center gap-2">
-            <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-orange-500/15">
-              <QrCode size={13} className="text-orange-300" />
+            <div className="flex h-6 w-6 items-center justify-center rounded-[var(--radius-md)] bg-accent-soft">
+              <QrCode size={13} className="text-accent-strong" />
             </div>
-            <h2 className="text-sm font-semibold text-zinc-100">Insert QR Code</h2>
+            <h2 className="text-sm font-semibold text-fg">Insert QR Code</h2>
           </div>
           <button
             onClick={onClose}
             aria-label="Close"
-            className="rounded-lg p-1.5 text-zinc-600 transition hover:bg-white/[0.06] hover:text-zinc-300"
+            className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <X size={14} />
           </button>
@@ -133,7 +133,7 @@ export default function QrCodeInserter({
         <div className="space-y-4 p-4">
           {/* URL input */}
           <div>
-            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-500">
+            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.12em] text-fg-3">
               URL
             </label>
             <input
@@ -142,20 +142,20 @@ export default function QrCodeInserter({
               onChange={(e) => setUrl(e.target.value)}
               placeholder="https://linkedin.com/in/yourname"
               autoFocus
-              className={`w-full rounded-lg border bg-white/[0.03] px-3 py-2 text-sm text-zinc-100 outline-none placeholder:text-zinc-700 transition ${
+              className={`w-full rounded-[var(--radius-md)] border bg-surface-2 px-3 py-2 text-sm text-fg outline-none placeholder:text-fg-3 transition ${
                 url && !valid
-                  ? 'border-rose-400/40 focus:border-rose-400/60'
-                  : 'border-white/[0.06] focus:border-orange-400/30'
+                  ? 'border-err/40 focus:border-err/60'
+                  : 'border-line focus:border-accent/30'
               }`}
             />
             {url && !valid && (
-              <p className="mt-1 text-[10px] text-rose-400">Enter a valid https:// URL</p>
+              <p className="mt-1 text-[10px] text-err">Enter a valid https:// URL</p>
             )}
           </div>
 
           {/* Size selector */}
           <div>
-            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-500">
+            <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.12em] text-fg-3">
               Size
             </label>
             <div className="flex gap-2">
@@ -163,36 +163,36 @@ export default function QrCodeInserter({
                 <button
                   key={s}
                   onClick={() => setSize(s)}
-                  className={`flex-1 rounded-lg border py-1.5 text-[11px] font-medium transition ${
+                  className={`flex-1 rounded-[var(--radius-md)] border py-1.5 text-[11px] font-medium transition ${
                     size === s
-                      ? 'border-orange-400/30 bg-orange-500/10 text-orange-200'
-                      : 'border-white/[0.06] text-zinc-500 hover:border-white/[0.10] hover:text-zinc-300'
+                      ? 'border-accent bg-accent-soft text-accent-strong'
+                      : 'border-line text-fg-3 hover:border-line-2 hover:text-fg-2'
                   }`}
                 >
                   {s.charAt(0).toUpperCase() + s.slice(1)}
                 </button>
               ))}
             </div>
-            <p className="mt-1 text-[10px] text-zinc-700">{SIZE_LABELS[size]}</p>
+            <p className="mt-1 text-[10px] text-fg-3">{SIZE_LABELS[size]}</p>
           </div>
 
           {/* Preview */}
-          <div className="flex items-center justify-center rounded-lg border border-white/[0.06] bg-black/30 p-4 min-h-[140px]">
+          <div className="flex items-center justify-center rounded-[var(--radius-md)] border border-line bg-surface-2 p-4 min-h-[140px]">
             {valid ? (
               <canvas ref={canvasRef} width={120} height={120} />
             ) : (
               <div className="flex flex-col items-center gap-2 text-center">
                 <canvas ref={canvasRef} width={120} height={120} className="hidden" />
-                <QrCode size={32} className="text-zinc-800" />
-                <p className="text-[11px] text-zinc-700">Enter a URL to preview</p>
+                <QrCode size={32} className="text-fg-3" />
+                <p className="text-[11px] text-fg-3">Enter a URL to preview</p>
               </div>
             )}
           </div>
 
           {/* LaTeX preview */}
           {valid && (
-            <div className="rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2">
-              <p className="font-mono text-[11px] text-zinc-500">
+            <div className="rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2">
+              <p className="font-mono text-[11px] text-fg-3">
                 {`\\qrcode[height=${SIZE_CM[size]}]{\\detokenize{${url.length > 35 ? url.slice(0, 35) + '…' : url}}}`}
               </p>
             </div>
@@ -202,14 +202,14 @@ export default function QrCodeInserter({
           <div className="flex gap-2 pt-1">
             <button
               onClick={onClose}
-              className="flex-1 rounded-lg border border-white/[0.06] py-2 text-xs font-semibold text-zinc-500 transition hover:text-zinc-300"
+              className="flex-1 rounded-[var(--radius-md)] border border-line py-2 text-xs font-semibold text-fg-3 transition hover:text-fg-2"
             >
               Cancel
             </button>
             <button
               onClick={handleInsert}
               disabled={!valid}
-              className="flex-1 rounded-lg bg-orange-500/20 py-2 text-xs font-semibold text-orange-200 ring-1 ring-orange-400/20 transition hover:bg-orange-500/30 disabled:opacity-40 disabled:cursor-not-allowed"
+              className="flex-1 rounded-[var(--radius-md)] bg-accent-soft py-2 text-xs font-semibold text-accent-strong ring-1 ring-accent transition hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Insert
             </button>

--- a/frontend/src/components/SaveCheckpointPopover.tsx
+++ b/frontend/src/components/SaveCheckpointPopover.tsx
@@ -70,7 +70,7 @@ export default function SaveCheckpointPopover({
     <div className="relative" ref={containerRef}>
       <button
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-1.5 text-xs text-zinc-400 transition hover:border-white/20 hover:text-zinc-200"
+        className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line px-3 py-1.5 text-xs text-fg-2 transition hover:border-line-2 hover:text-fg"
         title="Save checkpoint"
       >
         <Bookmark size={13} />
@@ -78,8 +78,8 @@ export default function SaveCheckpointPopover({
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-1.5 w-64 rounded-xl border border-white/10 bg-zinc-900 p-3 shadow-xl">
-          <p className="mb-2 text-[11px] font-medium text-zinc-400">
+        <div className="absolute right-0 top-full z-50 mt-1.5 w-64 rounded-[var(--radius-lg)] border border-line bg-surface p-3 shadow-[var(--shadow-2)]">
+          <p className="mb-2 text-[11px] font-medium text-fg-2">
             Name this checkpoint
           </p>
           <input
@@ -91,23 +91,23 @@ export default function SaveCheckpointPopover({
               if (e.key === 'Enter') handleSave()
             }}
             placeholder="e.g. Before rewrite"
-            className="mb-2 w-full rounded-lg border border-white/10 bg-black/40 px-2.5 py-1.5 text-xs text-white outline-none transition placeholder:text-zinc-600 focus:border-orange-300/40"
+            className="mb-2 w-full rounded-[var(--radius-md)] border border-line bg-bg px-2.5 py-1.5 text-xs text-fg outline-none transition placeholder:text-fg-3 focus:border-accent"
           />
           <div className="flex items-center justify-between">
-            <span className="text-[10px] text-zinc-600">
+            <span className="text-[10px] text-fg-3">
               {label.length}/100
             </span>
             <div className="flex gap-1.5">
               <button
                 onClick={() => setOpen(false)}
-                className="rounded-md px-2.5 py-1 text-[11px] text-zinc-500 transition hover:text-zinc-300"
+                className="rounded-[var(--radius-md)] px-2.5 py-1 text-[11px] text-fg-3 transition hover:text-fg-2"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSave}
                 disabled={!label.trim() || saving}
-                className="rounded-md bg-orange-300/15 px-2.5 py-1 text-[11px] font-medium text-orange-200 transition hover:bg-orange-300/25 disabled:opacity-40"
+                className="rounded-[var(--radius-md)] bg-accent-soft px-2.5 py-1 text-[11px] font-medium text-accent-strong border border-accent transition hover:brightness-110 disabled:opacity-40"
               >
                 {saving ? 'Saving…' : 'Save'}
               </button>

--- a/frontend/src/components/TikZEditor.tsx
+++ b/frontend/src/components/TikZEditor.tsx
@@ -104,8 +104,8 @@ function TabBtn({
     <button
       key={id}
       onClick={onClick}
-      className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium transition ${
-        active ? 'bg-violet-500/20 text-violet-300' : 'text-zinc-500 hover:text-zinc-300'
+      className={`flex items-center gap-1.5 rounded-[var(--radius-md)] px-3 py-1.5 text-[11px] font-medium transition ${
+        active ? 'bg-accent-soft text-accent-strong' : 'text-fg-3 hover:text-fg-2'
       }`}
     >
       <Icon size={11} />
@@ -144,17 +144,17 @@ function TimelineTab({
       {entries.map((e, i) => (
         <div
           key={i}
-          className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3"
+          className="rounded-[var(--radius-md)] border border-line bg-surface p-3"
         >
           <div className="mb-2 flex items-center gap-1">
-            <button onClick={() => move(i, -1)} className="rounded p-0.5 text-zinc-600 hover:text-zinc-300">
+            <button onClick={() => move(i, -1)} className="rounded p-0.5 text-fg-3 hover:text-fg-2">
               <ChevronUp size={11} />
             </button>
-            <button onClick={() => move(i, 1)} className="rounded p-0.5 text-zinc-600 hover:text-zinc-300">
+            <button onClick={() => move(i, 1)} className="rounded p-0.5 text-fg-3 hover:text-fg-2">
               <ChevronDown size={11} />
             </button>
             <span className="ml-auto">
-              <button onClick={() => remove(i)} className="rounded p-0.5 text-zinc-700 hover:text-red-400">
+              <button onClick={() => remove(i)} className="rounded p-0.5 text-fg-3 hover:text-err">
                 <Trash2 size={11} />
               </button>
             </span>
@@ -224,11 +224,11 @@ function SkillBarsTab({
               step={1}
               value={s.level}
               onChange={(e) => update(i, { level: Number(e.target.value) })}
-              className="w-20 accent-violet-500"
+              className="w-20 accent-accent"
             />
-            <span className="w-5 text-center text-[10px] tabular-nums text-zinc-400">{s.level}</span>
+            <span className="w-5 text-center text-[10px] tabular-nums text-fg-2">{s.level}</span>
           </div>
-          <button onClick={() => remove(i)} className="text-zinc-700 hover:text-red-400">
+          <button onClick={() => remove(i)} className="text-fg-3 hover:text-err">
             <Trash2 size={11} />
           </button>
         </div>
@@ -275,25 +275,25 @@ function FlowCanvas({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
-        <span className="text-[10px] text-zinc-500">Add:</span>
+        <span className="text-[10px] text-fg-3">Add:</span>
         {(['rect', 'diamond', 'circle'] as ShapeType[]).map((s) => (
           <button
             key={s}
             onClick={() => setNextShape(s)}
             className={`rounded px-2 py-0.5 text-[9px] font-medium transition ${
               nextShape === s
-                ? 'bg-violet-500/20 text-violet-300 ring-1 ring-violet-400/30'
-                : 'text-zinc-500 hover:text-zinc-300'
+                ? 'bg-accent-soft text-accent-strong ring-1 ring-accent'
+                : 'text-fg-3 hover:text-fg-2'
             }`}
           >
             {s}
           </button>
         ))}
-        <button onClick={addNode} className="ml-auto flex items-center gap-1 rounded bg-violet-500/15 px-2 py-0.5 text-[9px] text-violet-300 ring-1 ring-violet-400/20 hover:bg-violet-500/25">
+        <button onClick={addNode} className="ml-auto flex items-center gap-1 rounded bg-accent-soft px-2 py-0.5 text-[9px] text-accent-strong ring-1 ring-accent hover:brightness-110">
           <Plus size={9} /> Add node
         </button>
       </div>
-      <div className="h-[240px] rounded-lg border border-white/[0.06] bg-zinc-950 overflow-hidden">
+      <div className="h-[240px] rounded-[var(--radius-md)] border border-line bg-bg overflow-hidden">
         <ReactFlow
           nodes={nodes}
           edges={edges}
@@ -308,7 +308,7 @@ function FlowCanvas({
         </ReactFlow>
       </div>
       {bidirectional && (
-        <p className="text-[9px] text-zinc-600">Network mode: all edges are bidirectional.</p>
+        <p className="text-[9px] text-fg-3">Network mode: all edges are bidirectional.</p>
       )}
     </div>
   )
@@ -317,10 +317,10 @@ function FlowCanvas({
 // ── Shared styles ─────────────────────────────────────────────────────────────
 
 const inputCls =
-  'rounded border border-white/[0.06] bg-black/30 px-2 py-1 text-[11px] text-zinc-200 outline-none focus:border-violet-500/30 w-full'
+  'rounded border border-line bg-surface-2 px-2 py-1 text-[11px] text-fg outline-none focus:border-accent w-full'
 
 const addBtnCls =
-  'flex items-center gap-1 rounded border border-dashed border-white/[0.08] px-3 py-1.5 text-[10px] text-zinc-600 transition hover:border-violet-400/30 hover:text-violet-300'
+  'flex items-center gap-1 rounded border border-dashed border-line px-3 py-1.5 text-[10px] text-fg-3 transition hover:border-accent hover:text-accent-strong'
 
 // ── Main component ────────────────────────────────────────────────────────────
 
@@ -420,7 +420,7 @@ export default function TikZEditor({ onInsert, onPreview }: Props) {
   return (
     <div className="flex h-full flex-col gap-0 overflow-hidden">
       {/* Tab strip */}
-      <div className="flex shrink-0 gap-0.5 border-b border-white/[0.05] bg-black/10 px-2 py-1.5">
+      <div className="flex shrink-0 gap-0.5 border-b border-line bg-surface px-2 py-1.5">
         {tabs.map((t) => (
           <TabBtn
             key={t.id}
@@ -464,10 +464,10 @@ export default function TikZEditor({ onInsert, onPreview }: Props) {
       </div>
 
       {/* Live TikZ code preview */}
-      <div className="shrink-0 border-t border-white/[0.05]">
-        <div className="flex items-center gap-1.5 bg-black/20 px-3 py-1.5">
-          <Code2 size={10} className="text-zinc-600" />
-          <span className="text-[10px] text-zinc-500">Generated TikZ</span>
+      <div className="shrink-0 border-t border-line">
+        <div className="flex items-center gap-1.5 bg-surface px-3 py-1.5">
+          <Code2 size={10} className="text-fg-3" />
+          <span className="text-[10px] text-fg-3">Generated TikZ</span>
         </div>
         <div className="h-[160px]">
           <Editor
@@ -492,19 +492,19 @@ export default function TikZEditor({ onInsert, onPreview }: Props) {
       </div>
 
       {/* Action buttons */}
-      <div className="flex shrink-0 items-center gap-2 border-t border-white/[0.05] px-3 py-2">
+      <div className="flex shrink-0 items-center gap-2 border-t border-line px-3 py-2">
         <button
           onClick={handleCopy}
-          className="flex items-center gap-1.5 rounded px-2.5 py-1 text-[10px] text-zinc-500 transition hover:text-zinc-300"
+          className="flex items-center gap-1.5 rounded px-2.5 py-1 text-[10px] text-fg-3 transition hover:text-fg-2"
         >
-          {copied ? <Check size={10} className="text-emerald-400" /> : <Copy size={10} />}
+          {copied ? <Check size={10} className="text-ok" /> : <Copy size={10} />}
           {copied ? 'Copied!' : 'Copy TikZ'}
         </button>
         {onPreview && (
           <button
             onClick={handlePreview}
             disabled={previewing}
-            className="flex items-center gap-1.5 rounded px-2.5 py-1 text-[10px] text-zinc-500 transition hover:text-zinc-300 disabled:opacity-40"
+            className="flex items-center gap-1.5 rounded px-2.5 py-1 text-[10px] text-fg-3 transition hover:text-fg-2 disabled:opacity-40"
           >
             {previewing ? <Loader2 size={10} className="animate-spin" /> : null}
             Preview
@@ -512,7 +512,7 @@ export default function TikZEditor({ onInsert, onPreview }: Props) {
         )}
         <button
           onClick={() => onInsert(`\n${tikzCode}\n`)}
-          className="ml-auto flex items-center gap-1.5 rounded bg-violet-500/20 px-3 py-1 text-[10px] font-medium text-violet-300 ring-1 ring-violet-400/20 transition hover:bg-violet-500/30"
+          className="ml-auto flex items-center gap-1.5 rounded bg-accent-soft px-3 py-1 text-[10px] font-medium text-accent-strong ring-1 ring-accent transition hover:brightness-110"
         >
           Insert into Document
         </button>

--- a/frontend/src/components/WYSIWYGEditor.tsx
+++ b/frontend/src/components/WYSIWYGEditor.tsx
@@ -28,10 +28,10 @@ function Field({
   multiline?: boolean
 }) {
   const cls =
-    'w-full rounded border border-white/[0.08] bg-black/30 px-2 py-1 text-[11px] text-zinc-200 outline-none placeholder:text-zinc-700 focus:border-violet-500/40 focus:ring-1 focus:ring-violet-500/20'
+    'w-full rounded border border-line bg-bg px-2 py-1 text-[11px] text-fg outline-none placeholder:text-fg-3 focus:border-accent focus:ring-1 focus:ring-accent'
   return (
     <div className="flex flex-col gap-0.5">
-      <label className="text-[9px] font-semibold uppercase tracking-[0.12em] text-zinc-700">
+      <label className="text-[9px] font-semibold uppercase tracking-[0.12em] text-fg-3">
         {label}
       </label>
       {multiline ? (
@@ -75,18 +75,18 @@ function EntryCard({
   const removeBullet = (i: number) => upd({ bullets: entry.bullets.filter((_, j) => j !== i) })
 
   return (
-    <div className="group relative rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+    <div className="group relative rounded-[var(--radius-md)] border border-line bg-surface p-3">
       <button
         onClick={onRemove}
-        className="absolute right-2 top-2 hidden rounded p-0.5 text-zinc-700 transition hover:bg-red-500/20 hover:text-red-400 group-hover:flex"
+        className="absolute right-2 top-2 hidden rounded p-0.5 text-fg-3 transition hover:bg-err/20 hover:text-err group-hover:flex"
       >
         <Trash2 size={11} />
       </button>
 
       {/* Type badge */}
       <div className="mb-2 flex items-center gap-1.5">
-        <GripVertical size={11} className="text-zinc-800" />
-        <span className="rounded bg-white/[0.05] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-zinc-600">
+        <GripVertical size={11} className="text-fg-3" />
+        <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-fg-3">
           {entry.type}
         </span>
       </div>
@@ -123,22 +123,22 @@ function EntryCard({
 
           {/* Bullets */}
           <div>
-            <div className="mb-1 text-[9px] font-semibold uppercase tracking-[0.12em] text-zinc-700">
+            <div className="mb-1 text-[9px] font-semibold uppercase tracking-[0.12em] text-fg-3">
               Bullets
             </div>
             <div className="space-y-1">
               {entry.bullets.map((b, i) => (
                 <div key={i} className="flex items-start gap-1">
-                  <span className="mt-1.5 text-zinc-800">•</span>
+                  <span className="mt-1.5 text-fg-3">•</span>
                   <input
                     value={b}
                     onChange={(e) => updBullet(i, e.target.value)}
-                    className="flex-1 rounded border border-white/[0.06] bg-black/20 px-2 py-1 text-[11px] text-zinc-300 outline-none focus:border-violet-500/30"
+                    className="flex-1 rounded border border-line bg-bg px-2 py-1 text-[11px] text-fg-2 outline-none focus:border-accent"
                     placeholder="Bullet point…"
                   />
                   <button
                     onClick={() => removeBullet(i)}
-                    className="mt-0.5 rounded p-0.5 text-zinc-800 transition hover:text-red-400"
+                    className="mt-0.5 rounded p-0.5 text-fg-3 transition hover:text-err"
                   >
                     <Trash2 size={10} />
                   </button>
@@ -147,7 +147,7 @@ function EntryCard({
             </div>
             <button
               onClick={addBullet}
-              className="mt-1.5 flex items-center gap-1 text-[10px] text-zinc-700 transition hover:text-zinc-400"
+              className="mt-1.5 flex items-center gap-1 text-[10px] text-fg-3 transition hover:text-fg-2"
             >
               <Plus size={10} />
               Add bullet
@@ -192,12 +192,12 @@ function SectionCard({
   }
 
   return (
-    <div className="rounded-xl border border-white/[0.05] bg-white/[0.01] p-4">
+    <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-4">
       <div className="mb-3 flex items-center justify-between">
         <input
           value={section.title}
           onChange={(e) => onChange({ ...section, title: e.target.value })}
-          className="flex-1 rounded border border-transparent bg-transparent px-1 py-0.5 text-[13px] font-bold text-zinc-200 outline-none hover:border-white/[0.08] focus:border-violet-500/40"
+          className="flex-1 rounded border border-transparent bg-transparent px-1 py-0.5 text-[13px] font-bold text-fg outline-none hover:border-line focus:border-accent"
           placeholder="Section Title"
         />
       </div>
@@ -218,7 +218,7 @@ function SectionCard({
           <button
             key={type}
             onClick={() => addEntry(type)}
-            className="flex items-center gap-1 rounded-md border border-white/[0.06] bg-white/[0.02] px-2 py-1 text-[10px] text-zinc-600 transition hover:border-violet-500/30 hover:text-zinc-400"
+            className="flex items-center gap-1 rounded-[var(--radius-md)] border border-line bg-surface px-2 py-1 text-[10px] text-fg-3 transition hover:border-accent hover:text-fg-2"
           >
             <Plus size={10} />
             {type === 'subheading' ? 'Job / Education' : type === 'project' ? 'Project' : 'Bullet list'}
@@ -254,7 +254,7 @@ export default function WYSIWYGEditor({ doc, onChange, hasRawEntries }: WYSIWYGE
   return (
     <div className="flex flex-col gap-4">
       {hasRawEntries && (
-        <div className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-300">
+        <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-warn/20 bg-warn/10 px-3 py-2 text-[11px] text-warn">
           <AlertTriangle size={12} />
           Some blocks could not be parsed and are shown as raw LaTeX. They will be preserved as-is.
         </div>
@@ -270,7 +270,7 @@ export default function WYSIWYGEditor({ doc, onChange, hasRawEntries }: WYSIWYGE
 
       <button
         onClick={addSection}
-        className="flex items-center justify-center gap-1.5 rounded-xl border border-dashed border-white/[0.08] py-3 text-[11px] text-zinc-700 transition hover:border-violet-500/30 hover:text-zinc-500"
+        className="flex items-center justify-center gap-1.5 rounded-[var(--radius-lg)] border border-dashed border-line py-3 text-[11px] text-fg-3 transition hover:border-accent hover:text-fg-2"
       >
         <Plus size={12} />
         Add Section

--- a/frontend/src/components/WatermarkDownloadPopover.tsx
+++ b/frontend/src/components/WatermarkDownloadPopover.tsx
@@ -84,7 +84,7 @@ export default function WatermarkDownloadPopover({
         onClick={() => setOpen((o) => !o)}
         disabled={loading}
         title="Download with Watermark"
-        className="flex items-center gap-1 px-2 py-1 text-[10px] text-zinc-600 transition hover:text-zinc-300 disabled:opacity-50"
+        className="flex items-center gap-1 px-2 py-1 text-[10px] text-fg-3 transition hover:text-fg-2 disabled:opacity-50"
       >
         {loading ? <Loader2 size={11} className="animate-spin" /> : <Stamp size={11} />}
         Watermark
@@ -98,8 +98,8 @@ export default function WatermarkDownloadPopover({
             onClick={() => setOpen(false)}
           />
           {/* Popover */}
-          <div className="absolute right-0 z-50 mt-1 w-56 rounded-xl border border-white/[0.08] bg-[#0d0d0d] p-3 shadow-2xl">
-            <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+          <div className="absolute right-0 z-50 mt-1 w-56 rounded-[var(--radius-lg)] border border-line bg-surface p-3 shadow-[var(--shadow-2)]">
+            <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-fg-3">
               Watermark text
             </p>
 
@@ -109,7 +109,7 @@ export default function WatermarkDownloadPopover({
                 <button
                   key={preset}
                   onClick={() => triggerDownload(preset)}
-                  className="rounded-md px-2.5 py-1.5 text-left text-[11px] font-medium text-zinc-300 transition hover:bg-white/[0.06]"
+                  className="rounded-[var(--radius-md)] px-2.5 py-1.5 text-left text-[11px] font-medium text-fg-2 transition hover:bg-surface-2"
                 >
                   {preset}
                 </button>
@@ -117,7 +117,7 @@ export default function WatermarkDownloadPopover({
             </div>
 
             {/* Divider */}
-            <div className="my-2 border-t border-white/[0.06]" />
+            <div className="my-2 border-t border-line" />
 
             {/* Custom input */}
             <div className="flex gap-1.5">
@@ -128,17 +128,17 @@ export default function WatermarkDownloadPopover({
                 onChange={(e) => setCustom(e.target.value)}
                 onKeyDown={(e) => { if (e.key === 'Enter') handleCustomDownload() }}
                 placeholder="Custom…"
-                className="min-w-0 flex-1 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[11px] text-zinc-200 placeholder-zinc-600 outline-none focus:border-white/[0.15]"
+                className="min-w-0 flex-1 rounded-[var(--radius-md)] border border-line bg-surface-2 px-2 py-1 text-[11px] text-fg placeholder-fg-3 outline-none focus:border-line-2"
               />
               <button
                 onClick={handleCustomDownload}
                 disabled={!custom.trim()}
-                className="rounded-md bg-white/[0.06] px-2 py-1 text-[10px] font-semibold text-zinc-300 transition hover:bg-white/[0.10] disabled:opacity-40"
+                className="rounded-[var(--radius-md)] bg-surface-2 px-2 py-1 text-[10px] font-semibold text-fg-2 transition hover:brightness-110 disabled:opacity-40"
               >
                 ↓
               </button>
             </div>
-            <p className="mt-1.5 text-[9px] text-zinc-600">
+            <p className="mt-1.5 text-[9px] text-fg-3">
               Letters, digits, spaces, hyphens, dots · max {MAX_LEN} chars
             </p>
           </div>

--- a/frontend/src/components/builder/BuilderPreview.tsx
+++ b/frontend/src/components/builder/BuilderPreview.tsx
@@ -15,20 +15,20 @@ interface BuilderPreviewProps {
 function headerAccent(templateFamily: string) {
   switch (templateFamily) {
     case 'executive':
-      return 'from-zinc-100/70 via-zinc-200/35 to-transparent'
+      return 'from-black/10 via-black/[0.04] to-transparent'
     case 'ats':
-      return 'from-emerald-200/80 via-emerald-300/35 to-transparent'
+      return 'from-[var(--accent-soft)] via-[var(--accent-soft)] to-transparent'
     case 'minimal':
-      return 'from-orange-200/70 via-orange-300/35 to-transparent'
+      return 'from-[var(--accent-soft)] via-[var(--accent-soft)] to-transparent'
     default:
-      return 'from-sky-200/70 via-sky-300/35 to-transparent'
+      return 'from-[var(--accent-soft)] via-[var(--accent-soft)] to-transparent'
   }
 }
 
 function statTone(value: number) {
-  if (value >= 85) return 'text-emerald-200 border-emerald-300/20 bg-emerald-300/[0.08]'
-  if (value >= 65) return 'text-amber-100 border-amber-300/20 bg-amber-300/[0.08]'
-  return 'text-rose-100 border-rose-300/20 bg-rose-300/[0.08]'
+  if (value >= 85) return 'text-ok border-ok bg-surface-2'
+  if (value >= 65) return 'text-warn border-warn bg-surface-2'
+  return 'text-err border-err bg-surface-2'
 }
 
 export default function BuilderPreview({
@@ -45,12 +45,12 @@ export default function BuilderPreview({
   const activeSections = structured.section_order.filter(section => !structured.hidden_sections.includes(section))
 
   return (
-    <div className="surface-panel edge-highlight sticky top-24 overflow-hidden">
-      <div className="border-b border-white/10 px-5 py-4">
+    <div className="rounded-[var(--radius-lg)] border border-line bg-surface sticky top-24 overflow-hidden">
+      <div className="border-b border-line px-5 py-4">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <p className="text-[10px] uppercase tracking-[0.24em] text-zinc-500">Live Preview</p>
-            <p className="mt-2 text-sm text-zinc-300">
+            <p className="text-[10px] uppercase tracking-[0.24em] text-fg-3">Live Preview</p>
+            <p className="mt-2 text-sm text-fg-2">
               Render-safe snapshot of the structured resume that will drive generated LaTeX.
             </p>
           </div>
@@ -60,17 +60,17 @@ export default function BuilderPreview({
         </div>
 
         <div className="mt-4 grid gap-3 sm:grid-cols-3">
-          <div className="rounded-2xl border border-white/8 bg-black/20 px-3 py-3">
-            <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Template</p>
-            <p className="mt-2 text-sm font-semibold text-white">{templateFamily}</p>
+          <div className="rounded-[var(--radius-lg)] border border-line bg-surface-2 px-3 py-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-fg-3">Template</p>
+            <p className="mt-2 text-sm font-semibold text-fg">{templateFamily}</p>
           </div>
-          <div className="rounded-2xl border border-white/8 bg-black/20 px-3 py-3">
-            <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Page Target</p>
-            <p className="mt-2 text-sm font-semibold text-white">{pageEstimate} page{pageEstimate === 1 ? '' : 's'}</p>
+          <div className="rounded-[var(--radius-lg)] border border-line bg-surface-2 px-3 py-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-fg-3">Page Target</p>
+            <p className="mt-2 text-sm font-semibold text-fg">{pageEstimate} page{pageEstimate === 1 ? '' : 's'}</p>
           </div>
-          <div className="rounded-2xl border border-white/8 bg-black/20 px-3 py-3">
-            <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Visible Sections</p>
-            <p className="mt-2 text-sm font-semibold text-white">{sectionCount || activeSections.length}</p>
+          <div className="rounded-[var(--radius-lg)] border border-line bg-surface-2 px-3 py-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-fg-3">Visible Sections</p>
+            <p className="mt-2 text-sm font-semibold text-fg">{sectionCount || activeSections.length}</p>
           </div>
         </div>
 
@@ -79,7 +79,7 @@ export default function BuilderPreview({
             {activeSections.map(section => (
               <span
                 key={section}
-                className="rounded-full border border-white/8 bg-white/[0.04] px-2.5 py-1 text-[11px] uppercase tracking-[0.16em] text-zinc-400"
+                className="rounded-full border border-line bg-surface-2 px-2.5 py-1 text-[11px] uppercase tracking-[0.16em] text-fg-2"
               >
                 {section.replace('_', ' ')}
               </span>
@@ -88,9 +88,9 @@ export default function BuilderPreview({
         ) : null}
 
         {!!warnings.length && (
-          <div className="mt-4 rounded-2xl border border-amber-300/15 bg-amber-300/[0.06] px-4 py-3">
-            <p className="text-[10px] uppercase tracking-[0.18em] text-amber-100/75">Preview warnings</p>
-            <ul className="mt-2 space-y-1 text-xs text-amber-50/90">
+          <div className="mt-4 rounded-[var(--radius-lg)] border border-warn bg-surface-2 px-4 py-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-warn">Preview warnings</p>
+            <ul className="mt-2 space-y-1 text-xs text-fg-2">
               {warnings.slice(0, 2).map(warning => (
                 <li key={warning}>• {warning}</li>
               ))}
@@ -98,7 +98,7 @@ export default function BuilderPreview({
           </div>
         )}
 
-        <div className="mt-5 rounded-[28px] border border-white/8 bg-[#f7f4ef] p-6 text-[#171717] shadow-[0_24px_80px_rgba(0,0,0,0.24)]">
+        <div className="mt-5 rounded-[var(--radius-lg)] border border-line bg-[#f7f4ef] p-6 text-[#171717] shadow-[var(--shadow-2)]">
           <div className={`border-b border-black/8 bg-gradient-to-r ${headerAccent(templateFamily)} pb-4`}>
             <h2 className="text-2xl font-semibold tracking-tight text-[#111111]">
               {basics.name || title || 'Untitled Resume'}
@@ -142,7 +142,7 @@ export default function BuilderPreview({
                 </section>
               ))
             ) : (
-              <div className="rounded-2xl border border-dashed border-black/10 bg-white/50 px-4 py-6 text-center text-sm text-[#696969]">
+              <div className="rounded-[var(--radius-lg)] border border-dashed border-black/10 bg-white/50 px-4 py-6 text-center text-sm text-[#696969]">
                 Start filling the builder to generate a live preview.
               </div>
             )}

--- a/frontend/src/components/help/HelpCenter.tsx
+++ b/frontend/src/components/help/HelpCenter.tsx
@@ -225,11 +225,11 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
 
   const getCategoryColor = (color: string) => {
     const colors = {
-      blue: 'bg-blue-50 text-blue-700 border-blue-200',
-      green: 'bg-green-50 text-green-700 border-green-200',
-      purple: 'bg-purple-50 text-purple-700 border-purple-200',
-      red: 'bg-red-50 text-red-700 border-red-200',
-      orange: 'bg-orange-50 text-orange-700 border-orange-200'
+      blue: 'bg-accent-soft text-accent-strong border-accent',
+      green: 'bg-accent-soft text-accent-strong border-accent',
+      purple: 'bg-accent-soft text-accent-strong border-accent',
+      red: 'bg-accent-soft text-accent-strong border-accent',
+      orange: 'bg-accent-soft text-accent-strong border-accent'
     }
     return colors[color as keyof typeof colors] || colors.blue
   }
@@ -237,27 +237,27 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-[var(--overlay)] flex items-center justify-center z-50 p-4">
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.9 }}
-        className="bg-white rounded-2xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col"
+        className="bg-surface rounded-[var(--radius-lg)] shadow-[var(--shadow-2)] max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col"
       >
         {/* Header */}
-        <div className="p-6 border-b border-secondary-200 bg-gradient-to-r from-primary-50 to-blue-50">
+        <div className="p-6 border-b border-line bg-surface-2">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-2xl font-bold text-secondary-900 mb-2">
+              <h2 className="text-2xl font-bold text-fg mb-2">
                 Help Center
               </h2>
-              <p className="text-secondary-600">
+              <p className="text-fg-2">
                 Find answers to common questions and get help with Latexy
               </p>
             </div>
             <button
               onClick={onClose}
-              className="text-secondary-400 hover:text-secondary-600 text-xl font-semibold"
+              className="text-fg-3 hover:text-fg-2 text-xl font-semibold"
             >
               ×
             </button>
@@ -265,29 +265,29 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
 
           {/* Search */}
           <div className="mt-4 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-secondary-400 w-5 h-5" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-fg-3 w-5 h-5" />
             <input
               type="text"
               placeholder="Search for help..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-3 border border-secondary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              className="w-full pl-10 pr-4 py-3 border border-line rounded-[var(--radius-md)] focus:ring-2 focus:ring-accent focus:border-transparent"
             />
           </div>
         </div>
 
         <div className="flex flex-1 overflow-hidden">
           {/* Sidebar */}
-          <div className="w-80 border-r border-secondary-200 bg-secondary-50 overflow-y-auto">
+          <div className="w-80 border-r border-line bg-surface-2 overflow-y-auto">
             <div className="p-4">
-              <h3 className="font-semibold text-secondary-900 mb-3">Categories</h3>
+              <h3 className="font-semibold text-fg mb-3">Categories</h3>
               <div className="space-y-2">
                 <button
                   onClick={() => setSelectedCategory(null)}
-                  className={`w-full text-left p-3 rounded-lg transition-colors ${
+                  className={`w-full text-left p-3 rounded-[var(--radius-md)] transition-colors ${
                     selectedCategory === null
-                      ? 'bg-primary-100 text-primary-700 border border-primary-200'
-                      : 'hover:bg-secondary-100'
+                      ? 'bg-accent-soft text-accent-strong border border-accent'
+                      : 'hover:bg-surface-2'
                   }`}
                 >
                   <div className="flex items-center gap-3">
@@ -300,10 +300,10 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
                   <button
                     key={category.id}
                     onClick={() => setSelectedCategory(category.id)}
-                    className={`w-full text-left p-3 rounded-lg transition-colors border ${
+                    className={`w-full text-left p-3 rounded-[var(--radius-md)] transition-colors border ${
                       selectedCategory === category.id
                         ? getCategoryColor(category.color)
-                        : 'hover:bg-secondary-100 border-transparent'
+                        : 'hover:bg-surface-2 border-transparent'
                     }`}
                   >
                     <div className="flex items-center gap-3">
@@ -318,26 +318,26 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
               </div>
 
               {/* Contact Support */}
-              <div className="mt-6 p-4 bg-white rounded-lg border border-secondary-200">
-                <h4 className="font-semibold text-secondary-900 mb-2">Need More Help?</h4>
+              <div className="mt-6 p-4 bg-surface rounded-[var(--radius-md)] border border-line">
+                <h4 className="font-semibold text-fg mb-2">Need More Help?</h4>
                 <div className="space-y-2">
                   <a
                     href="mailto:support@latexy.com"
-                    className="flex items-center gap-2 text-sm text-secondary-600 hover:text-primary-600"
+                    className="flex items-center gap-2 text-sm text-fg-2 hover:text-accent-strong"
                   >
                     <Mail className="w-4 h-4" />
                     Email Support
                   </a>
                   <a
                     href="/contact"
-                    className="flex items-center gap-2 text-sm text-secondary-600 hover:text-primary-600"
+                    className="flex items-center gap-2 text-sm text-fg-2 hover:text-accent-strong"
                   >
                     <MessageCircle className="w-4 h-4" />
                     Live Chat
                   </a>
                   <a
                     href="/documentation"
-                    className="flex items-center gap-2 text-sm text-secondary-600 hover:text-primary-600"
+                    className="flex items-center gap-2 text-sm text-fg-2 hover:text-accent-strong"
                   >
                     <ExternalLink className="w-4 h-4" />
                     Documentation
@@ -351,18 +351,18 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
           <div className="flex-1 overflow-y-auto">
             <div className="p-6">
               {searchQuery && (
-                <div className="mb-4 text-sm text-secondary-600">
+                <div className="mb-4 text-sm text-fg-2">
                   Found {filteredFAQs.length} result{filteredFAQs.length !== 1 ? 's' : ''} for "{searchQuery}"
                 </div>
               )}
 
               {filteredFAQs.length === 0 ? (
                 <div className="text-center py-12">
-                  <Search className="w-12 h-12 text-secondary-300 mx-auto mb-4" />
-                  <h3 className="text-lg font-semibold text-secondary-900 mb-2">
+                  <Search className="w-12 h-12 text-fg-3 mx-auto mb-4" />
+                  <h3 className="text-lg font-semibold text-fg mb-2">
                     No results found
                   </h3>
-                  <p className="text-secondary-600 mb-4">
+                  <p className="text-fg-2 mb-4">
                     Try adjusting your search terms or browse categories
                   </p>
                   <button
@@ -370,7 +370,7 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
                       setSearchQuery('')
                       setSelectedCategory(null)
                     }}
-                    className="btn-outline"
+                    className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-sm text-fg hover:bg-surface-2"
                   >
                     Clear Search
                   </button>
@@ -382,20 +382,20 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
                       key={faq.id}
                       initial={{ opacity: 0, y: 20 }}
                       animate={{ opacity: 1, y: 0 }}
-                      className="border border-secondary-200 rounded-lg overflow-hidden"
+                      className="border border-line rounded-[var(--radius-md)] overflow-hidden"
                     >
                       <button
                         onClick={() => toggleFAQ(faq.id)}
-                        className="w-full p-4 text-left hover:bg-secondary-50 transition-colors"
+                        className="w-full p-4 text-left hover:bg-surface-2 transition-colors"
                       >
                         <div className="flex items-center justify-between">
-                          <h3 className="font-semibold text-secondary-900 pr-4">
+                          <h3 className="font-semibold text-fg pr-4">
                             {faq.question}
                           </h3>
                           {expandedFAQ === faq.id ? (
-                            <ChevronDown className="w-5 h-5 text-secondary-400 flex-shrink-0" />
+                            <ChevronDown className="w-5 h-5 text-fg-3 flex-shrink-0" />
                           ) : (
-                            <ChevronRight className="w-5 h-5 text-secondary-400 flex-shrink-0" />
+                            <ChevronRight className="w-5 h-5 text-fg-3 flex-shrink-0" />
                           )}
                         </div>
                       </button>
@@ -408,15 +408,15 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
                             exit={{ height: 0 }}
                             className="overflow-hidden"
                           >
-                            <div className="p-4 pt-0 border-t border-secondary-100">
-                              <p className="text-secondary-700 leading-relaxed">
+                            <div className="p-4 pt-0 border-t border-line">
+                              <p className="text-fg-2 leading-relaxed">
                                 {faq.answer}
                               </p>
                               <div className="mt-3 flex flex-wrap gap-2">
                                 {faq.tags.map((tag) => (
                                   <span
                                     key={tag}
-                                    className="px-2 py-1 bg-secondary-100 text-secondary-600 text-xs rounded-full"
+                                    className="px-2 py-1 bg-surface-2 text-fg-2 text-xs rounded-full"
                                   >
                                     {tag}
                                   </span>
@@ -435,15 +435,15 @@ export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
         </div>
 
         {/* Footer */}
-        <div className="p-4 border-t border-secondary-200 bg-secondary-50">
-          <div className="flex items-center justify-between text-sm text-secondary-600">
+        <div className="p-4 border-t border-line bg-surface-2">
+          <div className="flex items-center justify-between text-sm text-fg-2">
             <div>
-              Still need help? <a href="mailto:support@latexy.com" className="text-primary-600 hover:underline">Contact Support</a>
+              Still need help? <a href="mailto:support@latexy.com" className="text-accent-strong hover:underline">Contact Support</a>
             </div>
             <div className="flex items-center gap-4">
-              <a href="/documentation" className="hover:text-primary-600">Documentation</a>
-              <a href="/tutorials" className="hover:text-primary-600">Tutorials</a>
-              <a href="/status" className="hover:text-primary-600">System Status</a>
+              <a href="/documentation" className="hover:text-accent-strong">Documentation</a>
+              <a href="/tutorials" className="hover:text-accent-strong">Tutorials</a>
+              <a href="/status" className="hover:text-accent-strong">System Status</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Refs #1073. Final 12 components (editors + misc) re-skinned to tokens. Editor chrome tokenized while Monaco/CodeMirror theme colors preserved; resume paper-preview stays light by design. HEAD-diff reviewed (logicPreserved on all 12). 493 tests pass, build compiles. **This completes the component migration — all ~87 shared components are now on the token system.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated editors, previews, builders, dialogs, logs, and help interfaces to use consistent design-system theme tokens.
  * Improved visual consistency across surfaces, text, borders, controls, statuses, warnings, and focus states.
  * Refined PDF preview heatmap iconography and scrollbar styling.
  * No functional behavior or displayed content changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->