### PR TITLE
Redesign Phase 5h: large/editor app pages (tokens)

### DIFF
--- a/frontend/src/app/try/page.tsx
+++ b/frontend/src/app/try/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, useRef, useCallback } from 'react'
 import dynamic from 'next/dynamic'
-import { ChevronDown, Link2, Loader2, Upload, X, Zap } from 'lucide-react'
+import { AlertTriangle, ChevronDown, Clock, Link2, Loader2, MapPin, Upload, X, Zap } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { toast } from 'sonner'
 import { apiClient, type ExplainErrorResponse, type ScrapeJobResponse } from '@/lib/api-client'
@@ -275,10 +275,10 @@ export default function TryPage() {
   }, [latexContent, jobDescription, resolvedSession, trialStatus, TRIM_INSTRUCTION, effectiveCanRun])
 
   const statusTone = useMemo(() => {
-    if (stream.status === 'completed') return 'text-emerald-300'
-    if (stream.status === 'failed') return 'text-rose-300'
-    if (isProcessing) return 'text-orange-300 animate-pulse'
-    return 'text-slate-500'
+    if (stream.status === 'completed') return 'text-ok'
+    if (stream.status === 'failed') return 'text-err'
+    if (isProcessing) return 'text-accent-strong animate-pulse'
+    return 'text-fg-3'
   }, [stream.status, isProcessing])
 
   const categoryScores = stream.atsDetails?.category_scores as Record<string, number> | undefined
@@ -324,9 +324,9 @@ export default function TryPage() {
             ['Active Job', activeJobId ? `${activeJobId.slice(0, 12)}…` : 'None'],
             ['Trials Left', resolvedSession ? '∞' : hydrated ? String(trialStatus.remaining) : '…'],
           ].map(([k, v]) => (
-            <article key={k} className="surface-card edge-highlight p-3">
-              <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">{k}</p>
-              <p className={`mt-1 text-base text-white ${k === 'Status' ? statusTone : ''}`}>{v}</p>
+            <article key={k} className="rounded-[var(--radius-lg)] border border-line bg-surface p-3">
+              <p className="text-xs uppercase tracking-[0.18em] text-fg-3">{k}</p>
+              <p className={`mt-1 text-base text-fg ${k === 'Status' ? statusTone : ''}`}>{v}</p>
             </article>
           ))}
         </section>
@@ -335,31 +335,31 @@ export default function TryPage() {
         <div className="grid gap-5 xl:grid-cols-[1fr_1.1fr]">
 
           {/* ── LEFT: editor panel ── */}
-          <section className="surface-panel edge-highlight p-5 flex flex-col h-[820px]">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 flex flex-col h-[820px]">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3 flex-shrink-0">
               <div>
-                <h1 className="text-2xl font-semibold text-white">Resume Studio</h1>
-                <p className="mt-1 text-sm text-slate-400">Edit LaTeX source, attach job context, and run compile pipelines.</p>
+                <h1 className="text-2xl font-semibold text-fg">Resume Studio</h1>
+                <p className="mt-1 text-sm text-fg-2">Edit LaTeX source, attach job context, and run compile pipelines.</p>
               </div>
-              <span className="text-xs font-mono uppercase tracking-[0.24em] text-slate-400">LaTeX Pipeline</span>
+              <span className="text-xs font-mono uppercase tracking-[0.24em] text-fg-2">LaTeX Pipeline</span>
             </div>
 
             <div className="mb-3 flex flex-wrap gap-2 flex-shrink-0">
               <button
                 onClick={() => { setLatexContent(DEMO_RESUME_TEMPLATE); editorRef.current?.setValue(DEMO_RESUME_TEMPLATE) }}
-                className="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-xs text-slate-200 hover:bg-white/10"
+                className="rounded-[var(--radius-md)] border border-line-2 bg-surface-2 px-3 py-1.5 text-xs text-fg hover:bg-surface-2"
               >
                 Reset Sample
               </button>
               <button
                 onClick={() => { setLatexContent(''); editorRef.current?.setValue('') }}
-                className="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-xs text-slate-200 hover:bg-white/10"
+                className="rounded-[var(--radius-md)] border border-line-2 bg-surface-2 px-3 py-1.5 text-xs text-fg hover:bg-surface-2"
               >
                 Clear Source
               </button>
               <button
                 onClick={() => setShowImportModal(true)}
-                className="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-xs text-slate-200 hover:bg-white/10 flex items-center gap-1.5"
+                className="rounded-[var(--radius-md)] border border-line-2 bg-surface-2 px-3 py-1.5 text-xs text-fg hover:bg-surface-2 flex items-center gap-1.5"
               >
                 <Upload size={12} />
                 Import File
@@ -369,14 +369,14 @@ export default function TryPage() {
             <div className="flex-1 min-h-0 flex flex-col gap-4">
               {/* Page overflow warning banner */}
               {stream.pageCount !== null && stream.pageCount > 1 && (
-                <div className="flex-shrink-0 flex items-center justify-between rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2">
-                  <span className="text-xs text-amber-400">
-                    ⚠ Your resume is {stream.pageCount} pages. Most recruiters prefer 1 page.
+                <div className="flex-shrink-0 flex items-center justify-between rounded-[var(--radius-md)] border border-warn/20 bg-warn/10 px-4 py-2">
+                  <span className="text-xs text-warn">
+                    <AlertTriangle size={12} className="inline mr-1 -mt-0.5" /> Your resume is {stream.pageCount} pages. Most recruiters prefer 1 page.
                   </span>
                   <button
                     onClick={handleTrimToOnePage}
                     disabled={isSubmitting || isProcessing}
-                    className="ml-3 text-xs text-amber-300 underline hover:text-amber-100 disabled:opacity-50"
+                    className="ml-3 text-xs text-warn underline hover:brightness-110 disabled:opacity-50"
                   >
                     Trim with AI →
                   </button>
@@ -385,9 +385,9 @@ export default function TryPage() {
 
               {/* Compile timeout banner */}
               {stream.timeoutError && (
-                <div className="flex-shrink-0 flex items-center justify-between rounded-lg border border-orange-500/20 bg-orange-500/10 px-4 py-2">
-                  <span className="text-xs text-orange-300">
-                    ⏱ Compile timed out — {stream.timeoutError.plan} plan limit ({
+                <div className="flex-shrink-0 flex items-center justify-between rounded-[var(--radius-md)] border border-accent/20 bg-accent-soft px-4 py-2">
+                  <span className="text-xs text-accent-strong">
+                    <Clock size={12} className="inline mr-1 -mt-0.5" /> Compile timed out — {stream.timeoutError.plan} plan limit ({
                       stream.timeoutError.plan === 'free' ? '30s'
                       : stream.timeoutError.plan === 'basic' ? '120s'
                       : '240s'
@@ -396,14 +396,14 @@ export default function TryPage() {
                   {flags.upgrade_ctas && (
                     <a
                       href="/billing"
-                      className="ml-3 shrink-0 text-xs font-medium text-orange-200 underline hover:text-orange-100"
+                      className="ml-3 shrink-0 text-xs font-medium text-accent-strong underline hover:brightness-110"
                     >
                       Upgrade for longer timeouts →
                     </a>
                   )}
                 </div>
               )}
-              <div className="relative flex-1 min-h-0 rounded-xl border border-white/10 bg-slate-950/70 overflow-hidden">
+              <div className="relative flex-1 min-h-0 rounded-[var(--radius-lg)] border border-line bg-bg overflow-hidden">
                 <LaTeXEditor
                   ref={editorRef}
                   value={latexContent}
@@ -429,8 +429,8 @@ export default function TryPage() {
               </div>
               <div className="min-h-32 flex-shrink-0 flex flex-col">
                 <div className="mb-2 flex items-center justify-between">
-                  <label className="block text-xs uppercase tracking-[0.22em] text-slate-400">Job Description</label>
-                  <span className="text-[10px] text-slate-600">optional</span>
+                  <label className="block text-xs uppercase tracking-[0.22em] text-fg-2">Job Description</label>
+                  <span className="text-[10px] text-fg-3">optional</span>
                 </div>
                 <div className="mb-1.5 flex flex-col gap-2 sm:flex-row">
                   <input
@@ -440,13 +440,13 @@ export default function TryPage() {
                     onKeyDown={(e) => { if (e.key === 'Enter') handleScrapeUrl() }}
                     placeholder="Paste job URL (Greenhouse, Lever, Workday, Indeed…)"
                     disabled={isProcessing || isScraping}
-                    className="w-full min-w-0 flex-1 rounded-lg border border-white/10 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 outline-none transition placeholder:text-slate-600 focus:border-orange-300/40 disabled:opacity-50 sm:py-1.5"
+                    className="w-full min-w-0 flex-1 rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-xs text-fg outline-none transition placeholder:text-fg-3 focus:border-accent disabled:opacity-50 sm:py-1.5"
                   />
                   <button
                     onClick={handleScrapeUrl}
                     disabled={!jobUrl.trim() || isProcessing || isScraping}
                     title="Import job description from URL"
-                    className="flex shrink-0 items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs font-medium text-slate-300 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 sm:py-1.5"
+                    className="flex shrink-0 items-center justify-center gap-1.5 rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-xs font-medium text-fg-2 transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40 sm:py-1.5"
                   >
                     {isScraping ? <Loader2 size={11} className="animate-spin" /> : <Link2 size={11} />}
                     {isScraping ? 'Importing…' : 'Import'}
@@ -455,38 +455,38 @@ export default function TryPage() {
                 {scrapedMeta && !scrapedMeta.error && (
                   <div className="mb-1.5 flex flex-wrap items-center gap-1">
                     {scrapedMeta.title && (
-                      <span className="rounded bg-orange-400/10 px-1.5 py-0.5 text-[10px] font-medium text-orange-300">
+                      <span className="rounded bg-accent-soft px-1.5 py-0.5 text-[10px] font-medium text-accent-strong">
                         {scrapedMeta.title}
                       </span>
                     )}
                     {scrapedMeta.company && (
-                      <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-slate-400">
+                      <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-2">
                         {scrapedMeta.company}
                       </span>
                     )}
                     {scrapedMeta.location && (
-                      <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-slate-500">
-                        📍 {scrapedMeta.location}
+                      <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-3 inline-flex items-center gap-1">
+                        <MapPin size={10} /> {scrapedMeta.location}
                       </span>
                     )}
                     {scrapedMeta.job_type && (
-                      <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-slate-500">
+                      <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-3">
                         {scrapedMeta.job_type}
                       </span>
                     )}
                     {scrapedMeta.salary && (
-                      <span className="rounded bg-emerald-400/10 px-1.5 py-0.5 text-[10px] text-emerald-400">
+                      <span className="rounded bg-ok/10 px-1.5 py-0.5 text-[10px] text-ok">
                         {scrapedMeta.salary}
                       </span>
                     )}
-                    <span className="ml-auto text-[9px] text-slate-700">via {scrapedMeta.source}</span>
+                    <span className="ml-auto text-[9px] text-fg-3">via {scrapedMeta.source}</span>
                   </div>
                 )}
                 <textarea
                   value={jobDescription}
                   onChange={(e) => setJobDescription(e.target.value)}
                   placeholder="Paste a job description to tailor the optimization…"
-                  className="flex-1 w-full rounded-xl border border-white/10 bg-slate-950/70 p-4 text-sm text-slate-100 outline-none transition focus:border-orange-300/50 resize-none scrollbar-subtle"
+                  className="flex-1 w-full rounded-[var(--radius-lg)] border border-line bg-bg p-4 text-sm text-fg outline-none transition focus:border-accent resize-none scrollbar-subtle"
                 />
               </div>
             </div>
@@ -495,10 +495,10 @@ export default function TryPage() {
               <button
                 onClick={toggleAutoCompile}
                 title="Auto-compile on change (2s debounce)"
-                className={`flex items-center gap-1.5 rounded-lg border px-3 py-2 text-xs font-medium transition ${
+                className={`flex items-center gap-1.5 rounded-[var(--radius-md)] border px-3 py-2 text-xs font-medium transition ${
                   autoCompile
-                    ? 'border-orange-500/30 bg-orange-500/20 text-orange-300'
-                    : 'border-white/15 bg-white/5 text-zinc-500 hover:text-zinc-200 hover:bg-white/10'
+                    ? 'border-accent bg-accent-soft text-accent-strong'
+                    : 'border-line-2 bg-surface-2 text-fg-3 hover:text-fg hover:bg-surface-2'
                 }`}
               >
                 <Zap size={12} />
@@ -507,14 +507,14 @@ export default function TryPage() {
               <button
                 onClick={() => runCompile('compile')}
                 disabled={isSubmitting || isProcessing || (!resolvedSession && !effectiveCanRun)}
-                className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm text-slate-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-45"
+                className="rounded-[var(--radius-md)] border border-line-2 bg-surface-2 px-4 py-2 text-sm text-fg transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-45"
               >
                 {isSubmitting ? 'Compiling…' : 'Compile'}
               </button>
               <button
                 onClick={() => runCompile('combined')}
                 disabled={isSubmitting || isProcessing || (!resolvedSession && !effectiveCanRun)}
-                className="rounded-lg bg-orange-300 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-orange-200 disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-sm font-semibold text-accent-fg transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isSubmitting ? 'Running…' : 'Optimize + Compile'}
               </button>
@@ -531,29 +531,29 @@ export default function TryPage() {
             <motion.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
-              className="surface-panel edge-highlight px-5 py-4"
+              className="rounded-[var(--radius-lg)] border border-line bg-surface px-5 py-4"
             >
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3 min-w-0">
                   <span className={`text-xs font-semibold uppercase tracking-[0.16em] ${statusTone}`}>
                     {stream.status}
                   </span>
-                  <span className="text-sm text-slate-400 truncate">{stream.stage || 'waiting for submission'}</span>
+                  <span className="text-sm text-fg-2 truncate">{stream.stage || 'waiting for submission'}</span>
                 </div>
-                <span className="text-xs font-mono text-slate-500 flex-shrink-0">{stream.percent}%</span>
+                <span className="text-xs font-mono text-fg-3 flex-shrink-0">{stream.percent}%</span>
               </div>
-              <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-slate-800">
-                <div className="h-full rounded-full bg-orange-300 transition-all duration-500" style={{ width: `${stream.percent}%` }} />
+              <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-surface-2">
+                <div className="h-full rounded-full bg-accent transition-all duration-500" style={{ width: `${stream.percent}%` }} />
               </div>
               {stream.message && (
-                <p className="mt-2 text-xs text-slate-500 truncate">{stream.message}</p>
+                <p className="mt-2 text-xs text-fg-3 truncate">{stream.message}</p>
               )}
             </motion.div>
 
             {/* PDF viewer + Quality signals side-by-side */}
             <div className="grid gap-3 grid-cols-[1fr_188px]">
               {/* PDF viewer — large */}
-              <div className="surface-panel edge-highlight overflow-hidden h-[680px]">
+              <div className="rounded-[var(--radius-lg)] border border-line bg-surface overflow-hidden h-[680px]">
                 <PDFPreview
                   pdfUrl={pdfUrl}
                   isLoading={isProcessing}
@@ -565,19 +565,19 @@ export default function TryPage() {
               <div className="flex flex-col gap-5 py-1">
                 {/* ATS score */}
                 <div>
-                  <p className="text-[10px] uppercase tracking-[0.18em] text-slate-500">ATS Score</p>
-                  <p className="mt-1 text-4xl font-bold tabular-nums text-orange-200">
+                  <p className="text-[10px] uppercase tracking-[0.18em] text-fg-3">ATS Score</p>
+                  <p className="mt-1 text-4xl font-bold tabular-nums text-accent-strong">
                     {stream.atsScore != null ? stream.atsScore : '—'}
                   </p>
                   {stream.atsScore != null && (
-                    <p className="mt-0.5 text-[10px] text-slate-500">out of 100</p>
+                    <p className="mt-0.5 text-[10px] text-fg-3">out of 100</p>
                   )}
                 </div>
 
                 {/* Tokens */}
                 <div>
-                  <p className="text-[10px] uppercase tracking-[0.18em] text-slate-500">Tokens Used</p>
-                  <p className="mt-1 text-xl font-semibold tabular-nums text-slate-200">
+                  <p className="text-[10px] uppercase tracking-[0.18em] text-fg-3">Tokens Used</p>
+                  <p className="mt-1 text-xl font-semibold tabular-nums text-fg">
                     {stream.tokensUsed != null ? stream.tokensUsed.toLocaleString() : '—'}
                   </p>
                 </div>
@@ -585,16 +585,16 @@ export default function TryPage() {
                 {/* Category scores */}
                 {categoryScores && (
                   <div className="space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.18em] text-slate-500">Categories</p>
+                    <p className="text-[10px] uppercase tracking-[0.18em] text-fg-3">Categories</p>
                     {Object.entries(categoryScores).map(([key, val]) => (
                       <div key={key}>
                         <div className="flex items-center justify-between mb-0.5">
-                          <span className="text-[10px] text-slate-400">{CATEGORY_LABELS[key] ?? key}</span>
-                          <span className="text-[10px] font-mono text-slate-300">{val}</span>
+                          <span className="text-[10px] text-fg-2">{CATEGORY_LABELS[key] ?? key}</span>
+                          <span className="text-[10px] font-mono text-fg-2">{val}</span>
                         </div>
-                        <div className="h-1 w-full rounded-full bg-slate-800">
+                        <div className="h-1 w-full rounded-full bg-surface-2">
                           <div
-                            className="h-full rounded-full bg-orange-300/70 transition-all"
+                            className="h-full rounded-full bg-accent/70 transition-all"
                             style={{ width: `${val}%` }}
                           />
                         </div>
@@ -606,50 +606,50 @@ export default function TryPage() {
                 {/* Changes count */}
                 {stream.changesMade && stream.changesMade.length > 0 && (
                   <div>
-                    <p className="text-[10px] uppercase tracking-[0.18em] text-slate-500">Changes</p>
-                    <p className="mt-1 text-xl font-semibold tabular-nums text-slate-200">{stream.changesMade.length}</p>
-                    <p className="mt-0.5 text-[10px] text-slate-500">sections modified</p>
+                    <p className="text-[10px] uppercase tracking-[0.18em] text-fg-3">Changes</p>
+                    <p className="mt-1 text-xl font-semibold tabular-nums text-fg">{stream.changesMade.length}</p>
+                    <p className="mt-0.5 text-[10px] text-fg-3">sections modified</p>
                   </div>
                 )}
 
                 {/* AI Deep Analysis */}
-                <div className="border-t border-white/8 pt-4">
+                <div className="border-t border-line pt-4">
                   <button
                     onClick={() => { setDeepPanelOpen(true); if (!deepAnalysisJobId) handleRunDeepAnalysis() }}
                     disabled={isDeepAnalysisRunning}
-                    className="w-full rounded-lg bg-violet-500/20 px-3 py-2 text-[11px] font-semibold text-violet-200 ring-1 ring-violet-400/20 transition hover:bg-violet-500/30 disabled:opacity-50"
+                    className="w-full rounded-[var(--radius-md)] bg-accent-soft px-3 py-2 text-[11px] font-semibold text-accent-strong ring-1 ring-accent transition hover:brightness-110 disabled:opacity-50"
                   >
                     {isDeepAnalysisRunning ? 'Analysing…' : 'AI Analysis'}
                   </button>
                   {deepAnalysisUsesRemaining !== null && (
-                    <p className="mt-1.5 text-[10px] text-center text-slate-600">{deepAnalysisUsesRemaining} free uses left</p>
+                    <p className="mt-1.5 text-[10px] text-center text-fg-3">{deepAnalysisUsesRemaining} free uses left</p>
                   )}
                 </div>
               </div>
             </div>
 
             {/* Live logs — collapsed by default */}
-            <div className="surface-panel edge-highlight overflow-hidden">
+            <div className="rounded-[var(--radius-lg)] border border-line bg-surface overflow-hidden">
               <button
                 onClick={() => setLogsOpen(v => !v)}
                 className="flex w-full items-center justify-between px-5 py-3.5 text-left"
               >
                 <div className="flex items-center gap-2.5">
-                  <span className="text-sm font-semibold text-white">Live Logs</span>
+                  <span className="text-sm font-semibold text-fg">Live Logs</span>
                   {stream.logLines.length > 0 && (
-                    <span className="rounded-md bg-white/8 px-1.5 py-0.5 text-[10px] font-mono text-slate-400">
+                    <span className="rounded-[var(--radius-md)] bg-surface-2 px-1.5 py-0.5 text-[10px] font-mono text-fg-2">
                       {stream.logLines.length}
                     </span>
                   )}
                 </div>
                 <ChevronDown
                   size={14}
-                  className={`text-slate-500 transition-transform duration-200 ${logsOpen ? 'rotate-180' : ''}`}
+                  className={`text-fg-3 transition-transform duration-200 ${logsOpen ? 'rotate-180' : ''}`}
                 />
               </button>
               {logsOpen && (
-                <div className="border-t border-white/10">
-                  <div className="rounded-b-xl overflow-hidden bg-slate-950/70">
+                <div className="border-t border-line">
+                  <div className="rounded-b-[var(--radius-lg)] overflow-hidden bg-bg">
                     <LogViewer
                       lines={stream.logLines}
                       maxHeight="18rem"
@@ -676,18 +676,18 @@ export default function TryPage() {
 
       {/* Import modal */}
       {showImportModal && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="w-full max-w-md rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl shadow-black/60 p-6">
+        <div className="fixed inset-0 bg-[var(--overlay)] flex items-center justify-center z-50 p-4">
+          <div className="w-full max-w-md rounded-[var(--radius-lg)] border border-line bg-surface shadow-[var(--shadow-2)] p-6">
             <div className="flex justify-between items-center mb-3">
-              <h3 className="text-base font-semibold text-zinc-100">Import Resume File</h3>
+              <h3 className="text-base font-semibold text-fg">Import Resume File</h3>
               <button
                 onClick={() => setShowImportModal(false)}
-                className="rounded-md p-1.5 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-300"
+                className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg"
               >
                 <X size={16} />
               </button>
             </div>
-            <p className="text-xs text-zinc-500 mb-5">
+            <p className="text-xs text-fg-3 mb-5">
               This will replace the current editor content.
             </p>
             <MultiFormatUpload

--- a/frontend/src/app/workspace/[resumeId]/batch-tailor/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/batch-tailor/page.tsx
@@ -46,12 +46,12 @@ function emptyRow(): RowData {
 
 function StatusBadge({ status }: { status: string }) {
   const map: Record<string, { label: string; cls: string; icon: React.ReactNode }> = {
-    queued:    { label: 'Queued',     cls: 'bg-zinc-700 text-zinc-300', icon: null },
-    running:   { label: 'Running',    cls: 'bg-blue-600/30 text-blue-300 animate-pulse', icon: <Loader2 className="w-3 h-3 animate-spin" /> },
-    processing:{ label: 'Running',    cls: 'bg-blue-600/30 text-blue-300 animate-pulse', icon: <Loader2 className="w-3 h-3 animate-spin" /> },
-    completed: { label: 'Complete',   cls: 'bg-emerald-600/30 text-emerald-300', icon: <CheckCircle2 className="w-3 h-3" /> },
-    failed:    { label: 'Failed',     cls: 'bg-red-600/30 text-red-300', icon: <XCircle className="w-3 h-3" /> },
-    cancelled: { label: 'Cancelled',  cls: 'bg-zinc-600/30 text-zinc-400', icon: null },
+    queued:    { label: 'Queued',     cls: 'bg-surface-2 text-fg-2', icon: null },
+    running:   { label: 'Running',    cls: 'bg-accent-soft text-accent-strong animate-pulse', icon: <Loader2 className="w-3 h-3 animate-spin" /> },
+    processing:{ label: 'Running',    cls: 'bg-accent-soft text-accent-strong animate-pulse', icon: <Loader2 className="w-3 h-3 animate-spin" /> },
+    completed: { label: 'Complete',   cls: 'bg-ok/20 text-ok', icon: <CheckCircle2 className="w-3 h-3" /> },
+    failed:    { label: 'Failed',     cls: 'bg-err/20 text-err', icon: <XCircle className="w-3 h-3" /> },
+    cancelled: { label: 'Cancelled',  cls: 'bg-surface-2 text-fg-3', icon: null },
   }
   const cfg = map[status] ?? map['queued']
   return (
@@ -180,22 +180,22 @@ export default function BatchTailorPage() {
   // ---------------------------------------------------------------- //
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+    <div className="min-h-screen bg-bg text-fg">
       <div className="max-w-4xl mx-auto px-4 py-8">
         {/* Header */}
         <div className="flex items-center gap-3 mb-8">
           <Link
             href={`/workspace/${resumeId}/edit`}
-            className="p-2 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 transition-colors"
+            className="p-2 rounded-[var(--radius-md)] text-fg-2 hover:text-fg hover:bg-surface-2 transition-colors"
           >
             <ArrowLeft className="w-5 h-5" />
           </Link>
           <div>
-            <h1 className="text-2xl font-bold text-zinc-100 flex items-center gap-2">
-              <Zap className="w-6 h-6 text-violet-400" />
+            <h1 className="text-2xl font-bold text-fg flex items-center gap-2">
+              <Zap className="w-6 h-6 text-accent" />
               Batch Tailor
             </h1>
-            <p className="text-sm text-zinc-400 mt-0.5">
+            <p className="text-sm text-fg-2 mt-0.5">
               Submit up to 10 job descriptions — get a tailored resume variant for each.
             </p>
           </div>
@@ -212,16 +212,16 @@ export default function BatchTailorPage() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, height: 0, marginBottom: 0, overflow: 'hidden' }}
                   transition={{ duration: 0.15 }}
-                  className="border border-zinc-800 rounded-xl p-4 bg-zinc-900/50 space-y-3"
+                  className="rounded-[var(--radius-lg)] border border-line bg-surface p-4 space-y-3"
                 >
                   <div className="flex items-center justify-between mb-1">
-                    <span className="text-xs font-semibold text-zinc-500 uppercase tracking-wider">
+                    <span className="text-xs font-semibold text-fg-3 uppercase tracking-wider">
                       Job {idx + 1}
                     </span>
                     {rows.length > 1 && (
                       <button
                         onClick={() => removeRow(row.id)}
-                        className="p-1 rounded text-zinc-600 hover:text-red-400 hover:bg-zinc-800 transition-colors"
+                        className="p-1 rounded-[var(--radius-md)] text-fg-3 hover:text-err hover:bg-surface-2 transition-colors"
                       >
                         <Trash2 className="w-4 h-4" />
                       </button>
@@ -230,9 +230,9 @@ export default function BatchTailorPage() {
 
                   <div className="grid grid-cols-2 gap-3">
                     <div>
-                      <label className="block text-xs text-zinc-500 mb-1">Company *</label>
+                      <label className="block text-xs text-fg-3 mb-1">Company *</label>
                       <input
-                        className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-violet-500"
+                        className="w-full bg-surface-2 border border-line rounded-[var(--radius-md)] px-3 py-2 text-sm text-fg placeholder-fg-3 focus:outline-none focus:border-accent"
                         placeholder="Acme Corp"
                         value={row.company_name}
                         onChange={e => updateRow(row.id, 'company_name', e.target.value)}
@@ -240,9 +240,9 @@ export default function BatchTailorPage() {
                       />
                     </div>
                     <div>
-                      <label className="block text-xs text-zinc-500 mb-1">Role Title *</label>
+                      <label className="block text-xs text-fg-3 mb-1">Role Title *</label>
                       <input
-                        className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-violet-500"
+                        className="w-full bg-surface-2 border border-line rounded-[var(--radius-md)] px-3 py-2 text-sm text-fg placeholder-fg-3 focus:outline-none focus:border-accent"
                         placeholder="Software Engineer"
                         value={row.role_title}
                         onChange={e => updateRow(row.id, 'role_title', e.target.value)}
@@ -252,24 +252,24 @@ export default function BatchTailorPage() {
                   </div>
 
                   <div>
-                    <label className="block text-xs text-zinc-500 mb-1">Job Description *</label>
+                    <label className="block text-xs text-fg-3 mb-1">Job Description *</label>
                     <textarea
-                      className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-violet-500 resize-none"
+                      className="w-full bg-surface-2 border border-line rounded-[var(--radius-md)] px-3 py-2 text-sm text-fg placeholder-fg-3 focus:outline-none focus:border-accent resize-none"
                       rows={4}
                       placeholder="Paste the full job description here…"
                       value={row.job_description}
                       onChange={e => updateRow(row.id, 'job_description', e.target.value)}
                       maxLength={20000}
                     />
-                    <p className="text-right text-xs text-zinc-600 mt-0.5">
+                    <p className="text-right text-xs text-fg-3 mt-0.5">
                       {row.job_description.length.toLocaleString()} / 20,000
                     </p>
                   </div>
 
                   <div>
-                    <label className="block text-xs text-zinc-500 mb-1">Job URL (optional)</label>
+                    <label className="block text-xs text-fg-3 mb-1">Job URL (optional)</label>
                     <input
-                      className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-violet-500"
+                      className="w-full bg-surface-2 border border-line rounded-[var(--radius-md)] px-3 py-2 text-sm text-fg placeholder-fg-3 focus:outline-none focus:border-accent"
                       placeholder="https://linkedin.com/jobs/…"
                       value={row.job_url}
                       onChange={e => updateRow(row.id, 'job_url', e.target.value)}
@@ -284,17 +284,17 @@ export default function BatchTailorPage() {
               <button
                 onClick={addRow}
                 disabled={rows.length >= 10}
-                className="flex items-center gap-2 px-4 py-2 rounded-lg border border-zinc-700 text-zinc-400 hover:text-zinc-100 hover:border-zinc-500 text-sm transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                className="flex items-center gap-2 px-4 py-2 rounded-[var(--radius-md)] border border-line-2 text-fg-2 hover:text-fg hover:bg-surface-2 text-sm transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
               >
                 <Plus className="w-4 h-4" />
                 Add Row
-                <span className="text-zinc-600 text-xs">{rows.length}/10</span>
+                <span className="text-fg-3 text-xs">{rows.length}/10</span>
               </button>
 
               <button
                 onClick={handleSubmit}
                 disabled={submitting}
-                className="flex items-center gap-2 px-6 py-2.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-2 px-6 py-2.5 rounded-[var(--radius-md)] bg-accent hover:brightness-110 text-accent-fg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {submitting ? (
                   <><Loader2 className="w-4 h-4 animate-spin" /> Starting…</>
@@ -311,15 +311,15 @@ export default function BatchTailorPage() {
           <div className="space-y-4">
             <div className="flex items-center justify-between mb-2">
               <div>
-                <p className="text-sm text-zinc-400">
-                  Batch <span className="font-mono text-zinc-300">{batchId.slice(0, 8)}…</span>
+                <p className="text-sm text-fg-2">
+                  Batch <span className="font-mono text-fg-2">{batchId.slice(0, 8)}…</span>
                   {' · '}
                   <span className="capitalize">{batchStatus.status}</span>
                 </p>
               </div>
               <div className="flex items-center gap-3">
                 {allComplete && (
-                  <span className="text-xs text-emerald-400 font-medium">All complete — use View links below</span>
+                  <span className="text-xs text-ok font-medium">All complete — use View links below</span>
                 )}
                 <button
                   onClick={() => {
@@ -327,7 +327,7 @@ export default function BatchTailorPage() {
                     setBatchStatus(null)
                     setRows([emptyRow()])
                   }}
-                  className="px-4 py-2 rounded-lg border border-zinc-700 text-zinc-400 hover:text-zinc-100 text-sm transition-colors"
+                  className="px-4 py-2 rounded-[var(--radius-md)] border border-line-2 text-fg-2 hover:text-fg hover:bg-surface-2 text-sm transition-colors"
                 >
                   New Batch
                 </button>
@@ -341,7 +341,7 @@ export default function BatchTailorPage() {
             </div>
 
             {!allComplete && (
-              <p className="text-center text-xs text-zinc-600 pt-2">
+              <p className="text-center text-xs text-fg-3 pt-2">
                 Polling every 3s…
               </p>
             )}
@@ -351,7 +351,7 @@ export default function BatchTailorPage() {
         {/* Loading state before first poll result */}
         {batchId && !batchStatus && (
           <div className="flex justify-center py-16">
-            <Loader2 className="w-8 h-8 animate-spin text-violet-400" />
+            <Loader2 className="w-8 h-8 animate-spin text-accent" />
           </div>
         )}
       </div>
@@ -365,10 +365,10 @@ export default function BatchTailorPage() {
 
 function JobCard({ job, resumeId }: { job: BatchJobStatus; resumeId: string }) {
   return (
-    <div className="border border-zinc-800 rounded-xl p-4 bg-zinc-900/50 flex items-center gap-4">
+    <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-4 flex items-center gap-4">
       <div className="flex-1 min-w-0">
-        <p className="font-medium text-zinc-100 truncate">{job.role_title}</p>
-        <p className="text-sm text-zinc-400 truncate">{job.company_name}</p>
+        <p className="font-medium text-fg truncate">{job.role_title}</p>
+        <p className="text-sm text-fg-2 truncate">{job.company_name}</p>
       </div>
 
       <StatusBadge status={job.status} />
@@ -376,7 +376,7 @@ function JobCard({ job, resumeId }: { job: BatchJobStatus; resumeId: string }) {
       {job.status === 'completed' && job.variant_resume_id && (
         <Link
           href={`/workspace/${job.variant_resume_id}/edit`}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-zinc-700 text-zinc-300 hover:text-zinc-100 hover:border-zinc-500 text-xs transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)] border border-line-2 text-fg-2 hover:text-fg hover:bg-surface-2 text-xs transition-colors"
         >
           View <ExternalLink className="w-3 h-3" />
         </Link>

--- a/frontend/src/app/workspace/[resumeId]/career/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/career/page.tsx
@@ -154,19 +154,19 @@ export default function CareerPathPage() {
   // ── Render ───────────────────────────────────────────────────────────────────
 
   return (
-    <div className="bg-[#09090b] text-sm text-zinc-300">
+    <div className="bg-bg text-sm text-fg-2">
       {/* Header */}
-      <header className="flex h-12 items-center gap-3 border-b border-white/[0.05] bg-[#0a0a0a] px-4">
+      <header className="flex h-12 items-center gap-3 border-b border-line bg-surface px-4">
         <Link
           href={`/workspace/${resumeId}/edit`}
-          className="flex items-center gap-1.5 text-[11px] text-zinc-600 transition hover:text-zinc-300"
+          className="flex items-center gap-1.5 text-[11px] text-fg-3 transition hover:text-fg-2"
         >
           <ArrowLeft size={13} />
           Back to editor
         </Link>
-        <ChevronRight size={11} className="text-zinc-800" />
-        <span className="text-[11px] font-semibold text-zinc-400">Career Path</span>
-        <div className="ml-auto flex items-center gap-1.5 text-[11px] text-zinc-700">
+        <ChevronRight size={11} className="text-fg-3" />
+        <span className="text-[11px] font-semibold text-fg-2">Career Path</span>
+        <div className="ml-auto flex items-center gap-1.5 text-[11px] text-fg-3">
           <TrendingUp size={12} />
           Feature 80
         </div>
@@ -175,22 +175,22 @@ export default function CareerPathPage() {
       <div className="mx-auto max-w-4xl px-6 py-8">
         {/* Title */}
         <div className="mb-8">
-          <h1 className="text-xl font-bold text-zinc-100">Career Path Visualization</h1>
-          <p className="mt-1 text-[12px] text-zinc-600">
+          <h1 className="text-xl font-bold text-fg">Career Path Visualization</h1>
+          <p className="mt-1 text-[12px] text-fg-3">
             Enter a target role and we&apos;ll map the path from your current position,
             identify skills gaps, and generate a personalized development plan.
           </p>
         </div>
 
         {/* Search + Analyze */}
-        <div className="mb-8 rounded-xl border border-white/[0.06] bg-white/[0.02] p-5">
-          <label className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-600">
+        <div className="mb-8 rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+          <label className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.12em] text-fg-3">
             Target Role
           </label>
           <div className="relative">
             <div className="flex gap-2">
               <div className="relative flex-1">
-                <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-600" />
+                <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-fg-3" />
                 <input
                   value={query}
                   onChange={handleQueryChange}
@@ -198,23 +198,23 @@ export default function CareerPathPage() {
                   onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
                   onKeyDown={(e) => e.key === 'Enter' && handleAnalyze()}
                   placeholder="e.g. Staff Software Engineer, Principal Data Scientist…"
-                  className="w-full rounded-lg border border-white/[0.06] bg-black/30 py-2 pl-8 pr-3 text-[12px] text-zinc-200 outline-none placeholder:text-zinc-700 focus:border-violet-500/30 focus:ring-1 focus:ring-violet-500/20"
+                  className="w-full rounded-[var(--radius-md)] border border-line bg-bg py-2 pl-8 pr-3 text-[12px] text-fg outline-none placeholder:text-fg-3 focus:border-accent focus:ring-1 focus:ring-accent"
                   disabled={isAnalyzing}
                 />
                 {/* Autocomplete dropdown */}
                 {showSuggestions && suggestions.length > 0 && (
-                  <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-y-auto rounded-lg border border-white/[0.06] bg-[#111] shadow-xl">
+                  <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-line bg-surface-2 shadow-[var(--shadow-2)]">
                     {suggestions.map((role) => (
                       <button
                         key={role.id}
                         onMouseDown={() => handleSelectSuggestion(role)}
-                        className="flex w-full items-center gap-3 px-3 py-2 text-left text-[11px] transition hover:bg-white/[0.06]"
+                        className="flex w-full items-center gap-3 px-3 py-2 text-left text-[11px] transition hover:bg-surface-2"
                       >
-                        <span className="rounded bg-white/[0.05] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-zinc-600">
+                        <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-fg-3">
                           {role.level}
                         </span>
-                        <span className="text-zinc-300">{role.title}</span>
-                        <span className="ml-auto text-zinc-700">
+                        <span className="text-fg-2">{role.title}</span>
+                        <span className="ml-auto text-fg-3">
                           {role.industry.replace(/_/g, ' ')}
                         </span>
                       </button>
@@ -225,7 +225,7 @@ export default function CareerPathPage() {
               <button
                 onClick={handleAnalyze}
                 disabled={isAnalyzing || !query.trim()}
-                className="flex items-center gap-1.5 rounded-lg border border-violet-400/20 bg-gradient-to-r from-violet-500/15 to-orange-500/10 px-4 py-2 text-[12px] font-semibold text-violet-200 transition hover:from-violet-500/25 hover:to-orange-500/15 disabled:opacity-40"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-accent bg-accent-soft px-4 py-2 text-[12px] font-semibold text-accent-strong transition hover:brightness-110 disabled:opacity-40"
               >
                 {isAnalyzing ? <Loader2 size={13} className="animate-spin" /> : <Sparkles size={13} />}
                 {isAnalyzing ? 'Analyzing…' : 'Analyze'}
@@ -239,13 +239,13 @@ export default function CareerPathPage() {
               {STEPS.map((step, i) => (
                 <div key={step.key} className="flex items-center gap-2 text-[11px]">
                   {i < stepIdx ? (
-                    <span className="text-emerald-500">✓</span>
+                    <span className="text-ok">✓</span>
                   ) : i === stepIdx ? (
-                    <Loader2 size={11} className="animate-spin text-violet-400" />
+                    <Loader2 size={11} className="animate-spin text-accent" />
                   ) : (
-                    <span className="text-zinc-800">○</span>
+                    <span className="text-fg-3">○</span>
                   )}
-                  <span className={i <= stepIdx ? 'text-zinc-400' : 'text-zinc-800'}>
+                  <span className={i <= stepIdx ? 'text-fg-2' : 'text-fg-3'}>
                     {step.label}
                   </span>
                 </div>
@@ -257,21 +257,21 @@ export default function CareerPathPage() {
         {/* Results */}
         {analysis && (
           <div className="mb-8 space-y-6">
-            <div className="rounded-xl border border-violet-500/20 bg-violet-500/5 p-5">
-              <h2 className="mb-4 text-[13px] font-bold text-zinc-200">Career Path</h2>
+            <div className="rounded-[var(--radius-lg)] border border-accent bg-accent-soft p-5">
+              <h2 className="mb-4 text-[13px] font-bold text-fg">Career Path</h2>
               {analysis.path_roles && analysis.path_roles.length > 0 ? (
                 <CareerPathChart
                   pathRoles={analysis.path_roles}
                   targetRole={analysis.target_role ?? null}
                 />
               ) : (
-                <p className="text-[12px] text-zinc-600">
+                <p className="text-[12px] text-fg-3">
                   No matching path found in the career graph — see the plan below.
                 </p>
               )}
             </div>
 
-            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5">
+            <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
               <SkillsGapPanel analysis={analysis} />
             </div>
           </div>
@@ -279,13 +279,13 @@ export default function CareerPathPage() {
 
         {/* Past analyses */}
         <div>
-          <h2 className="mb-3 text-[12px] font-semibold text-zinc-500">Past Analyses</h2>
+          <h2 className="mb-3 text-[12px] font-semibold text-fg-3">Past Analyses</h2>
           {pastLoading ? (
             <div className="flex justify-center py-8">
-              <Loader2 size={16} className="animate-spin text-zinc-700" />
+              <Loader2 size={16} className="animate-spin text-fg-3" />
             </div>
           ) : pastAnalyses.length === 0 ? (
-            <div className="rounded-xl border border-white/[0.04] bg-white/[0.01] py-8 text-center text-[12px] text-zinc-700">
+            <div className="rounded-[var(--radius-lg)] border border-line bg-surface py-8 text-center text-[12px] text-fg-3">
               No analyses yet. Run your first analysis above.
             </div>
           ) : (
@@ -301,33 +301,33 @@ export default function CareerPathPage() {
                 return (
                   <div
                     key={pa.id}
-                    className="rounded-xl border border-white/[0.05] bg-white/[0.02]"
+                    className="rounded-[var(--radius-lg)] border border-line bg-surface"
                   >
                     <button
                       onClick={() => handleExpandPast(pa.id)}
                       className="flex w-full items-center gap-3 px-4 py-3 text-left"
                     >
-                      <TrendingUp size={12} className="shrink-0 text-violet-500" />
-                      <span className="flex-1 text-[12px] font-medium text-zinc-300">
+                      <TrendingUp size={12} className="shrink-0 text-accent" />
+                      <span className="flex-1 text-[12px] font-medium text-fg-2">
                         → {targetTitle}
                       </span>
                       {years && (
-                        <span className="flex items-center gap-1 text-[11px] text-zinc-600">
+                        <span className="flex items-center gap-1 text-[11px] text-fg-3">
                           <Clock size={10} />
                           ~{years} yr{years !== 1 ? 's' : ''}
                         </span>
                       )}
-                      <span className="text-[10px] text-zinc-700">
+                      <span className="text-[10px] text-fg-3">
                         {new Date(pa.created_at).toLocaleDateString()}
                       </span>
                       <ChevronDown
                         size={13}
-                        className={`text-zinc-700 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                        className={`text-fg-3 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
                       />
                     </button>
 
                     {isExpanded && (
-                      <div className="border-t border-white/[0.04] px-4 pb-4 pt-3">
+                      <div className="border-t border-line px-4 pb-4 pt-3">
                         {expandedPastData && expandedPastData.id === pa.id ? (
                           <div className="space-y-4">
                             {expandedPastData.path_roles && expandedPastData.path_roles.length > 0 && (
@@ -340,7 +340,7 @@ export default function CareerPathPage() {
                           </div>
                         ) : (
                           <div className="flex justify-center py-4">
-                            <Loader2 size={14} className="animate-spin text-zinc-700" />
+                            <Loader2 size={14} className="animate-spin text-fg-3" />
                           </div>
                         )}
                       </div>

--- a/frontend/src/app/workspace/[resumeId]/cover-letter/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/cover-letter/page.tsx
@@ -324,22 +324,22 @@ export default function CoverLetterPage() {
     <div className="content-shell min-h-screen space-y-6 pb-12">
       <header className="flex items-end justify-between gap-4">
         <div>
-          <p className="overline">Cover Letter</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">
+          <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Cover Letter</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-fg">
             AI Cover Letter Generator
           </h1>
-          <p className="mt-1 text-sm text-zinc-400">
+          <p className="mt-1 text-sm text-fg-2">
             Generate a tailored cover letter for &quot;{resume?.title}&quot; — matching your resume&apos;s style.
           </p>
         </div>
         <div className="flex gap-2">
           <Link
             href={`/workspace/${resumeId}/edit`}
-            className="btn-ghost px-4 py-2 text-xs"
+            className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs text-fg hover:bg-surface-2"
           >
             Back to Editor
           </Link>
-          <span className="rounded-lg border border-violet-300/25 bg-violet-300/10 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-violet-200">
+          <span className="rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-accent-strong">
             <Mail size={10} className="mr-1 inline" />
             Cover Letter
           </span>
@@ -350,29 +350,29 @@ export default function CoverLetterPage() {
         {/* Left sidebar — configuration */}
         <aside className="space-y-6">
           {/* Job Description */}
-          <section className="surface-panel edge-highlight p-5">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
             <div className="flex items-center justify-between">
-              <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+              <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
                 Job Description
               </h2>
-              <span className="text-[10px] text-zinc-600">required</span>
+              <span className="text-[10px] text-fg-3">required</span>
             </div>
             <textarea
               value={jobDescription}
               onChange={(e) => setJobDescription(e.target.value)}
               placeholder="Paste the job description to tailor the cover letter to a specific role..."
               disabled={isProcessing}
-              className="scrollbar-subtle mt-3 h-40 w-full resize-none rounded-xl border border-white/10 bg-black/40 p-4 text-sm text-zinc-100 outline-none transition focus:border-violet-300/50"
+              className="scrollbar-subtle mt-3 h-40 w-full resize-none rounded-[var(--radius-lg)] border border-line bg-bg p-4 text-sm text-fg outline-none transition focus:border-accent"
             />
-            <p className="mt-1 text-right text-[10px] text-zinc-600">
+            <p className="mt-1 text-right text-[10px] text-fg-3">
               {jobDescription.length.toLocaleString()} chars
             </p>
           </section>
 
           {/* Company & Role */}
-          <section className="surface-panel edge-highlight p-5 space-y-3">
-            <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
-              Details <span className="text-zinc-600 font-normal">(optional)</span>
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 space-y-3">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
+              Details <span className="text-fg-3 font-normal">(optional)</span>
             </h2>
             <input
               type="text"
@@ -380,7 +380,7 @@ export default function CoverLetterPage() {
               onChange={(e) => setCompanyName(e.target.value)}
               placeholder="Company name"
               disabled={isProcessing}
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-violet-300/50"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
             />
             <input
               type="text"
@@ -388,13 +388,13 @@ export default function CoverLetterPage() {
               onChange={(e) => setRoleTitle(e.target.value)}
               placeholder="Role title"
               disabled={isProcessing}
-              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-violet-300/50"
+              className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
             />
           </section>
 
           {/* Tone */}
-          <section className="surface-panel edge-highlight p-5">
-            <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
               Tone
             </h2>
             <div className="flex gap-2">
@@ -404,10 +404,10 @@ export default function CoverLetterPage() {
                   onClick={() => setTone(opt.value)}
                   disabled={isProcessing}
                   title={opt.desc}
-                  className={`flex-1 rounded-lg border px-3 py-2 text-xs font-medium transition ${
+                  className={`flex-1 rounded-[var(--radius-md)] border px-3 py-2 text-xs font-medium transition ${
                     tone === opt.value
-                      ? 'border-violet-400/40 bg-violet-500/20 text-violet-200'
-                      : 'border-white/10 text-zinc-500 hover:text-zinc-300'
+                      ? 'border-accent bg-accent-soft text-accent-strong'
+                      : 'border-line text-fg-3 hover:text-fg-2'
                   }`}
                 >
                   {opt.label}
@@ -417,8 +417,8 @@ export default function CoverLetterPage() {
           </section>
 
           {/* Length */}
-          <section className="surface-panel edge-highlight p-5">
-            <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
               Length
             </h2>
             <div className="flex gap-2">
@@ -428,10 +428,10 @@ export default function CoverLetterPage() {
                   onClick={() => setLengthPref(opt.value)}
                   disabled={isProcessing}
                   title={opt.desc}
-                  className={`flex-1 rounded-lg border px-3 py-2 text-xs font-medium transition ${
+                  className={`flex-1 rounded-[var(--radius-md)] border px-3 py-2 text-xs font-medium transition ${
                     lengthPref === opt.value
-                      ? 'border-violet-400/40 bg-violet-500/20 text-violet-200'
-                      : 'border-white/10 text-zinc-500 hover:text-zinc-300'
+                      ? 'border-accent bg-accent-soft text-accent-strong'
+                      : 'border-line text-fg-3 hover:text-fg-2'
                   }`}
                 >
                   {opt.label}
@@ -444,7 +444,7 @@ export default function CoverLetterPage() {
           <button
             onClick={runGeneration}
             disabled={isProcessing || isSubmitting || !jobDescription.trim()}
-            className="btn-accent w-full py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full rounded-[var(--radius-md)] bg-accent py-3 text-sm font-semibold text-accent-fg hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isProcessing || isSubmitting ? 'Generating...' : 'Generate Cover Letter'}
           </button>
@@ -456,26 +456,26 @@ export default function CoverLetterPage() {
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -8 }}
-                className="surface-panel edge-highlight p-5"
+                className="rounded-[var(--radius-lg)] border border-line bg-surface p-5"
               >
                 <div className="mb-4 flex items-start justify-between gap-3">
-                  <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+                  <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
                     Generation Status
                   </h2>
-                  <span className="font-mono text-[10px] text-zinc-500">
+                  <span className="font-mono text-[10px] text-fg-3">
                     {activeJobId.slice(0, 8)}
                   </span>
                 </div>
-                <div className="h-2 rounded-full bg-white/10">
+                <div className="h-2 rounded-full bg-surface-2">
                   <div
-                    className="h-full rounded-full bg-violet-400 transition-all"
+                    className="h-full rounded-full bg-accent transition-all"
                     style={{ width: `${stream.percent}%` }}
                   />
                 </div>
-                <p className="mt-3 text-sm capitalize text-zinc-200">
+                <p className="mt-3 text-sm capitalize text-fg">
                   {stream.stage || 'Initializing'}
                 </p>
-                <p className="mt-1 text-xs text-zinc-500">
+                <p className="mt-1 text-xs text-fg-3">
                   {stream.message || 'Connecting to workers...'}
                 </p>
               </motion.section>
@@ -483,11 +483,11 @@ export default function CoverLetterPage() {
           </AnimatePresence>
 
           {/* Live Logs */}
-          <section className="surface-panel edge-highlight p-5">
-            <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
               Live Logs
             </h2>
-            <div className="mt-4 h-40 overflow-hidden rounded-lg bg-black/60">
+            <div className="mt-4 h-40 overflow-hidden rounded-[var(--radius-md)] bg-bg">
               <LogViewer
                 lines={stream.logLines}
                 maxHeight="100%"
@@ -498,34 +498,34 @@ export default function CoverLetterPage() {
 
           {/* Existing Cover Letters */}
           {existingCoverLetters.length > 0 && (
-            <section className="surface-panel edge-highlight p-5">
-              <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+            <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+              <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
                 Previous Cover Letters ({existingCoverLetters.length})
               </h2>
               <div className="space-y-2 max-h-48 overflow-y-auto scrollbar-subtle">
                 {existingCoverLetters.map((cl) => (
                   <div
                     key={cl.id}
-                    className={`flex items-center justify-between rounded-lg border p-3 transition ${
+                    className={`flex items-center justify-between rounded-[var(--radius-md)] border p-3 transition ${
                       activeCoverLetterId === cl.id
-                        ? 'border-violet-400/40 bg-violet-500/10'
-                        : 'border-white/10 hover:border-white/20'
+                        ? 'border-accent bg-accent-soft'
+                        : 'border-line hover:border-line-2'
                     }`}
                   >
                     <button
                       onClick={() => loadCoverLetter(cl)}
                       className="flex-1 text-left"
                     >
-                      <p className="text-xs font-medium text-zinc-200 truncate">
+                      <p className="text-xs font-medium text-fg truncate">
                         {cl.company_name || cl.role_title || 'Cover Letter'}
                       </p>
-                      <p className="text-[10px] text-zinc-500">
+                      <p className="text-[10px] text-fg-3">
                         {new Date(cl.created_at).toLocaleDateString()}
                       </p>
                     </button>
                     <button
                       onClick={() => deleteCoverLetter(cl.id)}
-                      className="ml-2 text-[10px] text-zinc-600 hover:text-rose-400 transition"
+                      className="ml-2 text-[10px] text-fg-3 hover:text-err transition"
                     >
                       Delete
                     </button>
@@ -540,20 +540,20 @@ export default function CoverLetterPage() {
         <main className="space-y-6">
           <div className="grid gap-6 xl:grid-cols-2">
             {/* LaTeX Editor */}
-            <section className="surface-panel edge-highlight flex h-[620px] flex-col overflow-hidden">
-              <div className="flex h-11 items-center justify-between border-b border-white/10 bg-white/[0.03] px-4">
+            <section className="rounded-[var(--radius-lg)] border border-line bg-surface flex h-[620px] flex-col overflow-hidden">
+              <div className="flex h-11 items-center justify-between border-b border-line bg-surface-2 px-4">
                 <div className="flex items-center gap-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
                     <FileText size={12} className="mr-1 inline" />
                     Cover Letter LaTeX
                   </p>
                   <button
                     onClick={toggleAutoCompile}
                     title="Auto-compile on change (2s debounce)"
-                    className={`flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium transition ${
+                    className={`flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1 text-[10px] font-medium transition ${
                       autoCompile
-                        ? 'bg-violet-500/20 text-violet-300 ring-1 ring-violet-500/30'
-                        : 'text-zinc-600 hover:text-zinc-300'
+                        ? 'bg-accent-soft text-accent-strong ring-1 ring-accent'
+                        : 'text-fg-3 hover:text-fg-2'
                     }`}
                   >
                     <Zap size={10} />
@@ -564,7 +564,7 @@ export default function CoverLetterPage() {
                   {hasUnsavedEdits && activeCoverLetterId && (
                     <button
                       onClick={saveChanges}
-                      className="text-xs font-semibold text-violet-300 transition hover:text-white"
+                      className="text-xs font-semibold text-accent-strong transition hover:text-fg"
                     >
                       Save Changes
                     </button>
@@ -572,13 +572,13 @@ export default function CoverLetterPage() {
                   <button
                     onClick={compileCurrentContent}
                     disabled={isProcessing || isSubmitting}
-                    className="text-xs font-semibold text-zinc-300 transition hover:text-white disabled:opacity-50"
+                    className="text-xs font-semibold text-fg-2 transition hover:text-fg disabled:opacity-50"
                   >
                     Compile PDF
                   </button>
                 </div>
               </div>
-              <div className="min-h-0 flex-1 bg-black/20">
+              <div className="min-h-0 flex-1 bg-bg">
                 <LaTeXEditor
                   ref={editorRef}
                   value=""
@@ -591,22 +591,22 @@ export default function CoverLetterPage() {
             </section>
 
             {/* PDF Preview */}
-            <section className="surface-panel edge-highlight flex h-[620px] flex-col overflow-hidden">
-              <div className="flex h-11 items-center justify-between border-b border-white/10 bg-white/[0.03] px-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+            <section className="rounded-[var(--radius-lg)] border border-line bg-surface flex h-[620px] flex-col overflow-hidden">
+              <div className="flex h-11 items-center justify-between border-b border-line bg-surface-2 px-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">
                   Output Preview
                 </p>
                 {pdfUrl && (
                   <a
                     href={pdfUrl}
                     download="cover_letter.pdf"
-                    className="text-xs font-semibold text-zinc-300 transition hover:text-white"
+                    className="text-xs font-semibold text-fg-2 transition hover:text-fg"
                   >
                     Download PDF
                   </a>
                 )}
               </div>
-              <div className="min-h-0 flex-1 bg-black/30">
+              <div className="min-h-0 flex-1 bg-bg">
                 <PDFPreview
                   pdfUrl={pdfUrl}
                   isLoading={isProcessing && stream.percent > 40}
@@ -621,14 +621,14 @@ export default function CoverLetterPage() {
               <motion.section
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="surface-panel edge-highlight p-6"
+                className="rounded-[var(--radius-lg)] border border-line bg-surface p-6"
               >
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <h2 className="text-lg font-semibold text-white">
+                    <h2 className="text-lg font-semibold text-fg">
                       Cover Letter Ready
                     </h2>
-                    <p className="text-sm text-zinc-400">
+                    <p className="text-sm text-fg-2">
                       {stream.tokensUsed ? `${stream.tokensUsed} tokens` : ''}
                       {stream.optimizationTime
                         ? ` in ${stream.optimizationTime.toFixed(1)}s`
@@ -638,12 +638,12 @@ export default function CoverLetterPage() {
                   <div className="flex gap-2">
                     <button
                       onClick={saveChanges}
-                      className="btn-ghost px-4 py-2 text-xs"
+                      className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs text-fg hover:bg-surface-2"
                     >
                       Save to Resume
                     </button>
                     <button
-                      className="btn-accent px-4 py-2 text-xs"
+                      className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-xs font-semibold text-accent-fg hover:brightness-110"
                       onClick={async () => {
                         if (!stream.pdfJobId) return
                         try {

--- a/frontend/src/app/workspace/[resumeId]/edit/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/edit/page.tsx
@@ -159,8 +159,8 @@ function OutlinePanel({
   if (items.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 py-8 px-4">
-        <List size={18} className="text-zinc-800" />
-        <p className="text-[11px] text-zinc-700 text-center">
+        <List size={18} className="text-fg-3" />
+        <p className="text-[11px] text-fg-3 text-center">
           No sections found.<br />Add \section{} to your document.
         </p>
       </div>
@@ -173,11 +173,11 @@ function OutlinePanel({
         <button
           key={idx}
           onClick={() => onJump(item.line)}
-          className="flex w-full items-baseline gap-1 px-2 py-1 text-left text-[11px] text-zinc-500 transition hover:bg-white/[0.04] hover:text-zinc-200"
+          className="flex w-full items-baseline gap-1 px-2 py-1 text-left text-[11px] text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           style={{ paddingLeft: `${8 + item.level * 10}px` }}
           title={`Line ${item.line}`}
         >
-          <span className="shrink-0 text-zinc-800" style={{ fontSize: 9 }}>
+          <span className="shrink-0 text-fg-3" style={{ fontSize: 9 }}>
             {'─'.repeat(item.level > 0 ? 1 : 0)}
           </span>
           <span className="truncate">{item.label}</span>
@@ -200,7 +200,7 @@ function AIStagePipeline({ stage, percent, message }: { stage: string; percent: 
   return (
     <div className="w-full space-y-4">
       <div className="relative flex items-start justify-between">
-        <div className="absolute left-4 right-4 top-3.5 h-px bg-white/[0.06]" />
+        <div className="absolute left-4 right-4 top-3.5 h-px bg-line" />
         {STAGES.map((s, i) => {
           const done = i < current
           const active = i === current
@@ -209,17 +209,17 @@ function AIStagePipeline({ stage, percent, message }: { stage: string; percent: 
               <div
                 className={`flex h-7 w-7 items-center justify-center rounded-full border text-[10px] font-bold transition-all duration-300 ${
                   done
-                    ? 'border-emerald-400/40 bg-emerald-500/15 text-emerald-400'
+                    ? 'border-ok/40 bg-ok/15 text-ok'
                     : active
-                    ? 'border-violet-400/50 bg-violet-500/20 text-violet-300'
-                    : 'border-white/[0.08] bg-black/40 text-zinc-700'
+                    ? 'border-accent/50 bg-accent/20 text-accent-strong'
+                    : 'border-line bg-surface-2 text-fg-3'
                 }`}
               >
                 {done ? <CheckCircle2 size={13} /> : <span>{i + 1}</span>}
               </div>
               <span
                 className={`text-[10px] font-medium ${
-                  done ? 'text-emerald-400' : active ? 'text-violet-300' : 'text-zinc-700'
+                  done ? 'text-ok' : active ? 'text-accent-strong' : 'text-fg-3'
                 }`}
               >
                 {s.label}
@@ -230,12 +230,12 @@ function AIStagePipeline({ stage, percent, message }: { stage: string; percent: 
       </div>
       <div>
         <div className="mb-1.5 flex justify-between text-[10px]">
-          <span className="text-zinc-500 truncate">{message || 'Processing…'}</span>
-          <span className="shrink-0 pl-2 tabular-nums text-zinc-600">{percent}%</span>
+          <span className="text-fg-3 truncate">{message || 'Processing…'}</span>
+          <span className="shrink-0 pl-2 tabular-nums text-fg-3">{percent}%</span>
         </div>
-        <div className="h-[3px] w-full overflow-hidden rounded-full bg-white/[0.05]">
+        <div className="h-[3px] w-full overflow-hidden rounded-full bg-surface-2">
           <div
-            className="h-full rounded-full bg-gradient-to-r from-violet-500 to-orange-400 transition-all duration-500"
+            className="h-full rounded-full bg-accent transition-all duration-500"
             style={{ width: `${percent}%` }}
           />
         </div>
@@ -262,18 +262,18 @@ function LevelSelector({
   }
   return (
     <div>
-      <label className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-600">
+      <label className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-3">
         Optimization Level
       </label>
-      <div className="grid grid-cols-3 gap-1 rounded-xl border border-white/[0.06] bg-black/30 p-1">
+      <div className="grid grid-cols-3 gap-1 rounded-[var(--radius-lg)] border border-line bg-surface-2 p-1">
         {(['conservative', 'balanced', 'aggressive'] as OptLevel[]).map((level) => (
           <button
             key={level}
             onClick={() => onChange(level)}
-            className={`rounded-lg py-2 text-[11px] font-medium capitalize transition ${
+            className={`rounded-[var(--radius-md)] py-2 text-[11px] font-medium capitalize transition ${
               value === level
-                ? 'bg-violet-500/25 text-violet-200 ring-1 ring-violet-400/30'
-                : 'text-zinc-600 hover:text-zinc-300'
+                ? 'bg-accent/20 text-accent-strong ring-1 ring-accent/30'
+                : 'text-fg-3 hover:text-fg-2'
             }`}
           >
             {level}
@@ -281,7 +281,7 @@ function LevelSelector({
         ))}
       </div>
       {!compact && (
-        <p className="mt-1.5 text-[10px] text-zinc-700">{descriptions[value]}</p>
+        <p className="mt-1.5 text-[10px] text-fg-3">{descriptions[value]}</p>
       )}
     </div>
   )
@@ -302,18 +302,18 @@ function ModelSelector({
   ]
   return (
     <div>
-      <label className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-600">
+      <label className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-3">
         Model
       </label>
-      <div className="grid grid-cols-2 gap-1 rounded-xl border border-white/[0.06] bg-black/30 p-1">
+      <div className="grid grid-cols-2 gap-1 rounded-[var(--radius-lg)] border border-line bg-surface-2 p-1">
         {models.map((m) => (
           <button
             key={m.id}
             onClick={() => onChange(m.id)}
-            className={`rounded-lg py-2 text-[11px] font-medium transition ${
+            className={`rounded-[var(--radius-md)] py-2 text-[11px] font-medium transition ${
               value === m.id
-                ? 'bg-violet-500/25 text-violet-200 ring-1 ring-violet-400/30'
-                : 'text-zinc-600 hover:text-zinc-300'
+                ? 'bg-accent/20 text-accent-strong ring-1 ring-accent/30'
+                : 'text-fg-3 hover:text-fg-2'
             }`}
           >
             {m.label}
@@ -321,7 +321,7 @@ function ModelSelector({
         ))}
       </div>
       {!compact && (
-        <p className="mt-1.5 text-[10px] text-zinc-700">
+        <p className="mt-1.5 text-[10px] text-fg-3">
           {models.find((m) => m.id === value)?.desc}
         </p>
       )}
@@ -341,10 +341,10 @@ function JDInput({
   return (
     <div>
       <div className="mb-2 flex items-center justify-between">
-        <label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-600">
+        <label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-3">
           Job Description
         </label>
-        <span className="text-[10px] text-zinc-700">optional</span>
+        <span className="text-[10px] text-fg-3">optional</span>
       </div>
       <textarea
         value={value}
@@ -355,7 +355,7 @@ function JDInput({
             : 'Paste a job description to tailor optimization to a specific role. Leave blank for general improvements.'
         }
         rows={compact ? 3 : 5}
-        className="w-full resize-none rounded-xl border border-white/[0.06] bg-black/40 p-3 text-[12px] text-zinc-200 outline-none transition placeholder:text-zinc-700 focus:border-violet-400/30"
+        className="w-full resize-none rounded-[var(--radius-lg)] border border-line bg-surface-2 p-3 text-[12px] text-fg outline-none transition placeholder:text-fg-3 focus:border-accent"
       />
     </div>
   )
@@ -396,32 +396,32 @@ function SectionSelector({
   return (
     <div>
       <div className="mb-2 flex items-center justify-between">
-        <label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-600">
+        <label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-3">
           Sections
         </label>
         <button
           onClick={() => onChange([])}
-          className="text-[10px] text-zinc-700 transition hover:text-zinc-400"
+          className="text-[10px] text-fg-3 transition hover:text-fg-2"
         >
           {allSelected ? 'all' : `${selected.length} selected`}
         </button>
       </div>
-      <div className="max-h-32 overflow-y-auto rounded-xl border border-white/[0.06] bg-black/30 p-2 space-y-0.5">
+      <div className="max-h-32 overflow-y-auto rounded-[var(--radius-lg)] border border-line bg-surface-2 p-2 space-y-0.5">
         {outline.map((item) => {
           const checked = selected.length === 0 || selected.includes(item.label)
           return (
             <label
               key={item.label}
-              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[11px] transition hover:bg-white/[0.04]"
+              className="flex cursor-pointer items-center gap-2 rounded-[var(--radius-md)] px-2 py-1 text-[11px] transition hover:bg-surface-2"
             >
               <input
                 type="checkbox"
                 checked={checked}
                 onChange={() => toggle(item.label)}
-                className="h-3 w-3 accent-violet-400"
+                className="h-3 w-3 accent-[var(--accent)]"
               />
               <span
-                className="truncate text-zinc-400"
+                className="truncate text-fg-2"
                 style={{ paddingLeft: `${item.level * 8}px` }}
               >
                 {item.label}
@@ -487,10 +487,10 @@ function AIPanel({
         <div className="flex flex-1 flex-col items-center justify-center gap-8 p-6">
           <div className="w-full">
             <div className="mb-5 flex items-center gap-2">
-              <div className="flex h-5 w-5 items-center justify-center rounded-full bg-violet-500/20">
-                <Sparkles size={11} className="animate-pulse text-violet-300" />
+              <div className="flex h-5 w-5 items-center justify-center rounded-full bg-accent/20">
+                <Sparkles size={11} className="animate-pulse text-accent-strong" />
               </div>
-              <span className="text-xs font-semibold text-zinc-300">AI is working…</span>
+              <span className="text-xs font-semibold text-fg-2">AI is working…</span>
             </div>
             <AIStagePipeline
               stage={aiStream.stage}
@@ -499,7 +499,7 @@ function AIPanel({
             />
           </div>
           {aiStream.streamingLatex && (
-            <div className="flex items-center gap-2 rounded-lg border border-violet-400/20 bg-violet-500/5 px-3 py-2 text-[11px] text-violet-300">
+            <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-accent/20 bg-accent/5 px-3 py-2 text-[11px] text-accent-strong">
               <Sparkles size={11} />
               <span>Streaming to editor in real-time…</span>
             </div>
@@ -509,11 +509,11 @@ function AIPanel({
 
       {isDone && (
         <div className="space-y-4 p-4">
-          <div className="flex items-center gap-3 rounded-xl border border-emerald-400/20 bg-emerald-500/[0.07] p-3">
-            <CheckCircle2 size={16} className="shrink-0 text-emerald-400" />
+          <div className="flex items-center gap-3 rounded-[var(--radius-lg)] border border-ok/20 bg-ok/10 p-3">
+            <CheckCircle2 size={16} className="shrink-0 text-ok" />
             <div className="min-w-0">
-              <p className="text-sm font-semibold text-emerald-300">Optimization complete</p>
-              <p className="truncate text-[10px] text-zinc-500">
+              <p className="text-sm font-semibold text-ok">Optimization complete</p>
+              <p className="truncate text-[10px] text-fg-3">
                 {aiStream.changesMade?.length ?? 0} changes ·{' '}
                 {aiStream.tokensUsed ? `${aiStream.tokensUsed.toLocaleString()} tokens` : 'PDF ready'}
               </p>
@@ -521,13 +521,13 @@ function AIPanel({
           </div>
 
           {aiStream.atsScore != null && (
-            <div className="flex items-center gap-4 rounded-xl border border-white/[0.06] bg-black/40 p-4">
+            <div className="flex items-center gap-4 rounded-[var(--radius-lg)] border border-line bg-surface-2 p-4">
               <div className="relative shrink-0">
                 <svg className="h-[68px] w-[68px] -rotate-90" viewBox="0 0 36 36">
-                  <circle cx="18" cy="18" r="15.9" fill="none" stroke="rgba(255,255,255,0.05)" strokeWidth="3" />
+                  <circle cx="18" cy="18" r="15.9" fill="none" stroke="var(--line)" strokeWidth="3" />
                   <circle
                     cx="18" cy="18" r="15.9" fill="none"
-                    stroke={aiStream.atsScore >= 80 ? '#34d399' : aiStream.atsScore >= 60 ? '#f59e0b' : '#f87171'}
+                    stroke={aiStream.atsScore >= 80 ? 'var(--ok)' : aiStream.atsScore >= 60 ? 'var(--warn)' : 'var(--err)'}
                     strokeWidth="3"
                     strokeDasharray={`${aiStream.atsScore} ${100 - aiStream.atsScore}`}
                     strokeLinecap="round"
@@ -535,15 +535,15 @@ function AIPanel({
                 </svg>
                 <span
                   className={`absolute inset-0 flex items-center justify-center text-base font-bold ${
-                    aiStream.atsScore >= 80 ? 'text-emerald-400' : aiStream.atsScore >= 60 ? 'text-amber-400' : 'text-rose-400'
+                    aiStream.atsScore >= 80 ? 'text-ok' : aiStream.atsScore >= 60 ? 'text-warn' : 'text-err'
                   }`}
                 >
                   {Math.round(aiStream.atsScore)}
                 </span>
               </div>
               <div>
-                <p className="text-sm font-semibold text-zinc-200">ATS Score</p>
-                <p className="mt-0.5 text-[11px] leading-relaxed text-zinc-500">
+                <p className="text-sm font-semibold text-fg">ATS Score</p>
+                <p className="mt-0.5 text-[11px] leading-relaxed text-fg-3">
                   {aiStream.atsScore >= 80
                     ? 'Excellent — highly compatible'
                     : aiStream.atsScore >= 60
@@ -551,7 +551,7 @@ function AIPanel({
                     : 'Needs improvement'}
                 </p>
                 {aiStream.atsDetails?.recommendations?.[0] && (
-                  <p className="mt-1 text-[10px] italic text-zinc-600">
+                  <p className="mt-1 text-[10px] italic text-fg-3">
                     {aiStream.atsDetails.recommendations[0]}
                   </p>
                 )}
@@ -562,20 +562,20 @@ function AIPanel({
           <button
             onClick={onRun}
             disabled={isSubmitting}
-            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-violet-500/20 py-2.5 text-xs font-semibold text-violet-200 ring-1 ring-violet-400/20 transition hover:bg-violet-500/30"
+            className="flex w-full items-center justify-center gap-1.5 rounded-[var(--radius-lg)] bg-accent/20 py-2.5 text-xs font-semibold text-accent-strong ring-1 ring-accent/20 transition hover:bg-accent/25"
           >
             <Sparkles size={12} /> Run again
           </button>
 
           <button
             onClick={onOpenDeepAnalysis}
-            className="flex w-full items-center justify-center gap-2 rounded-xl border border-violet-400/20 bg-violet-500/10 py-2.5 text-xs font-semibold text-violet-200 transition hover:bg-violet-500/20"
+            className="flex w-full items-center justify-center gap-2 rounded-[var(--radius-lg)] border border-accent/20 bg-accent/10 py-2.5 text-xs font-semibold text-accent-strong transition hover:bg-accent/20"
           >
             <Brain size={12} /> Deep AI Analysis
           </button>
 
-          <div className="border-t border-white/[0.05]" />
-          <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-600">
+          <div className="border-t border-line" />
+          <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-3">
             Settings for next run
           </p>
           <LevelSelector value={optLevel} onChange={setOptLevel} compact />
@@ -586,18 +586,18 @@ function AIPanel({
 
       {isFailed && (
         <div className="space-y-4 p-4">
-          <div className="flex items-start gap-3 rounded-xl border border-rose-400/20 bg-rose-500/[0.07] p-3">
-            <AlertCircle size={15} className="mt-0.5 shrink-0 text-rose-400" />
+          <div className="flex items-start gap-3 rounded-[var(--radius-lg)] border border-err/20 bg-err/10 p-3">
+            <AlertCircle size={15} className="mt-0.5 shrink-0 text-err" />
             <div>
-              <p className="text-sm font-semibold text-rose-300">Optimization failed</p>
-              <p className="mt-0.5 text-[11px] text-zinc-500">{aiStream.error || 'An error occurred'}</p>
+              <p className="text-sm font-semibold text-err">Optimization failed</p>
+              <p className="mt-0.5 text-[11px] text-fg-3">{aiStream.error || 'An error occurred'}</p>
             </div>
           </div>
 
           {/* Timeout upgrade CTA */}
           {aiStream.errorCode === 'compile_timeout' && (
-            <div className="flex items-center justify-between rounded-xl border border-orange-500/20 bg-orange-500/10 px-3 py-2.5">
-              <span className="text-[11px] text-orange-300">
+            <div className="flex items-center justify-between rounded-[var(--radius-lg)] border border-accent/20 bg-accent/10 px-3 py-2.5">
+              <span className="text-[11px] text-accent-strong">
                 ⏱ {aiStream.timeoutError?.plan ?? 'free'} plan limit reached (
                 {aiStream.timeoutError?.plan === 'free' ? '30s'
                   : aiStream.timeoutError?.plan === 'basic' ? '120s'
@@ -606,7 +606,7 @@ function AIPanel({
               {flags.upgrade_ctas && (
                 <a
                   href="/billing"
-                  className="ml-3 shrink-0 text-[11px] font-medium text-orange-200 underline hover:text-orange-100"
+                  className="ml-3 shrink-0 text-[11px] font-medium text-accent-strong underline hover:text-accent-strong"
                 >
                   Upgrade →
                 </a>
@@ -616,17 +616,17 @@ function AIPanel({
 
           {/* Fix 3: Apply anyway when LLM succeeded but compile failed */}
           {aiStream.streamingLatex && (
-            <div className="rounded-xl border border-amber-400/20 bg-amber-500/[0.07] p-3">
+            <div className="rounded-[var(--radius-lg)] border border-warn/20 bg-warn/10 p-3">
               <div className="flex items-center gap-2 mb-2">
-                <AlertTriangle size={13} className="text-amber-400" />
-                <p className="text-[11px] font-semibold text-amber-300">AI rewrite is available</p>
+                <AlertTriangle size={13} className="text-warn" />
+                <p className="text-[11px] font-semibold text-warn">AI rewrite is available</p>
               </div>
-              <p className="text-[10px] text-zinc-500 mb-3">
+              <p className="text-[10px] text-fg-3 mb-3">
                 The LaTeX rewrite completed but failed to compile. You can apply it to the editor and fix the errors manually.
               </p>
               <button
                 onClick={onApplyAnyway}
-                className="w-full rounded-lg border border-amber-400/30 bg-amber-500/10 py-2 text-[11px] font-semibold text-amber-200 transition hover:bg-amber-500/20"
+                className="w-full rounded-[var(--radius-md)] border border-warn/30 bg-warn/10 py-2 text-[11px] font-semibold text-warn transition hover:bg-warn/20"
               >
                 Apply optimized LaTeX anyway
               </button>
@@ -635,7 +635,7 @@ function AIPanel({
 
           <button
             onClick={onRun}
-            className="flex w-full items-center justify-center gap-2 rounded-xl bg-violet-500/20 py-2.5 text-sm font-semibold text-violet-200 ring-1 ring-violet-400/20 transition hover:bg-violet-500/30"
+            className="flex w-full items-center justify-center gap-2 rounded-[var(--radius-lg)] bg-accent/20 py-2.5 text-sm font-semibold text-accent-strong ring-1 ring-accent/20 transition hover:bg-accent/25"
           >
             <Sparkles size={13} /> Try again
           </button>
@@ -645,16 +645,16 @@ function AIPanel({
       {isIdle && (
         <div className="space-y-5 p-4">
           <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-violet-500/20 to-orange-500/10 ring-1 ring-violet-400/20">
-              <Sparkles size={16} className="text-violet-300" />
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[var(--radius-lg)] bg-accent-soft ring-1 ring-accent/20">
+              <Sparkles size={16} className="text-accent-strong" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-zinc-100">AI Optimization</p>
-              <p className="text-[10px] text-zinc-600">GPT-4o · Optimize + Compile + Score</p>
+              <p className="text-sm font-semibold text-fg">AI Optimization</p>
+              <p className="text-[10px] text-fg-3">GPT-4o · Optimize + Compile + Score</p>
             </div>
           </div>
 
-          <p className="text-[12px] leading-relaxed text-zinc-500">
+          <p className="text-[12px] leading-relaxed text-fg-3">
             Rewrites your resume with improved language and ATS keywords, then compiles to PDF and
             scores for recruiter visibility.
           </p>
@@ -676,7 +676,7 @@ function AIPanel({
           <div>
             <button
               onClick={() => setShowCustom((v) => !v)}
-              className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-600 transition hover:text-zinc-400"
+              className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-3 transition hover:text-fg-2"
             >
               <ChevronDown
                 size={11}
@@ -690,7 +690,7 @@ function AIPanel({
                 onChange={(e) => setCustomInstructions(e.target.value)}
                 placeholder="e.g. keep it to 1 page, emphasize Python experience, avoid passive voice"
                 rows={3}
-                className="mt-2 w-full resize-none rounded-xl border border-white/[0.06] bg-black/40 p-3 text-[12px] text-zinc-200 outline-none transition placeholder:text-zinc-700 focus:border-violet-400/30"
+                className="mt-2 w-full resize-none rounded-[var(--radius-lg)] border border-line bg-surface-2 p-3 text-[12px] text-fg outline-none transition placeholder:text-fg-3 focus:border-accent"
               />
             )}
           </div>
@@ -698,7 +698,7 @@ function AIPanel({
           <button
             onClick={onRun}
             disabled={isSubmitting}
-            className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-violet-600/80 to-violet-500/60 py-3 text-sm font-semibold text-white shadow-lg shadow-violet-900/20 ring-1 ring-violet-400/20 transition hover:from-violet-600 hover:to-violet-500/80 disabled:opacity-50"
+            className="flex w-full items-center justify-center gap-2 rounded-[var(--radius-lg)] bg-accent py-3 text-sm font-semibold text-accent-fg shadow-[var(--shadow-2)] ring-1 ring-accent/20 transition hover:brightness-110 disabled:opacity-50"
           >
             {isSubmitting ? (
               <><Loader2 size={14} className="animate-spin" /> Starting…</>
@@ -1824,27 +1824,27 @@ export default function ResumeEditPage() {
 
   if (isLoading) {
     return (
-      <div className="flex h-screen items-center justify-center bg-[#0d0d0d]">
+      <div className="flex h-screen items-center justify-center bg-bg">
         <LoadingSpinner />
       </div>
     )
   }
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-[#0d0d0d]">
+    <div className="flex h-screen flex-col overflow-hidden bg-bg">
 
       {/* ── TOP HEADER ── */}
-      <header className="flex h-11 shrink-0 items-center gap-2 border-b border-white/[0.07] bg-[#111] px-4">
+      <header className="flex h-11 shrink-0 items-center gap-2 border-b border-line bg-surface px-4">
         <div className="flex min-w-0 shrink items-center gap-1.5 text-xs">
-          <Link href="/workspace" className="hidden shrink-0 text-zinc-600 transition hover:text-zinc-300 sm:inline">
+          <Link href="/workspace" className="hidden shrink-0 text-fg-3 transition hover:text-fg-2 sm:inline">
             Workspace
           </Link>
-          <ChevronRight size={12} className="hidden shrink-0 text-zinc-800 sm:block" />
+          <ChevronRight size={12} className="hidden shrink-0 text-fg-3 sm:block" />
           <input
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="w-[120px] min-w-0 max-w-[280px] bg-transparent text-sm font-medium text-zinc-300 outline-none transition placeholder:text-zinc-700 hover:text-white focus:text-white sm:w-auto"
+            className="w-[120px] min-w-0 max-w-[280px] bg-transparent text-sm font-medium text-fg-2 outline-none transition placeholder:text-fg-3 hover:text-fg focus:text-fg sm:w-auto"
             placeholder="Untitled"
           />
         </div>
@@ -1852,7 +1852,7 @@ export default function ResumeEditPage() {
         <div className="flex min-w-0 flex-1 items-center justify-start gap-1 overflow-x-auto whitespace-nowrap scrollbar-none sm:justify-end">
           <button
             onClick={() => setShowImportModal(true)}
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <Upload size={12} />
             Import
@@ -1863,7 +1863,7 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setQrInserterOpen(true)}
             title="Insert QR code"
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <QrCode size={12} />
             QR
@@ -1872,7 +1872,7 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setDateStandardizerOpen(true)}
             title="Standardize date formats"
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <Calendar size={12} />
             Dates
@@ -1881,7 +1881,7 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setAgeAnalysisOpen(true)}
             title="Analyze experience age"
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <Clock size={12} />
             Age
@@ -1890,7 +1890,7 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setContactFormatterOpen(true)}
             title="Normalize contact info"
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <Phone size={12} />
             Contacts
@@ -1899,7 +1899,7 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setSalaryEstimatorOpen(true)}
             title="Estimate salary for this resume"
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <DollarSign size={12} />
             Salary
@@ -1908,7 +1908,7 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setSectionReorderOpen(true)}
             title="AI section reordering"
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <SlidersHorizontal size={12} />
             Reorder
@@ -1917,7 +1917,7 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setImportModalOpen(true)}
             title="Import top projects from GitHub"
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
           >
             <Github size={12} />
             Projects
@@ -1925,7 +1925,7 @@ export default function ResumeEditPage() {
 
           <Link
             href={`/workspace/${resumeId}/cover-letter`}
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-violet-300/80 transition hover:bg-violet-500/10 hover:text-violet-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-accent-strong transition hover:bg-accent/10 hover:text-accent-strong"
           >
             <Mail size={12} />
             Cover Letter
@@ -1933,7 +1933,7 @@ export default function ResumeEditPage() {
 
           <Link
             href={`/workspace/${resumeId}/career`}
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-emerald-300/80 transition hover:bg-emerald-500/10 hover:text-emerald-200"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-ok transition hover:bg-ok/10 hover:text-ok"
           >
             <TrendingUp size={12} />
             Career Path
@@ -1942,10 +1942,10 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setAcademicConvertOpen(true)}
             title="Convert academic CV to industry resume"
-            className={`flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition ${
+            className={`flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium transition ${
               academicReport?.is_academic_cv
-                ? 'text-cyan-200 hover:bg-cyan-500/10 hover:text-cyan-100'
-                : 'text-zinc-500 hover:bg-white/[0.05] hover:text-zinc-200'
+                ? 'text-accent-strong hover:bg-accent/10 hover:text-accent-strong'
+                : 'text-fg-3 hover:bg-surface-2 hover:text-fg'
             }`}
           >
             <GraduationCap size={12} />
@@ -1957,7 +1957,7 @@ export default function ResumeEditPage() {
             <button
               ref={forkTriggerRef}
               onClick={() => { if (forkPopoverOpen) { setForkPopoverOpen(false) } else { openForkPopover() } }}
-              className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg"
             >
               <GitFork size={12} />
               Variant
@@ -1968,7 +1968,7 @@ export default function ResumeEditPage() {
                 <div className="fixed inset-0 z-[200]" onClick={() => setForkPopoverOpen(false)} />
                 {/* Popover — fixed positioning from trigger rect so the scrolling toolbar can't clip it */}
                 <div
-                  className="z-[201] w-64 rounded-lg border border-white/10 bg-zinc-950 p-3 shadow-xl"
+                  className="z-[201] w-64 rounded-[var(--radius-md)] border border-line bg-surface p-3 shadow-[var(--shadow-2)]"
                   style={{ position: 'fixed', top: forkPopoverPos.top, right: forkPopoverPos.right }}
                 >
                   <input
@@ -1978,11 +1978,11 @@ export default function ResumeEditPage() {
                     onKeyDown={e => { if (e.key === 'Enter') handleCreateVariant(); if (e.key === 'Escape') setForkPopoverOpen(false) }}
                     placeholder="Variant title"
                     autoFocus
-                    className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-xs text-zinc-100 outline-none focus:border-orange-300/40 mb-2"
+                    className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-2 py-1.5 text-xs text-fg outline-none focus:border-accent mb-2"
                   />
                   <div className="flex gap-2 justify-end">
-                    <button onClick={() => setForkPopoverOpen(false)} className="px-2 py-1 text-[10px] text-zinc-500 hover:text-zinc-300">Cancel</button>
-                    <button onClick={handleCreateVariant} disabled={isForkingResume} className="rounded-md bg-orange-500/20 px-3 py-1 text-[10px] font-semibold text-orange-200 ring-1 ring-orange-400/20 hover:bg-orange-500/30 disabled:opacity-50">
+                    <button onClick={() => setForkPopoverOpen(false)} className="px-2 py-1 text-[10px] text-fg-3 hover:text-fg-2">Cancel</button>
+                    <button onClick={handleCreateVariant} disabled={isForkingResume} className="rounded-[var(--radius-md)] bg-accent/20 px-3 py-1 text-[10px] font-semibold text-accent-strong ring-1 ring-accent/20 hover:bg-accent/25 disabled:opacity-50">
                       {isForkingResume ? 'Creating...' : 'Create'}
                     </button>
                   </div>
@@ -1995,7 +1995,7 @@ export default function ResumeEditPage() {
           <button
             onClick={handleSave}
             disabled={isSaving}
-            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200 disabled:opacity-40"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
           >
             <Save size={12} />
             {isSaving ? 'Saving…' : 'Save'}
@@ -2006,10 +2006,10 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setShareModalOpen(true)}
             title="Share resume"
-            className={`flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition ${
+            className={`flex items-center gap-1.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-[11px] font-medium transition ${
               shareToken
-                ? 'text-sky-300/90 hover:bg-sky-500/10 hover:text-sky-200'
-                : 'text-zinc-500 hover:bg-white/[0.05] hover:text-zinc-200'
+                ? 'text-accent-strong hover:bg-accent/10 hover:text-accent-strong'
+                : 'text-fg-3 hover:bg-surface-2 hover:text-fg'
             }`}
           >
             <Share2 size={12} />
@@ -2023,10 +2023,10 @@ export default function ResumeEditPage() {
                 onClick={handleToggleGitHubSync}
                 disabled={ghTogglingSync}
                 title={ghSyncEnabled ? 'Disable GitHub sync' : 'Enable GitHub sync'}
-                className={`flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium transition ${
+                className={`flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium transition ${
                   ghSyncEnabled
-                    ? 'bg-zinc-800 text-zinc-200 ring-1 ring-white/[0.1]'
-                    : 'text-zinc-600 hover:text-zinc-300'
+                    ? 'bg-surface-2 text-fg ring-1 ring-line'
+                    : 'text-fg-3 hover:text-fg-2'
                 }`}
               >
                 {ghTogglingSync ? <Loader2 size={11} className="animate-spin" /> : <Github size={11} />}
@@ -2038,7 +2038,7 @@ export default function ResumeEditPage() {
                     onClick={handlePushToGitHub}
                     disabled={ghPushing}
                     title="Push to GitHub"
-                    className="flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200 disabled:opacity-40"
+                    className="flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
                   >
                     {ghPushing ? <Loader2 size={11} className="animate-spin" /> : <Upload size={11} />}
                     Push
@@ -2047,7 +2047,7 @@ export default function ResumeEditPage() {
                     onClick={handlePullFromGitHub}
                     disabled={ghPushing}
                     title="Pull from GitHub"
-                    className="flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200 disabled:opacity-40"
+                    className="flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
                   >
                     <Download size={11} />
                     Pull
@@ -2064,10 +2064,10 @@ export default function ResumeEditPage() {
                 onClick={handleToggleDropboxSync}
                 disabled={dbxTogglingSync}
                 title={dbxSyncEnabled ? 'Disable Dropbox sync' : 'Enable Dropbox sync'}
-                className={`flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium transition ${
+                className={`flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium transition ${
                   dbxSyncEnabled
-                    ? 'bg-zinc-800 text-zinc-200 ring-1 ring-white/[0.1]'
-                    : 'text-zinc-600 hover:text-zinc-300'
+                    ? 'bg-surface-2 text-fg ring-1 ring-line'
+                    : 'text-fg-3 hover:text-fg-2'
                 }`}
               >
                 {dbxTogglingSync ? <Loader2 size={11} className="animate-spin" /> : <Cloud size={11} />}
@@ -2079,7 +2079,7 @@ export default function ResumeEditPage() {
                     onClick={handlePushToDropbox}
                     disabled={dbxSyncing}
                     title="Push to Dropbox"
-                    className="flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200 disabled:opacity-40"
+                    className="flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
                   >
                     {dbxSyncing ? <Loader2 size={11} className="animate-spin" /> : <Upload size={11} />}
                     Push
@@ -2088,7 +2088,7 @@ export default function ResumeEditPage() {
                     onClick={handlePullFromDropbox}
                     disabled={dbxSyncing}
                     title="Pull from Dropbox"
-                    className="flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.05] hover:text-zinc-200 disabled:opacity-40"
+                    className="flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
                   >
                     <Download size={11} />
                     Pull
@@ -2098,7 +2098,7 @@ export default function ResumeEditPage() {
             </>
           )}
 
-          <div className="mx-1 h-3.5 w-px bg-white/[0.08]" />
+          <div className="mx-1 h-3.5 w-px bg-line" />
 
           <CompilerSelector
             resumeId={resumeId}
@@ -2113,7 +2113,7 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setCompileSettingsOpen(true)}
             title="Compile settings"
-            className="flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.04] hover:text-zinc-300"
+            className="flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <Settings2 size={11} />
           </button>
@@ -2122,25 +2122,25 @@ export default function ResumeEditPage() {
           <button
             onClick={() => setCollabOpen(true)}
             title="Collaborators"
-            className="relative flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium text-zinc-500 transition hover:bg-white/[0.04] hover:text-zinc-300"
+            className="relative flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
           >
             <Users size={11} />
             {presenceUsers.length > 0 && (
-              <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-violet-500 text-[8px] font-bold text-white">
+              <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-accent text-[8px] font-bold text-accent-fg">
                 {presenceUsers.length}
               </span>
             )}
           </button>
 
-          <div className="mx-1 h-3.5 w-px bg-white/[0.08]" />
+          <div className="mx-1 h-3.5 w-px bg-line" />
 
           <button
             onClick={toggleAutoCompile}
             title="Auto-compile on change (2s debounce)"
-            className={`flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium transition ${
+            className={`flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1.5 text-[11px] font-medium transition ${
               autoCompile
-                ? 'bg-orange-500/20 text-orange-300 ring-1 ring-orange-500/30'
-                : 'text-zinc-600 hover:text-zinc-300'
+                ? 'bg-accent/20 text-accent-strong ring-1 ring-accent/30'
+                : 'text-fg-3 hover:text-fg-2'
             }`}
           >
             <Zap size={11} />
@@ -2150,7 +2150,7 @@ export default function ResumeEditPage() {
           {(userPlan === 'pro' || userPlan === 'byok') && (
             <span
               title="Your compilations are processed with priority in the queue"
-              className="flex items-center gap-1 rounded-md bg-violet-500/15 px-2 py-1.5 text-[10px] font-semibold text-violet-300 ring-1 ring-violet-500/20"
+              className="flex items-center gap-1 rounded-[var(--radius-md)] bg-accent/15 px-2 py-1.5 text-[10px] font-semibold text-accent-strong ring-1 ring-accent/20"
             >
               <Zap size={9} className="fill-current" />
               Priority
@@ -2160,7 +2160,7 @@ export default function ResumeEditPage() {
           <button
             onClick={runCompile}
             disabled={isSubmitting || isAnyRunning}
-            className="flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.05] px-3 py-1.5 text-[11px] font-semibold text-zinc-200 transition hover:bg-white/[0.09] disabled:opacity-40"
+            className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-1.5 text-[11px] font-semibold text-fg transition hover:bg-surface-2 disabled:opacity-40"
           >
             {isCompiling
               ? <Loader2 size={11} className="animate-spin" />
@@ -2170,10 +2170,10 @@ export default function ResumeEditPage() {
 
           <button
             onClick={() => setRightTab('ai')}
-            className={`flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[11px] font-semibold transition ${
+            className={`flex items-center gap-1.5 rounded-[var(--radius-md)] border px-3 py-1.5 text-[11px] font-semibold transition ${
               isAiRunning
-                ? 'border-violet-400/30 bg-violet-500/15 text-violet-200'
-                : 'border-violet-400/20 bg-gradient-to-r from-violet-500/15 to-orange-500/10 text-violet-200 hover:from-violet-500/25 hover:to-orange-500/15'
+                ? 'border-accent bg-accent/15 text-accent-strong'
+                : 'border-accent/20 bg-accent-soft text-accent-strong hover:brightness-110'
             }`}
           >
             {isAiRunning
@@ -2186,13 +2186,13 @@ export default function ResumeEditPage() {
 
       {/* Variant banner */}
       {parentResumeId && parentTitle && (
-        <div className="flex h-7 shrink-0 items-center justify-between border-b border-orange-500/10 bg-orange-500/5 px-4">
-          <span className="text-xs text-zinc-400">
-            Variant of: <span className="font-medium text-zinc-300">{parentTitle}</span>
+        <div className="flex h-7 shrink-0 items-center justify-between border-b border-accent/10 bg-accent/5 px-4">
+          <span className="text-xs text-fg-2">
+            Variant of: <span className="font-medium text-fg-2">{parentTitle}</span>
           </span>
           <button
             onClick={handleCompareWithParent}
-            className="text-xs font-semibold text-orange-300 transition hover:text-orange-200"
+            className="text-xs font-semibold text-accent-strong transition hover:text-accent-strong"
           >
             Compare with Parent
           </button>
@@ -2209,13 +2209,13 @@ export default function ResumeEditPage() {
 
         {/* ── Left: Outline sidebar (collapsible) — hidden on mobile ── */}
         <aside
-          className={`hidden shrink-0 flex-col border-r border-white/[0.05] bg-[#0a0a0a] transition-all duration-200 md:flex ${
+          className={`hidden shrink-0 flex-col border-r border-line bg-surface transition-all duration-200 md:flex ${
             showOutline ? 'w-48' : 'w-8'
           }`}
         >
           <button
             onClick={() => setShowOutline((v) => !v)}
-            className={`flex h-8 w-full shrink-0 items-center border-b border-white/[0.05] px-1.5 text-zinc-600 transition hover:text-zinc-300 ${
+            className={`flex h-8 w-full shrink-0 items-center border-b border-line px-1.5 text-fg-3 transition hover:text-fg-2 ${
               showOutline ? 'justify-between' : 'justify-center'
             }`}
             title={showOutline ? 'Hide outline' : 'Show outline'}
@@ -2239,18 +2239,18 @@ export default function ResumeEditPage() {
 
         {/* ── Editor ── */}
         <section className="flex min-h-[55vh] w-full min-w-0 flex-col md:min-h-0 md:w-auto" style={{ flex: '3 1 0%' }}>
-          <div className="flex h-8 shrink-0 items-center gap-2 border-b border-white/[0.05] bg-[#0a0a0a] px-3">
-            <div className="flex items-center gap-1.5 rounded-md bg-white/[0.04] px-2.5 py-1 text-[11px] font-medium text-zinc-400">
-              <FileText size={11} className="text-zinc-600" />
+          <div className="flex h-8 shrink-0 items-center gap-2 border-b border-line bg-surface px-3">
+            <div className="flex items-center gap-1.5 rounded-[var(--radius-md)] bg-surface-2 px-2.5 py-1 text-[11px] font-medium text-fg-2">
+              <FileText size={11} className="text-fg-3" />
               {title || 'Untitled'}.tex
             </div>
-            <div className="ml-auto flex items-center gap-0.5 rounded-md bg-white/[0.04] p-0.5">
+            <div className="ml-auto flex items-center gap-0.5 rounded-[var(--radius-md)] bg-surface-2 p-0.5">
               <button
                 onClick={() => handleToggleEditorMode('source')}
                 className={`flex items-center gap-1 rounded px-2 py-0.5 text-[10px] font-medium transition ${
                   editorMode === 'source'
-                    ? 'bg-white/[0.08] text-zinc-200'
-                    : 'text-zinc-600 hover:text-zinc-400'
+                    ? 'bg-surface-2 text-fg'
+                    : 'text-fg-3 hover:text-fg-2'
                 }`}
               >
                 <Code2 size={10} />
@@ -2260,8 +2260,8 @@ export default function ResumeEditPage() {
                 onClick={() => handleToggleEditorMode('wysiwyg')}
                 className={`flex items-center gap-1 rounded px-2 py-0.5 text-[10px] font-medium transition ${
                   editorMode === 'wysiwyg'
-                    ? 'bg-white/[0.08] text-zinc-200'
-                    : 'text-zinc-600 hover:text-zinc-400'
+                    ? 'bg-surface-2 text-fg'
+                    : 'text-fg-3 hover:text-fg-2'
                 }`}
               >
                 <LayoutTemplate size={10} />
@@ -2272,13 +2272,13 @@ export default function ResumeEditPage() {
           {/* Offline status banner (Feature 79F) */}
           <OfflineBanner pendingCount={offlinePendingCount} />
           {academicReport?.is_academic_cv && (
-            <div className="flex shrink-0 items-center justify-between border-b border-cyan-500/20 bg-cyan-500/10 px-4 py-1.5">
-              <span className="text-[11px] text-cyan-200">
+            <div className="flex shrink-0 items-center justify-between border-b border-accent/20 bg-accent/10 px-4 py-1.5">
+              <span className="text-[11px] text-accent-strong">
                 Academic CV detected ({academicReport.estimated_pages} pages, {academicReport.detected_sections.join(', ') || 'academic signals'}). Convert it into an industry resume variant.
               </span>
               <button
                 onClick={() => setAcademicConvertOpen(true)}
-                className="ml-3 text-[11px] text-cyan-100 underline hover:text-white"
+                className="ml-3 text-[11px] text-accent-strong underline hover:text-fg"
               >
                 Convert with AI →
               </button>
@@ -2286,14 +2286,14 @@ export default function ResumeEditPage() {
           )}
           {/* Page overflow warning banner */}
           {pageCount !== null && pageCount > 1 && (
-            <div className="flex shrink-0 items-center justify-between border-b border-amber-500/20 bg-amber-500/10 px-4 py-1.5">
-              <span className="text-[11px] text-amber-400">
+            <div className="flex shrink-0 items-center justify-between border-b border-warn/20 bg-warn/10 px-4 py-1.5">
+              <span className="text-[11px] text-warn">
                 ⚠ Your resume is {pageCount} pages. Most recruiters prefer 1 page.
               </span>
               <button
                 onClick={handleTrimToOnePage}
                 disabled={isAiSubmitting || isAnyRunning}
-                className="ml-3 text-[11px] text-amber-300 underline hover:text-amber-100 disabled:opacity-50"
+                className="ml-3 text-[11px] text-warn underline hover:text-warn disabled:opacity-50"
               >
                 Trim with AI →
               </button>
@@ -2310,7 +2310,7 @@ export default function ResumeEditPage() {
                 />
               </div>
             ) : editorMode === 'wysiwyg' && !wysiwygDoc ? (
-              <div className="flex h-full items-center justify-center text-[12px] text-zinc-600">
+              <div className="flex h-full items-center justify-center text-[12px] text-fg-3">
                 Parsing…
               </div>
             ) : isMobile ? (
@@ -2378,7 +2378,7 @@ export default function ResumeEditPage() {
               <button
                 onClick={handleOpenSummaryWidget}
                 title="AI Summary Generator"
-                className="absolute left-1 z-20 flex items-center gap-1 rounded-md bg-violet-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-violet-300 ring-1 ring-violet-400/20 transition hover:bg-violet-500/30"
+                className="absolute left-1 z-20 flex items-center gap-1 rounded-[var(--radius-md)] bg-accent/20 px-1.5 py-0.5 text-[10px] font-semibold text-accent-strong ring-1 ring-accent/20 transition hover:bg-accent/25"
                 style={{ top: (editorRef.current?.getCaretPosition()?.top ?? 0) + 2 }}
               >
                 <Sparkles size={9} />
@@ -2408,7 +2408,7 @@ export default function ResumeEditPage() {
               <button
                 onClick={handleOpenBulletWidget}
                 title="AI Bullet Generator"
-                className="absolute left-1 z-20 flex items-center gap-1 rounded-md bg-violet-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-violet-300 ring-1 ring-violet-400/20 transition hover:bg-violet-500/30"
+                className="absolute left-1 z-20 flex items-center gap-1 rounded-[var(--radius-md)] bg-accent/20 px-1.5 py-0.5 text-[10px] font-semibold text-accent-strong ring-1 ring-accent/20 transition hover:bg-accent/25"
                 style={{ top: (editorRef.current?.getCaretPosition()?.top ?? 0) + 2 }}
               >
                 <Sparkles size={9} />
@@ -2441,13 +2441,13 @@ export default function ResumeEditPage() {
           className="group relative hidden w-[5px] shrink-0 cursor-col-resize items-center justify-center md:flex"
           onMouseDown={startResize}
         >
-          <div className="h-full w-px bg-white/[0.05] transition-colors group-hover:bg-orange-400/30 group-active:bg-orange-400/60" />
+          <div className="h-full w-px bg-line transition-colors group-hover:bg-accent/30 group-active:bg-accent/60" />
         </div>
 
         {/* ── Right panel ── */}
         <aside
           ref={rightPanelRef}
-          className="flex min-h-[60vh] w-full min-w-0 flex-col border-t border-white/[0.05] bg-[#0e0e0e] md:min-h-0 md:w-auto md:border-l md:border-t-0"
+          className="flex min-h-[60vh] w-full min-w-0 flex-col border-t border-line bg-surface md:min-h-0 md:w-auto md:border-l md:border-t-0"
           style={
             isMobile
               ? undefined
@@ -2459,7 +2459,7 @@ export default function ResumeEditPage() {
           {/* Tab bar */}
           <div
             ref={rightTabBarRef}
-            className="flex h-9 shrink-0 snap-x items-center overflow-x-auto whitespace-nowrap border-b border-white/[0.05] bg-black/20 px-1 pr-3 scrollbar-none"
+            className="flex h-9 shrink-0 snap-x items-center overflow-x-auto whitespace-nowrap border-b border-line bg-surface px-1 pr-3 scrollbar-none"
             style={{ WebkitOverflowScrolling: 'touch' }}
           >
             {(
@@ -2487,28 +2487,28 @@ export default function ResumeEditPage() {
                 key={id}
                 ref={rightTab === id ? activeRightTabRef : undefined}
                 onClick={() => setRightTab(id)}
-                className={`relative flex shrink-0 snap-start items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium transition ${
-                  rightTab === id ? 'text-zinc-100' : 'text-zinc-600 hover:text-zinc-300'
+                className={`relative flex shrink-0 snap-start items-center gap-1.5 rounded-[var(--radius-md)] px-3 py-1.5 text-[11px] font-medium transition ${
+                  rightTab === id ? 'text-fg' : 'text-fg-3 hover:text-fg-2'
                 }`}
               >
                 <Icon size={11} />
                 {label}
                 {rightTab === id && (
-                  <span className="absolute inset-x-1 bottom-0 h-[2px] rounded-t-sm bg-orange-400" />
+                  <span className="absolute inset-x-1 bottom-0 h-[2px] rounded-t-sm bg-accent" />
                 )}
                 {id === 'ai' && isAiRunning && (
-                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-violet-400" />
+                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
                 )}
                 {id === 'logs' && isCompiling && (
-                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-orange-400" />
+                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
                 )}
                 {id === 'linter' && lintIssues.length > 0 && (
-                  <span className="ml-0.5 rounded bg-amber-500/20 px-1 py-0.5 font-mono text-[8px] text-amber-300">
+                  <span className="ml-0.5 rounded bg-warn/20 px-1 py-0.5 font-mono text-[8px] text-warn">
                     {lintIssues.length}
                   </span>
                 )}
                 {id === 'changes' && trackedChanges.length > 0 && (
-                  <span className="ml-0.5 rounded bg-emerald-500/20 px-1 py-0.5 font-mono text-[8px] text-emerald-300">
+                  <span className="ml-0.5 rounded bg-ok/20 px-1 py-0.5 font-mono text-[8px] text-ok">
                     {trackedChanges.length}
                   </span>
                 )}
@@ -2521,7 +2521,7 @@ export default function ResumeEditPage() {
               <>
                 <button
                   onClick={handleDownload}
-                  className="flex shrink-0 items-center gap-1 px-2 py-1 text-[10px] text-zinc-600 transition hover:text-zinc-300"
+                  className="flex shrink-0 items-center gap-1 px-2 py-1 text-[10px] text-fg-3 transition hover:text-fg-2"
                 >
                   <Download size={11} />
                   PDF
@@ -2580,13 +2580,13 @@ export default function ResumeEditPage() {
             {rightTab === 'logs' && (
               <div className="h-full overflow-auto p-3">
                 <div className="mb-2 flex items-center justify-between px-1">
-                  <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-700">
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-3">
                     {isCompiling ? 'Compilation output' : isAiRunning ? 'AI pipeline logs' : 'Last run logs'}
                   </span>
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => setShowErrorHistory(true)}
-                      className="text-[10px] font-medium text-zinc-500 hover:text-orange-400 transition"
+                      className="text-[10px] font-medium text-fg-3 hover:text-accent-strong transition"
                       title="View error history"
                     >
                       Error History
@@ -2594,10 +2594,10 @@ export default function ResumeEditPage() {
                     <span
                       className={`text-[10px] font-medium capitalize ${
                         isAnyRunning
-                          ? 'text-orange-400'
+                          ? 'text-accent-strong'
                           : compileStream.status === 'completed' || aiStream.status === 'completed'
-                          ? 'text-emerald-400'
-                          : 'text-zinc-600'
+                          ? 'text-ok'
+                          : 'text-fg-3'
                       }`}
                     >
                       {isAnyRunning
@@ -2797,18 +2797,18 @@ export default function ResumeEditPage() {
 
       {/* Import modal */}
       {showImportModal && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="w-full max-w-md rounded-2xl border border-white/10 bg-zinc-950 shadow-2xl shadow-black/60 p-6">
+        <div className="fixed inset-0 bg-[var(--overlay)] flex items-center justify-center z-50 p-4">
+          <div className="w-full max-w-md rounded-[var(--radius-lg)] border border-line bg-surface shadow-[var(--shadow-2)] p-6">
             <div className="flex justify-between items-center mb-3">
-              <h3 className="text-base font-semibold text-zinc-100">Import Resume File</h3>
+              <h3 className="text-base font-semibold text-fg">Import Resume File</h3>
               <button
                 onClick={() => setShowImportModal(false)}
-                className="rounded-md p-1.5 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-300"
+                className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2"
               >
                 <X size={16} />
               </button>
             </div>
-            <p className="text-xs text-zinc-500 mb-5">
+            <p className="text-xs text-fg-3 mb-5">
               This will replace the current editor content. Make sure to save first.
             </p>
             <MultiFormatUpload
@@ -2970,8 +2970,8 @@ export default function ResumeEditPage() {
 
       {/* ── TIMEOUT BANNER (compile stream) ── */}
       {compileStream.errorCode === 'compile_timeout' && compileStream.timeoutError && (
-        <div className="flex shrink-0 items-center justify-between border-t border-orange-500/20 bg-orange-500/[0.08] px-3 py-1.5">
-          <span className="text-[11px] text-orange-300">
+        <div className="flex shrink-0 items-center justify-between border-t border-accent/20 bg-accent/10 px-3 py-1.5">
+          <span className="text-[11px] text-accent-strong">
             ⏱ Compile timed out — {compileStream.timeoutError.plan} plan limit (
             {compileStream.timeoutError.plan === 'free' ? '30s'
               : compileStream.timeoutError.plan === 'basic' ? '120s'
@@ -2980,7 +2980,7 @@ export default function ResumeEditPage() {
           {flags.upgrade_ctas && (
             <a
               href="/billing"
-              className="ml-3 shrink-0 text-[11px] font-medium text-orange-200 underline hover:text-orange-100"
+              className="ml-3 shrink-0 text-[11px] font-medium text-accent-strong underline hover:text-accent-strong"
             >
               Upgrade for longer timeouts →
             </a>
@@ -3001,34 +3001,34 @@ export default function ResumeEditPage() {
       )}
 
       {academicConvertOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm" onClick={() => setAcademicConvertOpen(false)}>
-          <div className="w-full max-w-2xl rounded-2xl border border-white/10 bg-[#0f1012] p-5 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] px-4" onClick={() => setAcademicConvertOpen(false)}>
+          <div className="w-full max-w-2xl rounded-[var(--radius-lg)] border border-line bg-surface p-5 shadow-[var(--shadow-2)]" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-base font-semibold text-zinc-100">Academic CV → Industry Resume</h2>
-                <p className="mt-1 text-sm text-zinc-400">
+                <h2 className="text-base font-semibold text-fg">Academic CV → Industry Resume</h2>
+                <p className="mt-1 text-sm text-fg-2">
                   Create a new variant that reframes academic work into industry outcomes without overwriting the original CV.
                 </p>
               </div>
-              <button onClick={() => setAcademicConvertOpen(false)} className="rounded-md p-1.5 text-zinc-500 transition hover:bg-white/[0.06] hover:text-zinc-300">
+              <button onClick={() => setAcademicConvertOpen(false)} className="rounded-[var(--radius-md)] p-1.5 text-fg-3 transition hover:bg-surface-2 hover:text-fg-2">
                 <X size={16} />
               </button>
             </div>
 
             {academicReport && (
-              <div className="mt-4 rounded-xl border border-cyan-400/15 bg-cyan-500/[0.06] p-3 text-xs text-cyan-100/90">
+              <div className="mt-4 rounded-[var(--radius-lg)] border border-accent/15 bg-accent/10 p-3 text-xs text-accent-strong">
                 <div>Detection confidence: {Math.round(academicReport.confidence * 100)}%</div>
                 <div className="mt-1">Signals: {academicReport.detected_sections.join(', ') || 'general academic structure'}</div>
               </div>
             )}
 
             <div className="mt-4 grid gap-4 md:grid-cols-2">
-              <label className="grid gap-2 text-sm text-zinc-300">
+              <label className="grid gap-2 text-sm text-fg-2">
                 <span>Target industry</span>
                 <select
                   value={academicTargetIndustry}
                   onChange={(e) => setAcademicTargetIndustry(e.target.value as typeof academicTargetIndustry)}
-                  className="rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-cyan-300/40"
+                  className="rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none focus:border-accent"
                 >
                   <option value="tech">Software Engineering / Tech</option>
                   <option value="data_science">Data Science / ML</option>
@@ -3038,33 +3038,33 @@ export default function ResumeEditPage() {
                   <option value="other">Other</option>
                 </select>
               </label>
-              <div className="rounded-lg border border-white/8 bg-white/[0.03] p-3 text-xs text-zinc-500">
+              <div className="rounded-[var(--radius-md)] border border-line bg-surface-2 p-3 text-xs text-fg-3">
                 The output is saved as a child variant. You keep the original academic CV unchanged.
               </div>
             </div>
 
-            <label className="mt-4 grid gap-2 text-sm text-zinc-300">
+            <label className="mt-4 grid gap-2 text-sm text-fg-2">
               <span>Optional target role or job description</span>
               <textarea
                 value={academicRoleDescription}
                 onChange={(e) => setAcademicRoleDescription(e.target.value)}
                 rows={7}
                 placeholder="Paste a target role description to bias the conversion toward the right framing and keywords."
-                className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-zinc-100 outline-none placeholder:text-zinc-600 focus:border-cyan-300/40"
+                className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-2 text-sm text-fg outline-none placeholder:text-fg-3 focus:border-accent"
               />
             </label>
 
             <div className="mt-5 flex items-center justify-end gap-2">
               <button
                 onClick={() => setAcademicConvertOpen(false)}
-                className="rounded-md px-3 py-2 text-sm text-zinc-500 transition hover:text-zinc-300"
+                className="rounded-[var(--radius-md)] px-3 py-2 text-sm text-fg-3 transition hover:text-fg-2"
               >
                 Cancel
               </button>
               <button
                 onClick={handleAcademicConvert}
                 disabled={isAcademicConverting}
-                className="inline-flex items-center gap-2 rounded-md bg-cyan-500/20 px-3 py-2 text-sm font-medium text-cyan-100 ring-1 ring-cyan-400/20 transition hover:bg-cyan-500/30 disabled:opacity-50"
+                className="inline-flex items-center gap-2 rounded-[var(--radius-md)] bg-accent/20 px-3 py-2 text-sm font-medium text-accent-strong ring-1 ring-accent/20 transition hover:bg-accent/25 disabled:opacity-50"
               >
                 {isAcademicConverting ? <Loader2 size={14} className="animate-spin" /> : <GraduationCap size={14} />}
                 {isAcademicConverting ? 'Creating Variant…' : 'Create Industry Variant'}
@@ -3101,16 +3101,16 @@ export default function ResumeEditPage() {
       />
 
       {/* ── STATUS BAR ── */}
-      <footer className="flex h-6 shrink-0 items-center justify-between border-t border-white/[0.05] bg-[#0a0a0a] px-3">
+      <footer className="flex h-6 shrink-0 items-center justify-between border-t border-line bg-surface px-3">
         <span
           className={`text-[10px] font-medium ${
             isAnyRunning
-              ? 'text-violet-400'
+              ? 'text-accent-strong'
               : compileStream.status === 'completed' || aiStream.status === 'completed'
-              ? 'text-emerald-400/80'
+              ? 'text-ok'
               : aiStream.status === 'failed' || compileStream.status === 'failed'
-              ? 'text-rose-400/80'
-              : 'text-zinc-700'
+              ? 'text-err'
+              : 'text-fg-3'
           }`}
         >
           {statusText}
@@ -3118,12 +3118,12 @@ export default function ResumeEditPage() {
         <div className="flex items-center gap-3">
           {aiStream.atsScore != null && (
             <span
-              className={`flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11px] font-bold tabular-nums ${
+              className={`flex items-center gap-1.5 rounded-[var(--radius-md)] px-2 py-0.5 text-[11px] font-bold tabular-nums ${
                 aiStream.atsScore >= 80
-                  ? 'bg-emerald-500/15 text-emerald-400 ring-1 ring-emerald-500/20'
+                  ? 'bg-ok/15 text-ok ring-1 ring-ok/20'
                   : aiStream.atsScore >= 60
-                  ? 'bg-amber-500/15 text-amber-400 ring-1 ring-amber-500/20'
-                  : 'bg-rose-500/15 text-rose-400 ring-1 ring-rose-500/20'
+                  ? 'bg-warn/15 text-warn ring-1 ring-warn/20'
+                  : 'bg-err/15 text-err ring-1 ring-err/20'
               }`}
               title="ATS compatibility score from last AI optimization"
             >
@@ -3131,11 +3131,11 @@ export default function ResumeEditPage() {
             </span>
           )}
           {cursorLine && (
-            <span className="text-[10px] tabular-nums text-zinc-700">
+            <span className="text-[10px] tabular-nums text-fg-3">
               Ln {cursorLine}
             </span>
           )}
-          <span className="text-[10px] tabular-nums text-zinc-700">
+          <span className="text-[10px] tabular-nums text-fg-3">
             {latexContent.length.toLocaleString()} chars
           </span>
         </div>

--- a/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
+++ b/frontend/src/app/workspace/[resumeId]/optimize/page.tsx
@@ -425,21 +425,21 @@ export default function OptimizationSuitePage() {
     <div className="content-shell min-h-screen space-y-6 pb-12">
       <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div className="min-w-0">
-          <p className="overline">Optimization</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">Targeted Optimization</h1>
-          <p className="mt-1 text-sm text-zinc-400">Optimize "{resume?.title}" — add a job description to tailor it to a specific role, or leave blank for general improvements.</p>
+          <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Optimization</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-fg">Targeted Optimization</h1>
+          <p className="mt-1 text-sm text-fg-2">Optimize "{resume?.title}" — add a job description to tailor it to a specific role, or leave blank for general improvements.</p>
         </div>
         <div className="flex flex-wrap gap-2 sm:flex-nowrap sm:shrink-0">
           <div className="relative">
             <button
               onClick={() => { setForkPopoverOpen(v => !v); setForkTitleInput(`${resume?.title ?? ''} — Variant`) }}
-              className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-2 text-xs font-semibold text-zinc-400 transition hover:text-zinc-200"
+              className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line px-3 py-2 text-xs font-semibold text-fg-2 transition hover:text-fg"
             >
               <GitFork size={12} />
               Variant
             </button>
             {forkPopoverOpen && (
-              <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-white/10 bg-zinc-950 p-3 shadow-xl">
+              <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-[var(--radius-md)] border border-line bg-bg p-3 shadow-[var(--shadow-2)]">
                 <input
                   type="text"
                   value={forkTitleInput}
@@ -447,27 +447,27 @@ export default function OptimizationSuitePage() {
                   onKeyDown={e => { if (e.key === 'Enter') handleCreateVariant(); if (e.key === 'Escape') setForkPopoverOpen(false) }}
                   placeholder="Variant title"
                   autoFocus
-                  className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-xs text-zinc-100 outline-none focus:border-orange-300/40 mb-2"
+                  className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 px-2 py-1.5 text-xs text-fg outline-none focus:border-accent mb-2"
                 />
                 <div className="flex gap-2 justify-end">
-                  <button onClick={() => setForkPopoverOpen(false)} className="px-2 py-1 text-[10px] text-zinc-500 hover:text-zinc-300">Cancel</button>
-                  <button onClick={handleCreateVariant} disabled={isForkingResume} className="rounded-md bg-orange-500/20 px-3 py-1 text-[10px] font-semibold text-orange-200 ring-1 ring-orange-400/20 hover:bg-orange-500/30 disabled:opacity-50">
+                  <button onClick={() => setForkPopoverOpen(false)} className="px-2 py-1 text-[10px] text-fg-3 hover:text-fg-2">Cancel</button>
+                  <button onClick={handleCreateVariant} disabled={isForkingResume} className="rounded-[var(--radius-md)] bg-accent-soft px-3 py-1 text-[10px] font-semibold text-accent-strong ring-1 ring-accent/20 hover:brightness-110 disabled:opacity-50">
                     {isForkingResume ? 'Creating...' : 'Create'}
                   </button>
                 </div>
               </div>
             )}
           </div>
-          <Link href={`/workspace/${resumeId}/edit`} className="btn-ghost px-4 py-2 text-xs">
+          <Link href={`/workspace/${resumeId}/edit`} className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs text-fg hover:bg-surface-2">
             Back to Editor
           </Link>
           <Link
             href={`/workspace/${resumeId}/cover-letter`}
-            className="rounded-lg border border-violet-300/25 bg-violet-300/10 px-4 py-2 text-xs font-semibold text-violet-200 transition hover:bg-violet-300/20"
+            className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs font-semibold text-fg transition hover:bg-surface-2"
           >
             Cover Letter
           </Link>
-          <span className="rounded-lg border border-orange-300/25 bg-orange-300/10 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-orange-200">
+          <span className="rounded-[var(--radius-md)] border border-accent bg-accent-soft px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-accent-strong">
             Pro Pipeline
           </span>
         </div>
@@ -475,13 +475,13 @@ export default function OptimizationSuitePage() {
 
       {/* Variant banner */}
       {parentResumeId && parentTitle && (
-        <div className="flex items-center justify-between rounded-lg border border-orange-500/10 bg-orange-500/5 px-4 py-2">
-          <span className="text-xs text-zinc-400">
-            Variant of: <span className="font-medium text-zinc-300">{parentTitle}</span>
+        <div className="flex items-center justify-between rounded-[var(--radius-md)] border border-accent bg-accent-soft px-4 py-2">
+          <span className="text-xs text-fg-2">
+            Variant of: <span className="font-medium text-fg-2">{parentTitle}</span>
           </span>
           <button
             onClick={handleCompareWithParent}
-            className="text-xs font-semibold text-orange-300 transition hover:text-orange-200"
+            className="text-xs font-semibold text-accent-strong transition hover:brightness-110"
           >
             Compare with Parent
           </button>
@@ -491,12 +491,12 @@ export default function OptimizationSuitePage() {
       <div className="grid gap-6 lg:grid-cols-[380px_minmax(0,1fr)]">
         <aside className="min-w-0 space-y-6">
           {/* ── Persona selector (Feature 56) ── */}
-          <section className="surface-panel edge-highlight p-5">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
             <div className="flex items-center justify-between">
-              <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Optimization Style</h2>
-              <span className="text-[10px] text-zinc-600">optional</span>
+              <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">Optimization Style</h2>
+              <span className="text-[10px] text-fg-3">optional</span>
             </div>
-            <p className="mt-1 text-[11px] text-zinc-600">Choose a persona to bias the AI toward a specific context.</p>
+            <p className="mt-1 text-[11px] text-fg-3">Choose a persona to bias the AI toward a specific context.</p>
             <div className="mt-3 grid grid-cols-1 gap-1.5">
               {PERSONA_OPTIONS.map((p) => {
                 const active = persona === p.key
@@ -509,16 +509,16 @@ export default function OptimizationSuitePage() {
                       apiClient.updateResumeSettings(resumeId, { last_persona: next ?? '' }).catch(() => {})
                     }}
                     disabled={isProcessing}
-                    className={`flex items-start gap-2.5 rounded-lg border px-3 py-2 text-left transition disabled:opacity-50 ${
+                    className={`flex items-start gap-2.5 rounded-[var(--radius-md)] border px-3 py-2 text-left transition disabled:opacity-50 ${
                       active
-                        ? 'border-orange-400/40 bg-orange-400/10'
-                        : 'border-white/[0.06] bg-black/20 hover:bg-white/[0.04]'
+                        ? 'border-accent bg-accent-soft'
+                        : 'border-line bg-surface-2 hover:bg-surface-2'
                     }`}
                   >
                     <span className="mt-0.5 text-base leading-none">{p.icon}</span>
                     <div className="min-w-0">
-                      <p className={`text-[11px] font-semibold ${active ? 'text-orange-200' : 'text-zinc-300'}`}>{p.label}</p>
-                      <p className="mt-0.5 text-[10px] leading-relaxed text-zinc-600">{p.description}</p>
+                      <p className={`text-[11px] font-semibold ${active ? 'text-accent-strong' : 'text-fg-2'}`}>{p.label}</p>
+                      <p className="mt-0.5 text-[10px] leading-relaxed text-fg-3">{p.description}</p>
                     </div>
                   </button>
                 )
@@ -526,10 +526,10 @@ export default function OptimizationSuitePage() {
             </div>
           </section>
 
-          <section className="surface-panel edge-highlight p-5">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
             <div className="flex items-center justify-between">
-              <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Job Description</h2>
-              <span className="text-[10px] text-zinc-600">optional</span>
+              <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">Job Description</h2>
+              <span className="text-[10px] text-fg-3">optional</span>
             </div>
             <div className="mt-3 flex gap-2">
               <input
@@ -539,13 +539,13 @@ export default function OptimizationSuitePage() {
                 onKeyDown={(e) => { if (e.key === 'Enter') handleScrapeUrl() }}
                 placeholder="Paste job URL (Greenhouse, Lever, Workday, Indeed…)"
                 disabled={isProcessing || isScraping}
-                className="flex-1 rounded-lg border border-white/10 bg-black/40 px-3 py-1.5 text-xs text-zinc-100 outline-none transition placeholder:text-zinc-600 focus:border-orange-300/40 disabled:opacity-50"
+                className="flex-1 rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-1.5 text-xs text-fg outline-none transition placeholder:text-fg-3 focus:border-accent disabled:opacity-50"
               />
               <button
                 onClick={handleScrapeUrl}
                 disabled={!jobUrl.trim() || isProcessing || isScraping}
                 title="Import job description from URL"
-                className="flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-zinc-300 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+                className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-line bg-surface-2 px-3 py-1.5 text-xs font-medium text-fg-2 transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {isScraping ? <Loader2 size={11} className="animate-spin" /> : <Link2 size={11} />}
                 {isScraping ? 'Importing…' : 'Import'}
@@ -554,31 +554,31 @@ export default function OptimizationSuitePage() {
             {scrapedMeta && !scrapedMeta.error && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
                 {scrapedMeta.title && (
-                  <span className="rounded bg-orange-400/10 px-1.5 py-0.5 text-[10px] font-medium text-orange-300">
+                  <span className="rounded bg-accent-soft px-1.5 py-0.5 text-[10px] font-medium text-accent-strong">
                     {scrapedMeta.title}
                   </span>
                 )}
                 {scrapedMeta.company && (
-                  <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-zinc-400">
+                  <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-2">
                     {scrapedMeta.company}
                   </span>
                 )}
                 {scrapedMeta.location && (
-                  <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-zinc-500">
+                  <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-3">
                     📍 {scrapedMeta.location}
                   </span>
                 )}
                 {scrapedMeta.job_type && (
-                  <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-zinc-500">
+                  <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-3">
                     {scrapedMeta.job_type}
                   </span>
                 )}
                 {scrapedMeta.salary && (
-                  <span className="rounded bg-emerald-400/10 px-1.5 py-0.5 text-[10px] text-emerald-400">
+                  <span className="rounded bg-ok/10 px-1.5 py-0.5 text-[10px] text-ok">
                     {scrapedMeta.salary}
                   </span>
                 )}
-                <span className="ml-auto text-[9px] text-zinc-700">
+                <span className="ml-auto text-[9px] text-fg-3">
                   via {scrapedMeta.source}
                 </span>
               </div>
@@ -588,7 +588,7 @@ export default function OptimizationSuitePage() {
               onChange={(event) => setJobDescription(event.target.value)}
               placeholder="Paste a job description to tailor the optimization to a specific role. Leave blank for general improvements."
               disabled={isProcessing}
-              className="scrollbar-subtle mt-2 h-56 w-full resize-none rounded-xl border border-white/10 bg-black/40 p-4 text-sm text-zinc-100 outline-none transition focus:border-orange-300/50"
+              className="scrollbar-subtle mt-2 h-56 w-full resize-none rounded-[var(--radius-lg)] border border-line bg-surface-2 p-4 text-sm text-fg outline-none transition focus:border-accent"
             />
             <div className="mt-3">
               <GuidedIntakePanel value={intake} onChange={setIntake} />
@@ -596,12 +596,12 @@ export default function OptimizationSuitePage() {
             <button
               onClick={runOptimization}
               disabled={isProcessing || isSubmitting}
-              className="btn-accent mt-4 w-full py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-[var(--radius-md)] bg-accent px-4 text-accent-fg hover:brightness-110 mt-4 w-full py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isProcessing || isSubmitting ? 'Processing...' : jobDescription.trim() ? 'Optimize for this Role' : 'Optimize Resume'}
             </button>
             {!intakeIsEmpty(intake) && (
-              <p className="mt-2 text-[10px] leading-relaxed text-zinc-600">
+              <p className="mt-2 text-[10px] leading-relaxed text-fg-3">
                 The AI will follow your direction —
                 {[
                   intake.industry && ` ${intake.industry} industry`,
@@ -620,43 +620,43 @@ export default function OptimizationSuitePage() {
               <motion.section
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="surface-panel edge-highlight p-5"
+                className="rounded-[var(--radius-lg)] border border-line bg-surface p-5"
               >
                 <div className="mb-4 flex items-start justify-between gap-3">
-                  <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Pipeline Status</h2>
-                  <span className="text-[10px] font-mono text-zinc-500">{activeJobId.slice(0, 8)}</span>
+                  <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">Pipeline Status</h2>
+                  <span className="text-[10px] font-mono text-fg-3">{activeJobId.slice(0, 8)}</span>
                 </div>
-                <div className="h-2 rounded-full bg-white/10">
-                  <div className="h-full rounded-full bg-orange-300 transition-all" style={{ width: `${stream.percent}%` }} />
+                <div className="h-2 rounded-full bg-surface-2">
+                  <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${stream.percent}%` }} />
                 </div>
-                <p className="mt-3 text-sm capitalize text-zinc-200">{stream.stage || 'Initializing'}</p>
-                <p className="mt-1 text-xs text-zinc-500">{stream.message || 'Connecting to workers...'}</p>
+                <p className="mt-3 text-sm capitalize text-fg">{stream.stage || 'Initializing'}</p>
+                <p className="mt-1 text-xs text-fg-3">{stream.message || 'Connecting to workers...'}</p>
               </motion.section>
             )}
           </AnimatePresence>
 
-          <section className="surface-panel edge-highlight p-5">
-            <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Live Logs</h2>
-            <div className="mt-4 h-56 overflow-hidden rounded-lg bg-black/60">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">Live Logs</h2>
+            <div className="mt-4 h-56 overflow-hidden rounded-[var(--radius-md)] bg-[var(--overlay)]">
               <LogViewer lines={stream.logLines} maxHeight="100%" className="h-full text-[10px]" />
             </div>
           </section>
 
-          <section className="surface-panel edge-highlight overflow-hidden">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface overflow-hidden">
             <button
               onClick={() => setShowHistory((v) => !v)}
-              className="flex w-full items-center justify-between px-5 py-3.5 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400 transition hover:text-zinc-200"
+              className="flex w-full items-center justify-between px-5 py-3.5 text-xs font-semibold uppercase tracking-[0.14em] text-fg-2 transition hover:text-fg"
             >
               <span className="flex items-center gap-2">
                 <History size={13} />
                 Version History
               </span>
-              <span className="text-[10px] font-normal normal-case tracking-normal text-zinc-600">
+              <span className="text-[10px] font-normal normal-case tracking-normal text-fg-3">
                 {showHistory ? 'Hide' : 'Show'}
               </span>
             </button>
             {showHistory && (
-              <div className="max-h-80 overflow-y-auto border-t border-white/5">
+              <div className="max-h-80 overflow-y-auto border-t border-line">
                 <VersionHistoryPanel
                   resumeId={resumeId}
                   onRestore={handleHistoryRestore}
@@ -670,23 +670,23 @@ export default function OptimizationSuitePage() {
 
         <main className="min-w-0 space-y-6">
           <div className="grid gap-6 xl:grid-cols-2">
-            <section className="surface-panel edge-highlight flex h-[620px] min-w-0 flex-col overflow-hidden">
-              <div className="flex h-11 items-center justify-between gap-2 border-b border-white/10 bg-white/[0.03] px-4">
+            <section className="rounded-[var(--radius-lg)] border border-line bg-surface flex h-[620px] min-w-0 flex-col overflow-hidden">
+              <div className="flex h-11 items-center justify-between gap-2 border-b border-line bg-surface-2 px-4">
                 <div className="flex min-w-0 items-center gap-3 overflow-x-auto">
-                  <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">LaTeX Source</p>
+                  <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">LaTeX Source</p>
                   <button
                     onClick={toggleAutoCompile}
                     title="Auto-compile on change (2s debounce)"
-                    className={`flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium transition ${
+                    className={`flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1 text-[10px] font-medium transition ${
                       autoCompile
-                        ? 'bg-orange-500/20 text-orange-300 ring-1 ring-orange-500/30'
-                        : 'text-zinc-600 hover:text-zinc-300'
+                        ? 'bg-accent-soft text-accent-strong ring-1 ring-accent'
+                        : 'text-fg-3 hover:text-fg-2'
                     }`}
                   >
                     <Zap size={10} />
                     Auto
                   </button>
-                  <span className="h-4 w-px bg-white/10" />
+                  <span className="h-4 w-px bg-line" />
                   <CompilerSelector
                     resumeId={resumeId}
                     current={compiler}
@@ -694,25 +694,25 @@ export default function OptimizationSuitePage() {
                     disabled={isProcessing || isSubmitting}
                   />
                 </div>
-                <button onClick={restoreOriginal} className="shrink-0 text-xs font-semibold text-zinc-300 transition hover:text-white">
+                <button onClick={restoreOriginal} className="shrink-0 text-xs font-semibold text-fg-2 transition hover:text-fg">
                   Restore Original
                 </button>
               </div>
               {stream.pageCount !== null && stream.pageCount > 1 && (
-                <div className="flex shrink-0 items-center justify-between border-b border-amber-500/20 bg-amber-500/10 px-4 py-1.5">
-                  <span className="text-[11px] text-amber-400">
+                <div className="flex shrink-0 items-center justify-between border-b border-warn/20 bg-warn/10 px-4 py-1.5">
+                  <span className="text-[11px] text-warn">
                     ⚠ Your resume is {stream.pageCount} pages. Most recruiters prefer 1 page.
                   </span>
                   <button
                     onClick={handleTrimToOnePage}
                     disabled={isSubmitting || isProcessing}
-                    className="ml-3 text-[11px] text-amber-300 underline hover:text-amber-100 disabled:opacity-50"
+                    className="ml-3 text-[11px] text-warn underline hover:brightness-110 disabled:opacity-50"
                   >
                     Trim with AI →
                   </button>
                 </div>
               )}
-              <div className="relative min-h-0 min-w-0 flex-1 overflow-x-auto bg-black/20">
+              <div className="relative min-h-0 min-w-0 flex-1 overflow-x-auto bg-bg">
                 <LaTeXEditor
                   ref={editorRef}
                   value={resume?.latex_content || ''}
@@ -738,50 +738,50 @@ export default function OptimizationSuitePage() {
               </div>
             </section>
 
-            <section className="surface-panel edge-highlight flex h-[620px] min-w-0 flex-col overflow-hidden">
-              <div className="flex h-11 items-center justify-between gap-2 border-b border-white/10 bg-white/[0.03] px-4">
-                <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Output Preview</p>
+            <section className="rounded-[var(--radius-lg)] border border-line bg-surface flex h-[620px] min-w-0 flex-col overflow-hidden">
+              <div className="flex h-11 items-center justify-between gap-2 border-b border-line bg-surface-2 px-4">
+                <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.14em] text-fg-2">Output Preview</p>
                 <div className="flex items-center gap-3">
                   {compareAfterLatex !== null && compareOriginalLatex !== null && (
                     <>
                       <button
                         onClick={() => setShowReviewModal(true)}
-                        className="text-xs font-semibold text-emerald-300 transition hover:text-emerald-200"
+                        className="text-xs font-semibold text-ok transition hover:brightness-110"
                       >
                         Review Changes
                       </button>
                       <button
                         onClick={() => setShowCompareModal(true)}
-                        className="text-xs font-semibold text-orange-300 transition hover:text-orange-200"
+                        className="text-xs font-semibold text-accent-strong transition hover:brightness-110"
                       >
                         Compare with Original
                       </button>
                     </>
                   )}
                   {pdfUrl && (
-                    <a href={pdfUrl} download="optimized_resume.pdf" className="text-xs font-semibold text-zinc-300 transition hover:text-white">
+                    <a href={pdfUrl} download="optimized_resume.pdf" className="text-xs font-semibold text-fg-2 transition hover:text-fg">
                       Download PDF
                     </a>
                   )}
                 </div>
               </div>
-              <div className="min-h-0 flex-1 bg-black/30">
+              <div className="min-h-0 flex-1 bg-bg">
                 <PDFPreview pdfUrl={pdfUrl} isLoading={isProcessing && stream.percent > 40} />
               </div>
             </section>
           </div>
 
-          <section className="surface-panel edge-highlight overflow-hidden">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface overflow-hidden">
             {/* Tab bar */}
-            <div className="flex overflow-x-auto border-b border-white/10">
+            <div className="flex overflow-x-auto border-b border-line">
               {(['ATS Simulator', 'Keywords', 'Publications'] as const).map(tab => (
                 <button
                   key={tab}
                   onClick={() => setActiveToolTab(tab)}
                   className={`shrink-0 px-5 py-3 text-xs font-semibold uppercase tracking-[0.14em] transition ${
                     activeToolTab === tab
-                      ? 'border-b-2 border-orange-400 text-orange-300'
-                      : 'text-zinc-500 hover:text-zinc-300'
+                      ? 'border-b-2 border-accent text-accent-strong'
+                      : 'text-fg-3 hover:text-fg-2'
                   }`}
                 >
                   {tab}
@@ -791,7 +791,7 @@ export default function OptimizationSuitePage() {
             <div className="p-6">
               {activeToolTab === 'ATS Simulator' ? (
                 <>
-                  <p className="mb-5 text-sm text-zinc-400">
+                  <p className="mb-5 text-sm text-fg-2">
                     See how major ATS platforms parse your resume. Select a system to view the
                     plain-text representation it would extract and identify any compatibility issues.
                   </p>
@@ -799,7 +799,7 @@ export default function OptimizationSuitePage() {
                 </>
               ) : activeToolTab === 'Keywords' ? (
                 <>
-                  <p className="mb-5 text-sm text-zinc-400">
+                  <p className="mb-5 text-sm text-fg-2">
                     Paste a job description to see which keywords your resume covers. Green = present,
                     amber = partial match, red = missing. Click a missing keyword for insertion advice.
                   </p>
@@ -807,7 +807,7 @@ export default function OptimizationSuitePage() {
                 </>
               ) : (
                 <>
-                  <p className="mb-5 text-sm text-zinc-400">
+                  <p className="mb-5 text-sm text-fg-2">
                     Fetch your publications from ORCID and insert a formatted bibliography section
                     directly into your resume. Filter by year range or publication type.
                   </p>
@@ -822,13 +822,13 @@ export default function OptimizationSuitePage() {
               <motion.section
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="surface-panel edge-highlight p-6"
+                className="rounded-[var(--radius-lg)] border border-line bg-surface p-6"
               >
                 <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-                  <h2 className="text-xl font-semibold text-white">ATS Analysis</h2>
+                  <h2 className="text-xl font-semibold text-fg">ATS Analysis</h2>
                   <div className="flex gap-2">
                     <button
-                      className="btn-ghost px-4 py-2 text-xs"
+                      className="rounded-[var(--radius-md)] border border-line-2 px-4 py-2 text-xs text-fg hover:bg-surface-2"
                       onClick={async () => {
                         try {
                           const latex = editorRef.current?.getValue() || stream.streamingLatex || ''
@@ -842,7 +842,7 @@ export default function OptimizationSuitePage() {
                       Save as New Version
                     </button>
                     <button
-                      className="btn-accent px-4 py-2 text-xs"
+                      className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs"
                       onClick={async () => {
                         if (!stream.pdfJobId) return
                         try {

--- a/frontend/src/app/workspace/builder/[resumeId]/page.tsx
+++ b/frontend/src/app/workspace/builder/[resumeId]/page.tsx
@@ -100,12 +100,12 @@ const SECTION_CONFIG: SectionConfig[] = [
 ]
 
 function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
-  return <div className={`rounded-2xl border border-white/8 bg-black/20 p-4 ${className}`}>{children}</div>
+  return <div className={`rounded-[var(--radius-lg)] border border-line bg-surface p-4 ${className}`}>{children}</div>
 }
 
 function FieldLabel({ htmlFor, children }: { htmlFor?: string; children: React.ReactNode }) {
   return (
-    <label htmlFor={htmlFor} className="mb-2 block text-xs uppercase tracking-[0.14em] text-zinc-500">
+    <label htmlFor={htmlFor} className="mb-2 block font-ui text-xs uppercase tracking-[0.14em] text-fg-3">
       {children}
     </label>
   )
@@ -119,7 +119,7 @@ function TextInput(
   return (
     <input
       {...props}
-      className={`w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition focus:border-orange-300/50 ${props.className ?? ''}`}
+      className={`w-full rounded-[var(--radius-md)] border border-line bg-bg px-4 py-3 text-fg outline-none transition focus:border-accent focus:ring-accent focus:ring-offset-bg ${props.className ?? ''}`}
     />
   )
 }
@@ -128,7 +128,7 @@ function TextArea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
   return (
     <textarea
       {...props}
-      className={`w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition focus:border-orange-300/50 ${props.className ?? ''}`}
+      className={`w-full rounded-[var(--radius-md)] border border-line bg-bg px-4 py-3 text-fg outline-none transition focus:border-accent focus:ring-accent focus:ring-offset-bg ${props.className ?? ''}`}
     />
   )
 }
@@ -154,17 +154,17 @@ function SectionHeader({
   return (
     <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
       <div>
-        <p className="text-lg font-semibold text-white">{title}</p>
-        <p className="mt-1 max-w-2xl text-sm text-zinc-400">{description}</p>
+        <p className="text-lg font-semibold text-fg">{title}</p>
+        <p className="mt-1 max-w-2xl text-sm text-fg-2">{description}</p>
       </div>
       <div className="flex items-center gap-2">
-        <button type="button" onClick={() => onMove(sectionKey, -1)} disabled={idx <= 0} className="btn-ghost px-2 py-2 text-xs disabled:opacity-30">
+        <button type="button" onClick={() => onMove(sectionKey, -1)} disabled={idx <= 0} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-2 py-2 text-xs disabled:opacity-30">
           <ArrowUp className="h-3.5 w-3.5" />
         </button>
-        <button type="button" onClick={() => onMove(sectionKey, 1)} disabled={idx === -1 || idx >= order.length - 1} className="btn-ghost px-2 py-2 text-xs disabled:opacity-30">
+        <button type="button" onClick={() => onMove(sectionKey, 1)} disabled={idx === -1 || idx >= order.length - 1} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-2 py-2 text-xs disabled:opacity-30">
           <ArrowDown className="h-3.5 w-3.5" />
         </button>
-        <button type="button" onClick={() => onToggleHidden(sectionKey)} className="btn-ghost px-2 py-2 text-xs">
+        <button type="button" onClick={() => onToggleHidden(sectionKey)} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-2 py-2 text-xs">
           {hidden ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
         </button>
       </div>
@@ -183,7 +183,7 @@ function StarterChip({
     <button
       type="button"
       onClick={onClick}
-      className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-[11px] uppercase tracking-[0.16em] text-zinc-300 transition hover:bg-white/[0.08]"
+      className="rounded-full border border-line bg-surface-2 px-3 py-1.5 text-[11px] uppercase tracking-[0.16em] text-fg-2 transition hover:brightness-110"
     >
       {label}
     </button>
@@ -392,13 +392,13 @@ export default function BuilderResumePage() {
   )
 
   const healthTone = completenessScore >= 85
-    ? 'border-emerald-300/20 bg-emerald-300/[0.08] text-emerald-100'
+    ? 'border-ok/20 bg-ok/10 text-ok'
     : completenessScore >= 65
-      ? 'border-amber-300/20 bg-amber-300/[0.08] text-amber-100'
-      : 'border-rose-300/20 bg-rose-300/[0.08] text-rose-100'
+      ? 'border-warn/20 bg-warn/10 text-warn'
+      : 'border-err/20 bg-err/10 text-err'
 
   if (loading) {
-    return <div className="content-shell py-16 text-sm text-zinc-400">Loading builder…</div>
+    return <div className="content-shell py-16 text-sm text-fg-2">Loading builder…</div>
   }
 
   const hidden = new Set(structured.hidden_sections)
@@ -408,34 +408,34 @@ export default function BuilderResumePage() {
     <div className="content-shell space-y-8 pb-16">
       <header className="flex flex-wrap items-end justify-between gap-4 pt-2">
         <div>
-          <p className="overline">Guided Builder</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">{title || 'Untitled Resume'}</h1>
-          <p className="mt-2 max-w-3xl text-sm text-zinc-400">
+          <p className="font-ui text-xs uppercase tracking-[0.16em] text-fg-3">Guided Builder</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-fg">{title || 'Untitled Resume'}</h1>
+          <p className="mt-2 max-w-3xl text-sm text-fg-2">
             This builder is now the structured path: guide the narrative, tune density, and keep LaTeX synchronized
             without treating the resume like a raw text file.
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <Link href={`/workspace/${resumeId}/edit`} className="btn-ghost px-4 py-2 text-xs">
+          <Link href={`/workspace/${resumeId}/edit`} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
             Open Advanced Editor
           </Link>
-          <div className="rounded-full border border-white/10 px-3 py-2 text-xs text-zinc-400">
+          <div className="rounded-full border border-line px-3 py-2 text-xs text-fg-2">
             {saving ? 'Saving…' : dirty ? 'Unsaved changes' : 'All changes saved'}
           </div>
         </div>
       </header>
 
       {builderStatus === 'detached' ? (
-        <section className="surface-panel edge-highlight border border-amber-300/20 bg-amber-300/[0.05] p-5">
+        <section className="rounded-[var(--radius-lg)] border border-warn/20 bg-warn/10 p-5">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <p className="text-sm font-semibold text-amber-100">Builder detached</p>
-              <p className="mt-1 text-sm text-amber-50/80">
+              <p className="text-sm font-semibold text-warn">Builder detached</p>
+              <p className="mt-1 text-sm text-warn/80">
                 This resume was edited directly in the advanced editor. Structured changes are paused until you explicitly
                 overwrite the current LaTeX from builder data.
               </p>
             </div>
-            <button type="button" onClick={() => void forceReattach()} className="btn-accent px-4 py-2 text-xs">
+            <button type="button" onClick={() => void forceReattach()} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
               <RefreshCcw className="mr-2 inline h-3.5 w-3.5" />
               Reattach Builder
             </button>
@@ -454,25 +454,25 @@ export default function BuilderResumePage() {
           </p>
         </Card>
         <Card>
-          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Page Strategy</p>
-          <p className="mt-2 text-3xl font-semibold text-white">{pageEstimate}</p>
-          <p className="mt-2 text-sm text-zinc-400">
+          <p className="text-xs uppercase tracking-[0.14em] text-fg-3">Page Strategy</p>
+          <p className="mt-2 text-3xl font-semibold text-fg">{pageEstimate}</p>
+          <p className="mt-2 text-sm text-fg-2">
             {pageEstimate > 1 ? 'Trim bullets and optional sections to stay tighter.' : 'Compact enough for the most common one-page target.'}
           </p>
         </Card>
         <Card>
-          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Visible Sections</p>
-          <p className="mt-2 text-3xl font-semibold text-white">{visibleSections.length}</p>
-          <p className="mt-2 text-sm text-zinc-400">
+          <p className="text-xs uppercase tracking-[0.14em] text-fg-3">Visible Sections</p>
+          <p className="mt-2 text-3xl font-semibold text-fg">{visibleSections.length}</p>
+          <p className="mt-2 text-sm text-fg-2">
             {structured.hidden_sections.length
               ? `${structured.hidden_sections.length} section${structured.hidden_sections.length === 1 ? '' : 's'} hidden from the rendered resume.`
               : 'All configured sections are currently visible.'}
           </p>
         </Card>
         <Card>
-          <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">Current Template</p>
-          <p className="mt-2 text-lg font-semibold text-white">{selectedTemplate?.name || 'Template'}</p>
-          <p className="mt-2 text-sm text-zinc-400">
+          <p className="text-xs uppercase tracking-[0.14em] text-fg-3">Current Template</p>
+          <p className="mt-2 text-lg font-semibold text-fg">{selectedTemplate?.name || 'Template'}</p>
+          <p className="mt-2 text-sm text-fg-2">
             Family: {selectedTemplate?.template_family || templateFamily} · {selectedTemplate?.category_label || 'Builder'}
           </p>
         </Card>
@@ -481,8 +481,8 @@ export default function BuilderResumePage() {
       <section className="grid gap-6 xl:grid-cols-[260px_minmax(0,1fr)_420px]">
         <aside className="space-y-4">
           <Card className="sticky top-24">
-            <div className="flex items-center gap-2 text-sm font-semibold text-white">
-              <LayoutList className="h-4 w-4 text-orange-300" />
+            <div className="flex items-center gap-2 text-sm font-semibold text-fg">
+              <LayoutList className="h-4 w-4 text-accent-strong" />
               Builder Flow
             </div>
             <div className="mt-4 space-y-2">
@@ -495,17 +495,17 @@ export default function BuilderResumePage() {
                     key={section.key}
                     type="button"
                     onClick={() => jumpToSection(section.key)}
-                    className={`w-full rounded-2xl border px-3 py-3 text-left transition ${
+                    className={`w-full rounded-[var(--radius-lg)] border px-3 py-3 text-left transition ${
                       isActive
-                        ? 'border-orange-300/30 bg-orange-300/[0.08]'
-                        : 'border-white/8 bg-black/20 hover:bg-white/[0.04]'
+                        ? 'border-accent bg-accent-soft'
+                        : 'border-line bg-surface hover:bg-surface-2'
                     }`}
                   >
                     <div className="flex items-center justify-between gap-2">
-                      <p className="text-sm font-medium text-white">{section.title}</p>
-                      {ready ? <CheckCircle2 className="h-4 w-4 text-emerald-300" /> : null}
+                      <p className="text-sm font-medium text-fg">{section.title}</p>
+                      {ready ? <CheckCircle2 className="h-4 w-4 text-ok" /> : null}
                     </div>
-                    <p className="mt-1 text-xs text-zinc-500">
+                    <p className="mt-1 text-xs text-fg-3">
                       {hidden.has(section.key)
                         ? 'Hidden from output'
                         : count
@@ -518,8 +518,8 @@ export default function BuilderResumePage() {
             </div>
 
             {missingSections.length ? (
-              <div className="mt-5 rounded-2xl border border-amber-300/15 bg-amber-300/[0.06] px-3 py-3">
-                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-amber-100/85">
+              <div className="mt-5 rounded-[var(--radius-lg)] border border-warn/20 bg-warn/10 px-3 py-3">
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-warn">
                   <Target className="h-3.5 w-3.5" />
                   Next fixes
                 </div>
@@ -538,7 +538,7 @@ export default function BuilderResumePage() {
         </aside>
 
         <div className="space-y-6">
-          <section className="surface-panel edge-highlight p-6">
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-6">
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
               <div className="grid gap-4 md:grid-cols-2">
                 <div>
@@ -562,7 +562,7 @@ export default function BuilderResumePage() {
                       setSelectedTemplateId(event.target.value)
                       setDirty(true)
                     }}
-                    className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition focus:border-orange-300/50"
+                    className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-4 py-3 text-fg outline-none transition focus:border-accent focus:ring-accent focus:ring-offset-bg"
                   >
                     {templates.map(template => (
                       <option key={template.id} value={template.id}>
@@ -574,11 +574,11 @@ export default function BuilderResumePage() {
               </div>
 
               <Card className="flex h-full flex-col justify-between">
-                <div className="flex items-center gap-2 text-sm font-semibold text-white">
-                  <Wand2 className="h-4 w-4 text-orange-300" />
+                <div className="flex items-center gap-2 text-sm font-semibold text-fg">
+                  <Wand2 className="h-4 w-4 text-accent-strong" />
                   Builder Guidance
                 </div>
-                <div className="mt-3 space-y-2 text-sm text-zinc-300">
+                <div className="mt-3 space-y-2 text-sm text-fg-2">
                   <p>Lead with measurable impact, not responsibility lists.</p>
                   <p>Keep the preview one page unless the role clearly benefits from a second page.</p>
                   <p>Hide sections that don’t reinforce the target job instead of filling them with weak content.</p>
@@ -589,7 +589,7 @@ export default function BuilderResumePage() {
             {warnings.length ? (
               <div className="mt-4 space-y-2">
                 {warnings.map(warning => (
-                  <div key={warning} className="rounded-xl border border-amber-300/20 bg-amber-300/[0.05] px-3 py-2 text-xs text-amber-50/90">
+                  <div key={warning} className="rounded-[var(--radius-md)] border border-warn/20 bg-warn/10 px-3 py-2 text-xs text-warn">
                     {warning}
                   </div>
                 ))}
@@ -601,7 +601,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.summary = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Profile & Summary"
@@ -670,7 +670,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.experience = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Experience"
@@ -705,7 +705,7 @@ export default function BuilderResumePage() {
                       </div>
                     ))}
                   </div>
-                  <label className="mt-4 flex items-center gap-2 text-sm text-zinc-300">
+                  <label className="mt-4 flex items-center gap-2 text-sm text-fg-2">
                     <input
                       type="checkbox"
                       checked={entry.current}
@@ -753,7 +753,7 @@ export default function BuilderResumePage() {
                   <div className="mt-4 flex justify-end">
                     <button type="button" onClick={() => mutateStructured(draft => {
                       draft.experience.splice(idx, 1)
-                    })} className="btn-ghost px-4 py-2 text-xs">
+                    })} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
                       Remove entry
                     </button>
                   </div>
@@ -772,7 +772,7 @@ export default function BuilderResumePage() {
                   bullets: [],
                   technologies: [],
                 })
-              })} className="btn-accent px-4 py-2 text-xs">
+              })} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
                 <Plus className="mr-2 inline h-3.5 w-3.5" />
                 Add experience
               </button>
@@ -783,7 +783,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.education = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Education"
@@ -835,7 +835,7 @@ export default function BuilderResumePage() {
                   <div className="mt-4 flex justify-end">
                     <button type="button" onClick={() => mutateStructured(draft => {
                       draft.education.splice(idx, 1)
-                    })} className="btn-ghost px-4 py-2 text-xs">
+                    })} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
                       Remove education
                     </button>
                   </div>
@@ -853,7 +853,7 @@ export default function BuilderResumePage() {
                   gpa: '',
                   highlights: [],
                 })
-              })} className="btn-accent px-4 py-2 text-xs">
+              })} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
                 <Plus className="mr-2 inline h-3.5 w-3.5" />
                 Add education
               </button>
@@ -864,7 +864,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.skills = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Skills"
@@ -901,7 +901,7 @@ export default function BuilderResumePage() {
                   <div className="mt-4 flex justify-end">
                     <button type="button" onClick={() => mutateStructured(draft => {
                       draft.skills.splice(idx, 1)
-                    })} className="btn-ghost px-4 py-2 text-xs">
+                    })} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
                       Remove skill group
                     </button>
                   </div>
@@ -910,7 +910,7 @@ export default function BuilderResumePage() {
               <div className="flex flex-wrap gap-2">
                 <button type="button" onClick={() => mutateStructured(draft => {
                   draft.skills.push({ id: createBuilderId('skill'), name: 'Core Skills', keywords: [] })
-                })} className="btn-accent px-4 py-2 text-xs">
+                })} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
                   <Plus className="mr-2 inline h-3.5 w-3.5" />
                   Add skill group
                 </button>
@@ -933,7 +933,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.projects = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Projects"
@@ -1004,7 +1004,7 @@ export default function BuilderResumePage() {
                   <div className="mt-4 flex justify-end">
                     <button type="button" onClick={() => mutateStructured(draft => {
                       draft.projects.splice(idx, 1)
-                    })} className="btn-ghost px-4 py-2 text-xs">
+                    })} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
                       Remove project
                     </button>
                   </div>
@@ -1022,7 +1022,7 @@ export default function BuilderResumePage() {
                   bullets: [],
                   technologies: [],
                 })
-              })} className="btn-accent px-4 py-2 text-xs">
+              })} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
                 <Plus className="mr-2 inline h-3.5 w-3.5" />
                 Add project
               </button>
@@ -1033,7 +1033,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.certifications = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Certifications"
@@ -1070,7 +1070,7 @@ export default function BuilderResumePage() {
                   <div className="mt-4 flex justify-end">
                     <button type="button" onClick={() => mutateStructured(draft => {
                       draft.certifications.splice(idx, 1)
-                    })} className="btn-ghost px-4 py-2 text-xs">
+                    })} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
                       Remove certification
                     </button>
                   </div>
@@ -1078,7 +1078,7 @@ export default function BuilderResumePage() {
               ))}
               <button type="button" onClick={() => mutateStructured(draft => {
                 draft.certifications.push({ id: createBuilderId('cert'), name: '', issuer: '', date: '', url: '' })
-              })} className="btn-accent px-4 py-2 text-xs">
+              })} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
                 <Plus className="mr-2 inline h-3.5 w-3.5" />
                 Add certification
               </button>
@@ -1089,7 +1089,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.awards = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Awards"
@@ -1130,7 +1130,7 @@ export default function BuilderResumePage() {
                   <div className="mt-4 flex justify-end">
                     <button type="button" onClick={() => mutateStructured(draft => {
                       draft.awards.splice(idx, 1)
-                    })} className="btn-ghost px-4 py-2 text-xs">
+                    })} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
                       Remove award
                     </button>
                   </div>
@@ -1138,7 +1138,7 @@ export default function BuilderResumePage() {
               ))}
               <button type="button" onClick={() => mutateStructured(draft => {
                 draft.awards.push({ id: createBuilderId('award'), name: '', detail: '' })
-              })} className="btn-accent px-4 py-2 text-xs">
+              })} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
                 <Plus className="mr-2 inline h-3.5 w-3.5" />
                 Add award
               </button>
@@ -1149,7 +1149,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.languages = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Languages"
@@ -1191,7 +1191,7 @@ export default function BuilderResumePage() {
                   <div className="mt-4 flex justify-end">
                     <button type="button" onClick={() => mutateStructured(draft => {
                       draft.languages.splice(idx, 1)
-                    })} className="btn-ghost px-4 py-2 text-xs">
+                    })} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
                       Remove language
                     </button>
                   </div>
@@ -1199,7 +1199,7 @@ export default function BuilderResumePage() {
               ))}
               <button type="button" onClick={() => mutateStructured(draft => {
                 draft.languages.push({ id: createBuilderId('lang'), name: '', detail: '' })
-              })} className="btn-accent px-4 py-2 text-xs">
+              })} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
                 <Plus className="mr-2 inline h-3.5 w-3.5" />
                 Add language
               </button>
@@ -1210,7 +1210,7 @@ export default function BuilderResumePage() {
             ref={node => {
               sectionRefs.current.interests = node
             }}
-            className="surface-panel edge-highlight scroll-mt-28 p-6"
+            className="rounded-[var(--radius-lg)] border border-line bg-surface scroll-mt-28 p-6"
           >
             <SectionHeader
               title="Interests"
@@ -1252,7 +1252,7 @@ export default function BuilderResumePage() {
                   <div className="mt-4 flex justify-end">
                     <button type="button" onClick={() => mutateStructured(draft => {
                       draft.interests.splice(idx, 1)
-                    })} className="btn-ghost px-4 py-2 text-xs">
+                    })} className="rounded-[var(--radius-md)] border border-line-2 text-fg hover:bg-surface-2 px-4 py-2 text-xs">
                       Remove interest
                     </button>
                   </div>
@@ -1260,7 +1260,7 @@ export default function BuilderResumePage() {
               ))}
               <button type="button" onClick={() => mutateStructured(draft => {
                 draft.interests.push({ id: createBuilderId('interest'), name: '', detail: '' })
-              })} className="btn-accent px-4 py-2 text-xs">
+              })} className="rounded-[var(--radius-md)] bg-accent text-accent-fg hover:brightness-110 px-4 py-2 text-xs">
                 <Plus className="mr-2 inline h-3.5 w-3.5" />
                 Add interest
               </button>
@@ -1279,17 +1279,17 @@ export default function BuilderResumePage() {
             warnings={warnings}
           />
 
-          <section className="surface-panel edge-highlight p-6">
-            <div className="flex items-center gap-2 text-sm font-semibold text-white">
-              <Sparkles className="h-4 w-4 text-orange-300" />
+          <section className="rounded-[var(--radius-lg)] border border-line bg-surface p-6">
+            <div className="flex items-center gap-2 text-sm font-semibold text-fg">
+              <Sparkles className="h-4 w-4 text-accent-strong" />
               Builder Notes
             </div>
-            <div className="mt-4 space-y-3 text-sm text-zinc-300">
+            <div className="mt-4 space-y-3 text-sm text-fg-2">
               <p>Section order and visibility update both the preview and the generated LaTeX.</p>
               <p>Template switching stays within builder-native families so the structure remains stable.</p>
               <p>The advanced editor is still available when you need raw control, but that detaches the builder until you reattach it.</p>
             </div>
-            <div className="mt-5 rounded-2xl border border-white/8 bg-black/20 p-4 text-xs text-zinc-500">
+            <div className="mt-5 rounded-[var(--radius-lg)] border border-line bg-surface p-4 text-xs text-fg-3">
               <FileText className="mr-2 inline h-3.5 w-3.5" />
               Current mode: {builderStatus} · {selectedTemplate?.category_label || templateFamily}
             </div>


### PR DESCRIPTION
Refs #1073. The 7 large/editor app pages re-skinned to tokens (try Studio + workspace edit/optimize/cover-letter/career/batch-tailor + builder/[id]). Surgical on large stateful files (edit = 3123 lines); editor themes + websocket/streaming untouched. HEAD-diff reviewed (logicPreserved all 7). 493 tests pass, build compiles, no residue. **This completes token migration across all app pages.**