### PR TITLE
Redesign Phase 5i: final chrome cleanup (completes token migration)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -62,113 +62,14 @@
   .content-shell {
     @apply mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-10;
   }
-
-  .surface-panel {
-    @apply rounded-2xl border border-white/10 bg-zinc-950/75 backdrop-blur-xl;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 30px 70px rgba(0, 0, 0, 0.55);
-  }
-
-  .surface-card {
-    @apply rounded-xl border border-white/10 bg-zinc-900/65 backdrop-blur-md;
-  }
-
-  .enterprise-grid {
-    background-image:
-      linear-gradient(to right, rgba(255, 255, 255, 0.04) 1px, transparent 1px),
-      linear-gradient(to bottom, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
-    background-size: 48px 48px;
-  }
-
-  .edge-highlight {
-    position: relative;
-    overflow: hidden;
-  }
-
-  .edge-highlight::after {
-    content: '';
-    position: absolute;
-    inset: -1px;
-    border-radius: inherit;
-    padding: 1px;
-    background: linear-gradient(120deg, rgba(255, 255, 255, 0.22), rgba(247, 123, 82, 0.35), rgba(255, 255, 255, 0.08));
-    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-    pointer-events: none;
-  }
-
-  .hero-title {
-    font-size: clamp(2.4rem, 7.5vw, 7rem);
-    line-height: 0.92;
-    letter-spacing: -0.04em;
-  }
-
-  .section-title {
-    font-size: clamp(1.45rem, 2.7vw, 2.55rem);
-    line-height: 1.04;
-    letter-spacing: -0.03em;
-  }
-
-  .overline {
-    @apply text-xs uppercase tracking-[0.2em] text-zinc-500;
-  }
-
-  .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 rounded-xl bg-white px-5 py-2.5 text-sm font-semibold text-black transition hover:bg-zinc-200;
-  }
-
-  .btn-accent {
-    @apply inline-flex items-center justify-center gap-2 rounded-xl bg-orange-300 px-5 py-2.5 text-sm font-semibold text-black transition hover:bg-orange-200;
-  }
-
-  .btn-ghost {
-    @apply inline-flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/5 px-5 py-2.5 text-sm text-white transition hover:bg-white/10;
-  }
-
-  .orange-burst {
-    position: relative;
-    isolation: isolate;
-  }
-
-  .orange-burst::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(circle, rgba(247, 123, 82, 0.95) 0%, rgba(247, 123, 82, 0.55) 28%, rgba(247, 123, 82, 0.1) 60%, transparent 75%);
-    filter: blur(34px);
-    opacity: 0.84;
-    z-index: -2;
-  }
-
-  .orange-burst::after {
-    content: '';
-    position: absolute;
-    inset: -6%;
-    background-image: radial-gradient(rgba(255, 170, 141, 0.8) 0.8px, transparent 0.8px);
-    background-size: 3px 3px;
-    opacity: 0.28;
-    transform: rotate(-8deg);
-    z-index: -1;
-  }
+  /* Legacy surface/btn/edge-highlight/orange-burst/hero-title/section-title/
+     overline/enterprise-grid classes were removed after the token redesign
+     (PRD 2026-08-03) — all surfaces now use design tokens. */
 }
 
 @layer utilities {
   .text-balance {
     text-wrap: balance;
-  }
-
-  .noise-overlay {
-    position: relative;
-  }
-
-  .noise-overlay::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background-image: radial-gradient(rgba(255, 255, 255, 0.08) 0.5px, transparent 0.5px);
-    background-size: 2px 2px;
-    opacity: 0.06;
-    pointer-events: none;
   }
 
   .float-soft {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -67,7 +67,7 @@ export default function RootLayout({
             <AuthSync />
             <TenantThemeSync />
             <WebVitalsReporter />
-            <div className="min-h-screen enterprise-grid noise-overlay flex flex-col">
+            <div className="min-h-screen flex flex-col">
               <EmailVerifyBanner />
               <GlobalHeader />
               <main className="flex-1">
@@ -80,7 +80,7 @@ export default function RootLayout({
               position="bottom-right"
               duration={1500}
               toastOptions={{
-                className: 'border border-white/10 bg-zinc-950 text-zinc-100',
+                className: 'border border-line bg-surface text-fg',
               }}
             />
           </WebSocketProvider>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -34,31 +34,31 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
       }
 
       return (
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-blue-50">
+        <div className="min-h-screen flex items-center justify-center bg-bg">
           <div className="max-w-md w-full mx-4">
-            <div className="card">
-              <div className="card-content text-center py-8">
-                <AlertTriangle className="w-12 h-12 text-amber-500 mx-auto mb-4" />
-                <h2 className="text-lg font-semibold text-secondary-900 mb-2">
+            <div className="rounded-[var(--radius-lg)] border border-line bg-surface">
+              <div className="text-center p-8">
+                <AlertTriangle className="w-12 h-12 text-warn mx-auto mb-4" />
+                <h2 className="text-lg font-semibold text-fg mb-2">
                   Something went wrong
                 </h2>
-                <p className="text-secondary-600 mb-6">
+                <p className="text-fg-2 mb-6">
                   We encountered an unexpected error. Please try refreshing the page.
                 </p>
                 <button
                   onClick={() => window.location.reload()}
-                  className="btn-primary px-4 py-2 flex items-center gap-2 mx-auto"
+                  className="rounded-[var(--radius-md)] bg-accent px-4 py-2 flex items-center gap-2 mx-auto font-semibold text-accent-fg transition hover:brightness-110"
                 >
                   <RefreshCw size={16} />
                   Refresh Page
                 </button>
-                
+
                 {process.env.NODE_ENV === 'development' && this.state.error && (
                   <details className="mt-6 text-left">
-                    <summary className="cursor-pointer text-sm text-secondary-500 hover:text-secondary-700">
+                    <summary className="cursor-pointer text-sm text-fg-3 hover:text-fg-2">
                       Error Details (Development)
                     </summary>
-                    <pre className="mt-2 p-3 bg-secondary-50 rounded text-xs text-secondary-700 overflow-auto">
+                    <pre className="mt-2 p-3 bg-surface-2 rounded-[var(--radius-md)] text-xs text-fg-2 overflow-auto">
                       {this.state.error.toString()}
                     </pre>
                   </details>

--- a/frontend/src/components/JobDescriptionInput.tsx
+++ b/frontend/src/components/JobDescriptionInput.tsx
@@ -54,7 +54,7 @@ export default function JobDescriptionInput({ value, onChange }: JobDescriptionI
             <p className="text-secondary-500 mb-4">No job description yet</p>
             <button
               onClick={insertSample}
-              className="btn-primary px-4 py-2 text-sm"
+              className="rounded-[var(--radius-md)] bg-accent px-4 py-2 text-sm font-semibold text-accent-fg transition hover:brightness-110"
             >
               Insert Sample Job Description
             </button>

--- a/frontend/src/components/onboarding/OnboardingFlow.tsx
+++ b/frontend/src/components/onboarding/OnboardingFlow.tsx
@@ -44,25 +44,25 @@ export default function OnboardingFlow({
       id: 'welcome',
       title: 'Welcome to Latexy!',
       description: 'Your AI-powered resume optimization platform',
-      icon: <Sparkles className="w-8 h-8 text-primary-500" />,
+      icon: <Sparkles className="w-8 h-8 text-accent-strong" />,
       content: (
         <div className="text-center space-y-6">
-          <div className="w-24 h-24 mx-auto bg-gradient-to-br from-primary-500 to-primary-600 rounded-full flex items-center justify-center">
+          <div className="w-24 h-24 mx-auto bg-gradient-to-br from-accent to-accent rounded-full flex items-center justify-center">
             <FileText className="w-12 h-12 text-white" />
           </div>
           <div>
-            <h3 className="text-2xl font-bold text-secondary-900 mb-2">
+            <h3 className="text-2xl font-bold text-fg mb-2">
               Welcome to Latexy!
             </h3>
-            <p className="text-secondary-600 text-lg">
+            <p className="text-fg-2 text-lg">
               Create ATS-friendly resumes with LaTeX precision and AI optimization
             </p>
           </div>
           <div className="grid grid-cols-3 gap-4 text-center">
-            <div className="p-4 bg-blue-50 rounded-lg">
-              <Users className="w-6 h-6 text-blue-500 mx-auto mb-2" />
-              <p className="text-sm font-medium text-blue-700">10,000+</p>
-              <p className="text-xs text-blue-600">Happy Users</p>
+            <div className="p-4 bg-accent-soft rounded-lg">
+              <Users className="w-6 h-6 text-accent-strong mx-auto mb-2" />
+              <p className="text-sm font-medium text-accent-strong">10,000+</p>
+              <p className="text-xs text-accent-strong">Happy Users</p>
             </div>
             <div className="p-4 bg-green-50 rounded-lg">
               <TrendingUp className="w-6 h-6 text-green-500 mx-auto mb-2" />
@@ -82,20 +82,20 @@ export default function OnboardingFlow({
       id: 'how-it-works',
       title: 'How Latexy Works',
       description: 'Three simple steps to optimize your resume',
-      icon: <Zap className="w-8 h-8 text-primary-500" />,
+      icon: <Zap className="w-8 h-8 text-accent-strong" />,
       content: (
         <div className="space-y-6">
-          <h3 className="text-xl font-bold text-secondary-900 text-center mb-6">
+          <h3 className="text-xl font-bold text-fg text-center mb-6">
             Three Simple Steps
           </h3>
           <div className="space-y-4">
-            <div className="flex items-start gap-4 p-4 bg-blue-50 rounded-lg">
-              <div className="w-8 h-8 bg-blue-500 text-white rounded-full flex items-center justify-center font-bold text-sm">
+            <div className="flex items-start gap-4 p-4 bg-accent-soft rounded-lg">
+              <div className="w-8 h-8 bg-accent-soft0 text-white rounded-full flex items-center justify-center font-bold text-sm">
                 1
               </div>
               <div>
-                <h4 className="font-semibold text-blue-900">Upload or Create</h4>
-                <p className="text-blue-700 text-sm">
+                <h4 className="font-semibold text-accent-strong">Upload or Create</h4>
+                <p className="text-accent-strong text-sm">
                   Upload your existing resume or create one using our LaTeX editor
                 </p>
               </div>
@@ -130,38 +130,38 @@ export default function OnboardingFlow({
       id: 'features',
       title: 'Key Features',
       description: 'Discover what makes Latexy powerful',
-      icon: <Target className="w-8 h-8 text-primary-500" />,
+      icon: <Target className="w-8 h-8 text-accent-strong" />,
       content: (
         <div className="space-y-6">
-          <h3 className="text-xl font-bold text-secondary-900 text-center mb-6">
+          <h3 className="text-xl font-bold text-fg text-center mb-6">
             Powerful Features
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="p-4 border border-secondary-200 rounded-lg hover:border-primary-300 transition-colors">
-              <FileText className="w-6 h-6 text-primary-500 mb-2" />
-              <h4 className="font-semibold text-secondary-900 mb-1">LaTeX Editor</h4>
-              <p className="text-sm text-secondary-600">
+            <div className="p-4 border border-line rounded-lg hover:border-accent transition-colors">
+              <FileText className="w-6 h-6 text-accent-strong mb-2" />
+              <h4 className="font-semibold text-fg mb-1">LaTeX Editor</h4>
+              <p className="text-sm text-fg-2">
                 Professional typesetting with syntax highlighting
               </p>
             </div>
-            <div className="p-4 border border-secondary-200 rounded-lg hover:border-primary-300 transition-colors">
-              <Zap className="w-6 h-6 text-primary-500 mb-2" />
-              <h4 className="font-semibold text-secondary-900 mb-1">AI Optimization</h4>
-              <p className="text-sm text-secondary-600">
+            <div className="p-4 border border-line rounded-lg hover:border-accent transition-colors">
+              <Zap className="w-6 h-6 text-accent-strong mb-2" />
+              <h4 className="font-semibold text-fg mb-1">AI Optimization</h4>
+              <p className="text-sm text-fg-2">
                 Smart content optimization for job descriptions
               </p>
             </div>
-            <div className="p-4 border border-secondary-200 rounded-lg hover:border-primary-300 transition-colors">
-              <Target className="w-6 h-6 text-primary-500 mb-2" />
-              <h4 className="font-semibold text-secondary-900 mb-1">ATS Scoring</h4>
-              <p className="text-sm text-secondary-600">
+            <div className="p-4 border border-line rounded-lg hover:border-accent transition-colors">
+              <Target className="w-6 h-6 text-accent-strong mb-2" />
+              <h4 className="font-semibold text-fg mb-1">ATS Scoring</h4>
+              <p className="text-sm text-fg-2">
                 Real-time compatibility scoring and recommendations
               </p>
             </div>
-            <div className="p-4 border border-secondary-200 rounded-lg hover:border-primary-300 transition-colors">
-              <Shield className="w-6 h-6 text-primary-500 mb-2" />
-              <h4 className="font-semibold text-secondary-900 mb-1">BYOK Support</h4>
-              <p className="text-sm text-secondary-600">
+            <div className="p-4 border border-line rounded-lg hover:border-accent transition-colors">
+              <Shield className="w-6 h-6 text-accent-strong mb-2" />
+              <h4 className="font-semibold text-fg mb-1">BYOK Support</h4>
+              <p className="text-sm text-fg-2">
                 Use your own API keys for cost-effective optimization
               </p>
             </div>
@@ -173,25 +173,25 @@ export default function OnboardingFlow({
       id: 'get-started',
       title: 'Ready to Get Started?',
       description: 'Choose your path and start optimizing',
-      icon: <CheckCircle className="w-8 h-8 text-primary-500" />,
+      icon: <CheckCircle className="w-8 h-8 text-accent-strong" />,
       content: (
         <div className="text-center space-y-6">
           <div>
-            <h3 className="text-xl font-bold text-secondary-900 mb-2">
+            <h3 className="text-xl font-bold text-fg mb-2">
               You're All Set!
             </h3>
-            <p className="text-secondary-600">
+            <p className="text-fg-2">
               Ready to create your first optimized resume?
             </p>
           </div>
           
           {userType === 'new' && (
-            <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
-              <h4 className="font-semibold text-blue-900 mb-2">Free Trial Available</h4>
-              <p className="text-blue-700 text-sm mb-3">
+            <div className="p-4 bg-accent-soft rounded-lg border border-accent">
+              <h4 className="font-semibold text-accent-strong mb-2">Free Trial Available</h4>
+              <p className="text-accent-strong text-sm mb-3">
                 Try 3 resume compilations right now - no account, no credit card required!
               </p>
-              <div className="flex items-center justify-center gap-2 text-blue-600 text-sm">
+              <div className="flex items-center justify-center gap-2 text-accent-strong text-sm">
                 <CheckCircle className="w-4 h-4" />
                 <span>No registration needed for trial</span>
               </div>
@@ -219,13 +219,13 @@ export default function OnboardingFlow({
           <div className="space-y-3">
             <button
               onClick={onComplete}
-              className="w-full btn-primary py-3 text-base font-medium"
+              className="w-full rounded-[var(--radius-md)] bg-accent font-semibold text-accent-fg transition hover:brightness-110 py-3 text-base font-medium"
             >
               Start Creating My Resume
             </button>
             <button
               onClick={onSkip}
-              className="w-full text-secondary-600 hover:text-secondary-800 text-sm"
+              className="w-full text-fg-2 hover:text-fg text-sm"
             >
               Skip tutorial and explore on my own
             </button>
@@ -263,19 +263,19 @@ export default function OnboardingFlow({
         className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden"
       >
         {/* Header */}
-        <div className="p-6 border-b border-secondary-200">
+        <div className="p-6 border-b border-line">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-lg font-semibold text-secondary-900">
+              <h2 className="text-lg font-semibold text-fg">
                 Getting Started
               </h2>
-              <p className="text-sm text-secondary-600">
+              <p className="text-sm text-fg-2">
                 Step {currentStep + 1} of {steps.length}
               </p>
             </div>
             <button
               onClick={onSkip}
-              className="text-secondary-400 hover:text-secondary-600 text-sm"
+              className="text-fg-3 hover:text-fg-2 text-sm"
             >
               Skip
             </button>
@@ -290,8 +290,8 @@ export default function OnboardingFlow({
                   onClick={() => goToStep(index)}
                   className={`flex-1 h-2 rounded-full transition-colors ${
                     index <= currentStep
-                      ? 'bg-primary-500'
-                      : 'bg-secondary-200'
+                      ? 'bg-accent'
+                      : 'bg-surface-2'
                   }`}
                 />
               ))}
@@ -316,15 +316,15 @@ export default function OnboardingFlow({
         </div>
 
         {/* Footer */}
-        <div className="p-6 border-t border-secondary-200 bg-secondary-50">
+        <div className="p-6 border-t border-line bg-surface-2">
           <div className="flex items-center justify-between">
             <button
               onClick={prevStep}
               disabled={currentStep === 0}
               className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                 currentStep === 0
-                  ? 'text-secondary-400 cursor-not-allowed'
-                  : 'text-secondary-700 hover:bg-secondary-200'
+                  ? 'text-fg-3 cursor-not-allowed'
+                  : 'text-fg-2 hover:bg-surface-2'
               }`}
             >
               <ArrowLeft className="w-4 h-4" />
@@ -338,10 +338,10 @@ export default function OnboardingFlow({
                   onClick={() => goToStep(index)}
                   className={`w-2 h-2 rounded-full transition-colors ${
                     index === currentStep
-                      ? 'bg-primary-500'
+                      ? 'bg-accent'
                       : index < currentStep
-                      ? 'bg-primary-300'
-                      : 'bg-secondary-300'
+                      ? 'bg-accent-soft'
+                      : 'bg-surface-2'
                   }`}
                 />
               ))}
@@ -350,7 +350,7 @@ export default function OnboardingFlow({
             {currentStep < steps.length - 1 ? (
               <button
                 onClick={nextStep}
-                className="flex items-center gap-2 btn-primary px-4 py-2 text-sm font-medium"
+                className="flex items-center gap-2 rounded-[var(--radius-md)] bg-accent font-semibold text-accent-fg transition hover:brightness-110 px-4 py-2 text-sm font-medium"
               >
                 Next
                 <ArrowRight className="w-4 h-4" />
@@ -358,7 +358,7 @@ export default function OnboardingFlow({
             ) : (
               <button
                 onClick={onComplete}
-                className="flex items-center gap-2 btn-primary px-4 py-2 text-sm font-medium"
+                className="flex items-center gap-2 rounded-[var(--radius-md)] bg-accent font-semibold text-accent-fg transition hover:brightness-110 px-4 py-2 text-sm font-medium"
               >
                 Get Started
                 <CheckCircle className="w-4 h-4" />

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -8,7 +8,7 @@ export function Skeleton({ className }: { className?: string }) {
 
 export function CardSkeleton() {
   return (
-    <div className="surface-card edge-highlight p-5 space-y-4">
+    <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 space-y-4">
       <div className="flex items-center justify-between">
         <Skeleton className="h-4 w-24" />
         <Skeleton className="h-4 w-4 rounded-full" />
@@ -23,7 +23,7 @@ export function CardSkeleton() {
 
 export function ResumeCardSkeleton() {
   return (
-    <div className="surface-card edge-highlight p-5 space-y-6">
+    <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 space-y-6">
       <div className="flex items-start justify-between">
         <Skeleton className="h-12 w-12 rounded-lg" />
         <Skeleton className="h-6 w-6" />


### PR DESCRIPTION
Refs #1073. The closing cleanup: tokenizes the root layout wrapper + Toaster, re-skins the last stragglers (ErrorBoundary, JobDescriptionInput, ui/Skeleton, onboarding/OnboardingFlow incl. its blue-ramp → accent), and **removes the now-unused legacy `.surface-*`/`.btn-*`/`.edge-highlight`/`.orange-burst`/`.hero-title`/`.section-title`/`.overline`/`.enterprise-grid`/`.noise-overlay` definitions** from globals.css.

**This completes the Typeset × Compiler redesign** — every marketing, auth, app, and admin surface + all ~87 shared components are on the design-token system. 493 tests pass, build compiles, and a full-app scan shows zero forbidden classes remaining in the UI (only test fixtures + an explanatory comment).