### PR TITLE
ci+test: gate the TUI in CI, cover keyboard in a pty, and make a storage outage visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, "feature/**", "fix/**"]
+    # chore/**, test/** and ci/** are here because a branch matching none of these
+    # gets NO CI at all: the pull_request trigger below only fires for PRs into
+    # main or develop, so a stacked PR targeting another branch is unchecked in
+    # both directions. That is how the Ink 7 upgrade branch ended up with no
+    # backend, frontend or TUI job running against it.
+    branches: [main, develop, "feature/**", "fix/**", "chore/**", "test/**", "ci/**"]
   pull_request:
     branches: [main, develop]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,11 @@ jobs:
       # clearConfig(), and during an earlier audit round it destroyed a developer's real
       # session token — so the guard is load-bearing, not decorative. Point it at the
       # runner's temp dir so the guard is satisfied even though no live test runs here.
-      XDG_CONFIG_HOME: ${{ runner.temp }}/xdg
+      # A literal path, not ${{ runner.temp }}: the `runner` context is not
+      # available in a job-level env block and GitHub rejects the whole workflow
+      # file for it — which fails the run before any job starts, so it does not
+      # show up as a job failure.
+      XDG_CONFIG_HOME: /tmp/latexy-ci-xdg
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,44 @@ jobs:
       - name: Build
         run: pnpm build
 
+  tui-test:
+    name: TUI Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/tui
+    env:
+      # The live suites refuse to run unless this is set outside $HOME. /logout calls
+      # clearConfig(), and during an earlier audit round it destroyed a developer's real
+      # session token — so the guard is load-bearing, not decorative. Point it at the
+      # runner's temp dir so the guard is satisfied even though no live test runs here.
+      XDG_CONFIG_HOME: ${{ runner.temp }}/xdg
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+      - uses: actions/setup-node@v7
+        with:
+          # packages/tui declares engines.node >=22; the other jobs pin 20.
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+      - name: Typecheck
+        run: pnpm run typecheck
+      - name: Build
+        run: pnpm run build
+      # No LATEXY_LIVE: the 66 live tests need a backend, worker, Postgres, Redis and
+      # (for sign-in) the Next.js app, and they skip cleanly without it. The remaining
+      # 164 need nothing, and they are what four audit rounds' worth of invariants live
+      # in — the registry/dispatch parity check, websocket lifecycle, config atomicity,
+      # retry safety and argv parsing.
+      - name: Test
+        run: pnpm test
+
   full-stack-smoke:
     name: Full-Stack Smoke
     runs-on: ubuntu-latest

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -294,9 +294,32 @@ async def health_check():
         logger.warning("Health check: redis unavailable: %s", exc)
         redis_status = "unavailable"
 
-    # Consider service healthy if LaTeX is available AND both backing services are up.
-    # DB/Redis unavailability degrades status but does not change HTTP status code.
-    if not latex_available or db_status != "ok" or redis_status != "ok":
+    # Object storage was the one backing service left unprobed, so this endpoint
+    # answered "healthy" while every template thumbnail and preview PDF returned
+    # 502 Storage unavailable in production — 0 of 147 served. Run it in a thread:
+    # boto3 is synchronous and would otherwise block the event loop for up to the
+    # client's 5s connect timeout.
+    storage_status = "ok"
+    try:
+        from app.services import storage_service
+
+        ok, detail = await asyncio.to_thread(storage_service.probe)
+        if not ok:
+            logger.warning("Health check: object storage unavailable: %s", detail)
+            storage_status = "unavailable"
+    except Exception as exc:
+        logger.warning("Health check: object storage probe failed: %s", exc)
+        storage_status = "unavailable"
+
+    # Consider service healthy if LaTeX is available AND every backing service is up.
+    # Unavailability degrades status but does not change the HTTP status code, so
+    # availability probes that only check for 200 keep working.
+    if (
+        not latex_available
+        or db_status != "ok"
+        or redis_status != "ok"
+        or storage_status != "ok"
+    ):
         status = "degraded"
     else:
         status = "healthy"
@@ -307,6 +330,7 @@ async def health_check():
         latex_available=latex_available,
         database=db_status,
         redis=redis_status,
+        storage=storage_status,
     )
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -24,6 +24,9 @@ class HealthResponse(BaseModel):
     latex_available: bool
     database: str = "ok"
     redis: str = "ok"
+    # Object storage was unprobed, so /health reported "healthy" while every
+    # template thumbnail and preview PDF returned 502 Storage unavailable.
+    storage: str = "ok"
 
 
 class CompilationRequest(BaseModel):

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -6,6 +6,7 @@ Uses a module-level singleton client to avoid per-request client creation overhe
 """
 
 import threading
+import time
 
 import boto3
 from botocore.config import Config
@@ -120,3 +121,69 @@ def generate_presigned_url(key: str, ttl: int = 3600) -> str:
         Params={"Bucket": settings.MINIO_BUCKET, "Key": key},
         ExpiresIn=ttl,
     )
+
+
+_probe_client = None
+
+
+def _get_probe_client():
+    """
+    A separate client for health probing: fast, and no retries.
+
+    The shared client is tuned for real transfers — connect_timeout=5 with 3
+    retries. Reusing it here measured **24s** against a black-holed endpoint and
+    1.7s against a refused one, which would have turned a storage outage into a
+    /health outage: the TUI polls health every 30s and Modal probes it on a
+    schedule. A probe is allowed to be wrong under load; it is not allowed to hang.
+    """
+    global _probe_client
+    if _probe_client is None:
+        with _client_lock:
+            if _probe_client is None:
+                _probe_client = boto3.client(
+                    "s3",
+                    endpoint_url=settings.MINIO_ENDPOINT,
+                    aws_access_key_id=settings.MINIO_ACCESS_KEY,
+                    aws_secret_access_key=settings.MINIO_SECRET_KEY,
+                    region_name="us-east-1",
+                    config=Config(
+                        connect_timeout=2,
+                        read_timeout=2,
+                        retries={"max_attempts": 1, "mode": "standard"},
+                    ),
+                )
+    return _probe_client
+
+
+_probe_cache: tuple[float, bool, str] | None = None
+_PROBE_TTL = 30.0
+
+
+def probe() -> tuple[bool, str]:
+    """
+    Cheap reachability check for the health endpoint.
+
+    Object storage was the one backing service /health did not probe, so the
+    endpoint reported {"status": "healthy"} in production while every template
+    thumbnail and preview PDF returned 502 Storage unavailable — 0 of 147 served.
+    The outage was invisible to anything watching health.
+
+    HeadBucket is the lightest call that proves both connectivity and credentials.
+    Returns (ok, detail) rather than raising, so a health check can degrade
+    gracefully instead of failing.
+    """
+    global _probe_cache
+    now = time.monotonic()
+    if _probe_cache is not None and now - _probe_cache[0] < _PROBE_TTL:
+        # /health is polled roughly every 30s by the TUI and on a schedule by
+        # Modal. Without this, a down endpoint costs ~4s on every single call.
+        return _probe_cache[1], _probe_cache[2]
+
+    try:
+        _get_probe_client().head_bucket(Bucket=settings.MINIO_BUCKET)
+        result = (True, "ok")
+    except Exception as exc:                     # noqa: BLE001 — any failure is "unavailable"
+        result = (False, type(exc).__name__)
+
+    _probe_cache = (now, result[0], result[1])
+    return result

--- a/backend/test/test_health_probes.py
+++ b/backend/test/test_health_probes.py
@@ -80,3 +80,73 @@ async def test_metrics_exposes_new_series(client: AsyncClient):
         "latexy_db_pool_connections",
     ):
         assert family in text, f"expected metric family {family} in /metrics output"
+
+
+# --- object storage -------------------------------------------------------
+# /health probed the database and Redis but not object storage, so in production
+# it reported {"status": "healthy"} while every template thumbnail and preview PDF
+# returned 502 Storage unavailable — 0 of 147 served. The outage was invisible to
+# anything watching health.
+
+
+async def test_health_reports_storage_ok_when_reachable(client: AsyncClient):
+    from app.services import storage_service
+
+    class _FakeRedis:
+        async def ping(self):
+            return True
+
+    from app.api import routes
+
+    with patch.object(storage_service, "probe", lambda: (True, "ok")), \
+         patch.object(routes._redis_manager, "redis_client", _FakeRedis()):
+        resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["storage"] == "ok"
+    assert body["status"] == "healthy"
+
+
+async def test_health_degrades_when_storage_unreachable(client: AsyncClient):
+    """The exact production failure: DB and Redis fine, storage dead."""
+    from app.api import routes
+    from app.services import storage_service
+
+    class _FakeRedis:
+        async def ping(self):
+            return True
+
+    with patch.object(storage_service, "probe", lambda: (False, "EndpointConnectionError")), \
+         patch.object(routes._redis_manager, "redis_client", _FakeRedis()):
+        resp = await client.get("/health")
+
+    # Still 200 so availability probes that only check the status code keep working.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["storage"] == "unavailable"
+    assert body["status"] == "degraded", (
+        "storage being down must not report as healthy — that is what hid the outage"
+    )
+    assert body["database"] == "ok"
+    assert body["redis"] == "ok"
+
+
+async def test_health_survives_a_raising_storage_probe(client: AsyncClient):
+    """A probe that raises must degrade, not 500 the health endpoint."""
+    from app.api import routes
+    from app.services import storage_service
+
+    def _boom():
+        raise RuntimeError("boto3 exploded")
+
+    class _FakeRedis:
+        async def ping(self):
+            return True
+
+    with patch.object(storage_service, "probe", _boom), \
+         patch.object(routes._redis_manager, "redis_client", _FakeRedis()):
+        resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    assert resp.json()["storage"] == "unavailable"

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -180,9 +180,15 @@ export interface TrialStatusResponse {
 }
 
 export interface HealthResponse {
+  /** "healthy" or "degraded" — degraded when any backing service below is down. */
   status: string
   version: string
   latex_available: boolean
+  database?: string
+  redis?: string
+  /** Object storage. Its absence from this type is how a 502-ing template
+   *  gallery went unnoticed while /health still reported healthy. */
+  storage?: string
 }
 
 export interface BillingAvailability {

--- a/packages/tui/src/__tests__/keyboard.pty.test.ts
+++ b/packages/tui/src/__tests__/keyboard.pty.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Keyboard behaviour, driven through a real pty against the built CLI.
+ *
+ * This is the only automated coverage of the input layer. `ink-testing-library@4`
+ * does not deliver keystrokes to Ink 5 — a minimal `useInput` probe that appends
+ * every character it receives renders `[]` after two writes to its stdin — so
+ * every keyboard fix was previously verified by hand, and three of them shipped
+ * wrong before they were right (#1132).
+ *
+ * The work happens in `test-harness/pty_driver.py`: Python's stdlib `pty` needs no
+ * npm dependency and no native build, and the driver starts its own stub backend,
+ * so this needs nothing running. It does need `dist/` to be current — CI builds
+ * before testing; locally, run `pnpm build` first.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const DRIVER = join(process.cwd(), 'test-harness', 'pty_driver.py')
+const DIST = join(process.cwd(), 'dist', 'cli.js')
+
+function python(): string | null {
+  for (const bin of ['python3', 'python']) {
+    try {
+      execFileSync(bin, ['--version'], { stdio: 'ignore' })
+      return bin
+    } catch { /* try the next one */ }
+  }
+  return null
+}
+
+const PY = python()
+const READY = PY != null && existsSync(DRIVER) && existsSync(DIST)
+
+if (!READY) {
+  const why = PY == null ? 'no python3 on PATH'
+    : !existsSync(DIST) ? 'dist/cli.js missing — run `pnpm build`'
+      : 'driver missing'
+  process.stderr.write(`keyboard.pty: skipped — ${why}\n`)
+}
+
+interface Result {
+  prompt?: string
+  exited?: boolean
+  exit_code?: number | null
+  exit_seconds?: number | null
+  [k: string]: unknown
+}
+
+function run(scenario: string): Result {
+  const raw = execFileSync(PY!, [DRIVER, scenario], {
+    encoding: 'utf-8',
+    timeout: 90_000,
+    // A pty scenario writes nothing to stdout except its final JSON line.
+    maxBuffer: 4 * 1024 * 1024,
+  })
+  const line = raw.trim().split('\n').filter(Boolean).pop() ?? '{}'
+  return JSON.parse(line) as Result
+}
+
+;(READY ? describe : describe.skip)('keyboard behaviour in a real pty', () => {
+  it('boots to a usable prompt with no crash', () => {
+    const r = run('boot')
+    expect(r['ready'], 'never reached a focused prompt').toBe(true)
+    expect(r['booted']).toBe(true)
+    expect(r['has_prompt']).toBe(true)
+    expect(r['no_crash'], 'a stack trace reached the screen').toBe(true)
+  }, 90_000)
+
+  it('a bare / opens the command menu', () => {
+    // The welcome banner and hint line both say "type / to see available
+    // commands", but the list was gated on `value.length > 1`.
+    const r = run('slash_menu')
+    expect(r['suggestions_visible']).toBe(true)
+    expect(r.prompt).toBe('/')
+  }, 90_000)
+
+  describe('Ctrl+L clears the transcript without touching the prompt', () => {
+    // Ink normalises 0x0C to input='l' + key.ctrl before onChange runs, so
+    // ink-text-input appends the letter. Filtering control bytes in onChange was
+    // a no-op; the repair has to happen after the append.
+    it('leaves an empty prompt empty', () => {
+      expect(run('ctrl_l_empty').prompt).toBe('')
+    }, 90_000)
+
+    it('does not append to text already typed', () => {
+      expect(run('ctrl_l_text').prompt).toBe('hello')
+    }, 90_000)
+
+    it('does not eat a real trailing l, nor double it', () => {
+      // The decisive case: a repair applied before the append yields "abcll".
+      expect(run('ctrl_l_trailing_l').prompt).toBe('abcl')
+    }, 90_000)
+
+    it('applies to any ctrl-modified letter', () => {
+      expect(run('ctrl_a_text').prompt).toBe('abc')
+    }, 90_000)
+
+    it('does not break ordinary typing of the same letter', () => {
+      expect(run('typing_l').prompt).toBe('llama')
+    }, 90_000)
+  })
+
+  describe('pasted input', () => {
+    it('a command pasted with its newline is submitted', () => {
+      const r = run('paste_single')
+      expect(r['submitted'], 'the paste was inserted literally instead of running').toBe(true)
+      expect(r.prompt).toBe('')
+    }, 90_000)
+
+    it('every complete line of a multi-command paste runs', () => {
+      const r = run('paste_multi')
+      expect(r['first_ran']).toBe(true)
+      expect(r['second_ran'], 'only the first newline was consumed').toBe(true)
+      expect(r.prompt).toBe('')
+    }, 90_000)
+
+    it('a leading blank line does not swallow the command after it', () => {
+      expect(run('paste_blank_first')['submitted']).toBe(true)
+    }, 90_000)
+
+    it('an incomplete trailing line stays in the box', () => {
+      expect(run('paste_incomplete_tail').prompt).toBe('/clear')
+    }, 90_000)
+  })
+
+  describe('Ctrl+C', () => {
+    it('exits the process, and promptly', () => {
+      // Ink's exit() unmounts but does not end the process, and the websocket
+      // heartbeat plus the health poll kept the event loop alive — so this used
+      // to tear down the UI and then hang with the shell never returning.
+      const r = run('ctrl_c_exits')
+      expect(r.exited, 'the process never exited').toBe(true)
+      expect(r.exit_code).toBe(0)
+      expect(r.exit_seconds ?? 99).toBeLessThan(5)
+    }, 90_000)
+
+    it('does not delete a real trailing c on the way out', () => {
+      // ink-text-input deliberately does not append for Ctrl+C, so the guard
+      // must exclude it or "abc" becomes "ab".
+      const r = run('ctrl_c_keeps_c')
+      expect(r['prompt_before_exit']).toBe('abc')
+      expect(r.exited).toBe(true)
+    }, 90_000)
+  })
+})

--- a/packages/tui/test-harness/pty_driver.py
+++ b/packages/tui/test-harness/pty_driver.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+Drive the built CLI inside a real pty and report what the terminal shows.
+
+Why this exists: `ink-testing-library@4` does not deliver keystrokes to Ink 5. A
+minimal `useInput` probe that appends every character it receives renders `[]`
+after two writes to its stdin, with and without CI set. So the only way to test
+keyboard behaviour is a real pty — and without it, three separate keyboard fixes
+shipped wrong (the Ctrl+L repair twice, the paste handler once).
+
+`script(1)` is not usable here: under piped stdio it fails with
+`tcgetattr/ioctl: Operation not supported on socket`. Hence pty.fork().
+
+Two hard-won details, both of which produced false failures before they were
+understood:
+
+  * Keystrokes must be paced. Writing "hello\\r" in one call — or even one byte
+    at a time too quickly — lets the pty coalesce them into a single read, and
+    Ink parses the chunk as one key event with the \\r landing as a literal
+    character. That looks exactly like "Enter does not submit". PACE below is
+    deliberately generous.
+
+  * The child must be reaped while the master fd is drained. Breaking out of the
+    read loop on EIO without waitpid leaves a zombie, and a child blocked
+    mid-write to a full pty never exits — which looks exactly like "Ctrl+C does
+    not exit".
+
+Usage:  pty_driver.py <scenario>   ->  one JSON object on stdout
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import pty
+import re
+import select
+import shutil
+import signal
+import struct
+import sys
+import tempfile
+import termios
+import time
+
+PACE = 0.12          # seconds between keystrokes
+ROWS, COLS = 34, 110
+
+
+class StubBackend:
+    """
+    The smallest server that gets the app past its login overlay.
+
+    app.tsx validates the stored token with `GET /me` and opens LoginOverlay when
+    that fails. With the overlay up, PromptInput renders its blocked branch and
+    has no text input at all — so every keyboard scenario silently tested nothing.
+    Serving /me locally keeps the harness self-contained: no backend, no database,
+    nothing to start in CI.
+    """
+
+    def __init__(self) -> None:
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class Handler(BaseHTTPRequestHandler):
+            def _json(self, code: int, payload: dict) -> None:
+                body = json.dumps(payload).encode()
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self) -> None:            # noqa: N802
+                if self.path.startswith("/me"):
+                    self._json(200, {"id": "00000000-0000-4000-8000-000000000000",
+                                     "email": "pty@harness.test", "plan": "free"})
+                elif self.path.startswith("/health"):
+                    self._json(200, {"status": "healthy"})
+                elif self.path.startswith("/resumes"):
+                    self._json(200, {"resumes": [], "total": 0})
+                else:
+                    self._json(404, {"detail": "Not Found"})
+
+            def log_message(self, *_args) -> None:   # silence request logging
+                return
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+# Ink's alternate-screen and cursor sequences, plus OSC strings.
+ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[()][A-Z0-9]|\x1b[=>]")
+
+CTRL_C, CTRL_L, CTRL_A = "\x03", "\x0c", "\x01"
+
+
+class Session:
+    def __init__(self) -> None:
+        self.xdg = tempfile.mkdtemp(prefix="latexy-pty-")
+        self.backend = StubBackend()
+        env = dict(os.environ)
+        # Never the developer's real config: /logout calls clearConfig().
+        env["XDG_CONFIG_HOME"] = self.xdg
+        # Any non-empty token is enough: the stub above answers /me, which is what
+        # app.tsx checks before deciding whether to open the login overlay.
+        env["LATEXY_SESSION_TOKEN"] = "pty-harness-not-a-real-token"
+        env["LATEXY_API_URL"] = self.backend.url
+        env["LATEXY_APP_URL"] = self.backend.url
+        env.pop("CI", None)          # CI=true would route to headless mode
+        env.pop("LATEXY_PASSWORD", None)
+
+        self.buf = ""
+        self.raw = ""
+        self.pid, self.fd = pty.fork()
+        if self.pid == 0:
+            os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+            os.execve("/usr/bin/env", ["env", "node", "dist/cli.js"], env)
+        fcntl.ioctl(self.fd, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
+
+    def pump(self, seconds: float) -> None:
+        end = time.time() + seconds
+        while time.time() < end:
+            r, _, _ = select.select([self.fd], [], [], 0.1)
+            if not r:
+                continue
+            try:
+                chunk = os.read(self.fd, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            self.raw += chunk.decode("utf-8", "replace")
+            self.buf = ANSI.sub("", self.raw)
+
+    def await_prompt(self, timeout: float = 20.0) -> bool:
+        """Block until the prompt is focused, i.e. no overlay is covering it."""
+        end = time.time() + timeout
+        while time.time() < end:
+            self.pump(0.3)
+            if "overlay open" not in self.buf.splitlines()[-6:].__str__() and "❯" in self.buf:
+                # The last frame must show the input, not a stale earlier one.
+                tail = "\n".join(self.buf.splitlines()[-12:])
+                if "❯" in tail and "Sign in to Latexy" not in tail:
+                    return True
+        return False
+
+    def type(self, text: str, settle: float = 1.0) -> None:
+        for ch in text:
+            os.write(self.fd, ch.encode())
+            time.sleep(PACE)
+        self.pump(settle)
+
+    def enter(self, settle: float = 2.0) -> None:
+        """Send Enter as its own write, well after the last character."""
+        time.sleep(0.3)
+        os.write(self.fd, b"\r")
+        self.pump(settle)
+
+    def prompt(self) -> str:
+        """The prompt line's contents, glyph and placeholder stripped."""
+        for line in reversed(self.buf.splitlines()):
+            if "❯" in line:
+                text = line.split("❯", 1)[1].replace("│", "").strip()
+                return "" if text.startswith("Ask anything") else text
+        return "<no prompt line found>"
+
+    def transcript_has(self, needle: str) -> bool:
+        return needle in self.buf
+
+    def close(self, expect_exit: bool = False) -> dict:
+        """Reap while draining, so a child blocked on write can still exit."""
+        result = {"exited": False, "exit_code": None, "exit_seconds": None}
+        start = time.time()
+        if not expect_exit:
+            # Nothing has asked it to quit, so do not sit waiting out the full
+            # exit budget for every scenario — that alone cost ~12s each.
+            os.kill(self.pid, signal.SIGTERM)
+        deadline = start + (12 if expect_exit else 3)
+        while time.time() < deadline:
+            try:
+                wpid, status = os.waitpid(self.pid, os.WNOHANG)
+            except ChildProcessError:
+                result["exited"] = True
+                break
+            if wpid:
+                result["exited"] = True
+                result["exit_code"] = os.waitstatus_to_exitcode(status) if hasattr(
+                    os, "waitstatus_to_exitcode") else (status >> 8)
+                result["exit_seconds"] = round(time.time() - start, 2)
+                break
+            self.pump(0.2)      # keep draining or the child may block on write
+        if not result["exited"]:
+            os.kill(self.pid, signal.SIGKILL)
+            try:
+                os.waitpid(self.pid, 0)
+            except ChildProcessError:
+                pass
+        os.close(self.fd)
+        self.backend.stop()
+        shutil.rmtree(self.xdg, ignore_errors=True)
+        return result
+
+
+# --- scenarios ------------------------------------------------------------
+# Each returns a dict that the vitest wrapper asserts on.
+
+def s_boot() -> dict:
+    s = Session(); ready = s.await_prompt()
+    out = {"booted": "Latexy" in s.buf, "has_prompt": "❯" in s.buf, "ready": ready,
+           "no_crash": "at Object." not in s.buf and "Error:" not in s.buf}
+    out.update(s.close())
+    return out
+
+
+def s_slash_menu() -> dict:
+    s = Session(); ready = s.await_prompt()
+    s.type("/", settle=1.5)
+    shown = s.buf
+    out = {"suggestions_visible": "Commands" in shown or "/compile" in shown,
+           "prompt": s.prompt()}
+    out.update(s.close())
+    return out
+
+
+def _ctrl_l_case(prefix: str) -> dict:
+    s = Session(); ready = s.await_prompt()
+    if prefix:
+        s.type(prefix, settle=1.0)
+    s.type(CTRL_L, settle=1.5)
+    out = {"prompt": s.prompt()}
+    out.update(s.close())
+    return out
+
+
+def s_ctrl_l_empty() -> dict:        return _ctrl_l_case("")
+def s_ctrl_l_text() -> dict:         return _ctrl_l_case("hello")
+def s_ctrl_l_trailing_l() -> dict:   return _ctrl_l_case("abcl")
+
+
+def s_ctrl_a_text() -> dict:
+    s = Session(); ready = s.await_prompt()
+    s.type("abc", settle=1.0)
+    s.type(CTRL_A, settle=1.5)
+    out = {"prompt": s.prompt()}
+    out.update(s.close())
+    return out
+
+
+def s_ctrl_c_keeps_c() -> dict:
+    """ink-text-input does not append for Ctrl+C, so a real trailing c must survive."""
+    s = Session(); ready = s.await_prompt()
+    s.type("abc", settle=1.0)
+    before = s.prompt()
+    os.write(s.fd, CTRL_C.encode())
+    res = s.close(expect_exit=True)
+    return {"prompt_before_exit": before, **res}
+
+
+def s_typing_l() -> dict:
+    s = Session(); ready = s.await_prompt()
+    s.type("llama", settle=1.5)
+    out = {"prompt": s.prompt()}
+    out.update(s.close())
+    return out
+
+
+def s_paste_single() -> dict:
+    """A pasted command arrives as one chunk including its newline."""
+    s = Session(); ready = s.await_prompt()
+    os.write(s.fd, b"/help\r")
+    s.pump(3)
+    out = {"submitted": s.transcript_has("Available commands") or s.transcript_has("/compile"),
+           "prompt": s.prompt()}
+    out.update(s.close())
+    return out
+
+
+def s_paste_multi() -> dict:
+    s = Session(); ready = s.await_prompt()
+    # Two commands with distinct, additive output. An earlier version used /clear
+    # and asserted on its ABSENCE, which can never work here: this buffer keeps
+    # everything ever emitted, so a cleared transcript still contains the old text.
+    os.write(s.fd, b"/help\r/health\r")
+    s.pump(5)
+    out = {"prompt": s.prompt(),
+           "first_ran": s.transcript_has("Available commands"),
+           "second_ran": s.transcript_has("Backend status")}
+    out.update(s.close())
+    return out
+
+
+def s_paste_blank_first() -> dict:
+    s = Session(); ready = s.await_prompt()
+    os.write(s.fd, b"\n/help\r")
+    s.pump(3)
+    out = {"submitted": s.transcript_has("Available commands") or s.transcript_has("/compile"),
+           "prompt": s.prompt()}
+    out.update(s.close())
+    return out
+
+
+def s_paste_incomplete_tail() -> dict:
+    """No trailing newline: the last line must stay in the box, unsubmitted."""
+    s = Session(); ready = s.await_prompt()
+    os.write(s.fd, b"/help\r/clear")
+    s.pump(3)
+    out = {"prompt": s.prompt()}
+    out.update(s.close())
+    return out
+
+
+def s_ctrl_c_exits() -> dict:
+    s = Session(); ready = s.await_prompt()
+    os.write(s.fd, CTRL_C.encode())
+    return s.close(expect_exit=True)
+
+
+SCENARIOS = {name[2:]: fn for name, fn in list(globals().items()) if name.startswith("s_")}
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in SCENARIOS:
+        print(json.dumps({"error": "unknown scenario",
+                          "available": sorted(SCENARIOS)}), flush=True)
+        sys.exit(2)
+    print(json.dumps(SCENARIOS[sys.argv[1]]()), flush=True)


### PR DESCRIPTION
Fixes #1133
Fixes #1132
Refs #1143

Closes the two "we have no coverage here" issues from the round-4 audit, and fixes the reason the production storage outage went unnoticed.

## #1133 — CI now runs the TUI suite

`ci.yml` had no reference to `packages/tui`. Its tests ran only on a developer's machine, which is the mechanism behind four audit rounds finding 70 defects in one package: nothing regression-tested it in between.

The job needs **no service container**. Without `LATEXY_LIVE` the 66 live tests skip cleanly and the other 177 run, covering the invariants worth gating a PR on — registry/dispatch parity, websocket lifecycle and resume position, config atomicity, retry safety, argv parsing, error extraction.

Node 22 rather than the 20 other jobs pin, since `packages/tui` declares `engines.node >=22`. `XDG_CONFIG_HOME` points at the runner temp dir because the live suites refuse to run unless it is outside `$HOME` — `/logout` calls `clearConfig()`, and that guard exists because it destroyed a developer's real session token during an earlier round.

Simulated locally exactly as written: typecheck PASS, build PASS, `177 passed | 66 skipped`, ~62s.

## #1132 — keyboard behaviour is now tested

`ink-testing-library@4` does not deliver keystrokes to Ink 5 — a minimal `useInput` probe that appends every character it receives renders `[]` after two writes to stdin, with and without `CI` set. So the input layer had **no automated coverage**, and three keyboard fixes shipped wrong before they were right: the Ctrl+L repair twice, the paste handler once.

`test-harness/pty_driver.py` drives the built CLI in a real pty. Python stdlib — no npm dependency, no native build — and it starts its own stub HTTP server answering `/me`, so it needs nothing running. That stub is load-bearing: without it the app cannot validate its token, opens the login overlay, and `PromptInput` renders its blocked branch with no text input at all. Every scenario would have passed while testing nothing.

**13 scenarios** — boot, the bare-`/` menu, five Ctrl+L cases, four paste cases, two for Ctrl+C.

**The assertions were checked against the bugs they describe.** With the guard reverted:

```
ctrl_l_text          {"prompt": "hellol"}   # expected "hello"
ctrl_l_trailing_l    {"prompt": "abcll"}    # expected "abcl"
```

Those are the exact original signatures, so these tests have teeth rather than merely passing.

Two harness details are commented in the driver because each produced a false failure first, and both cost real time:
- **Keystrokes must be paced.** Written too quickly the pty coalesces them into one read and Ink parses the chunk as a single key event with the `\r` landing as a literal character — indistinguishable from "Enter does not submit". This caused me to briefly believe production sign-in was broken.
- **The child must be reaped while the master fd is drained.** Breaking out on `EIO` without `waitpid` leaves a zombie, and a child blocked mid-write to a full pty never exits — indistinguishable from "Ctrl+C does not exit", which is a bug this package genuinely had.

## #1143 (partial) — a storage outage can no longer hide

Object storage was the one backing service `/health` did not probe. In production it answered

```json
{"status":"healthy","database":"ok","redis":"ok"}
```

while **every** template thumbnail and preview PDF returned `502 Storage unavailable` — 0 of 147 served. Nothing watching health could tell.

`/health` now reports `storage` and degrades `status`, matching how database and redis are already handled: HTTP stays 200 so availability probes keep working, while anything asserting `status == "healthy"` notices.

**The probe gets its own boto3 client, and that detail matters more than it looks.** The shared client is tuned for real transfers — `connect_timeout=5`, 3 retries — and reusing it measured **24s** against a black-holed endpoint. Since `/health` is polled roughly every 30s by the TUI and on a schedule by Modal, that would have converted a storage outage into a health outage. With a 2s no-retry client plus a 30s result cache:

| situation | before | after |
|---|---|---|
| black-holed endpoint | 24.1s | 4.2s |
| connection refused | 1.7s | 0.19s |
| cached | — | 0.000s |
| storage actually up | — | 0.15s |

`HeadBucket` is the lightest call proving connectivity *and* credentials — which matters, because the production failure is a credentials/endpoint gap rather than a network one.

Tests cover storage up, storage down in the exact production shape (DB and Redis fine, storage dead), and a probe that raises. Verified to fail when the degrade condition is removed.

**This does not fix the outage.** #1143 needs real object-storage config in the `latexy-backend-secrets` Modal secret — `MINIO_ENDPOINT` currently falls back to `http://localhost:9000`, and there is no MinIO inside a Modal container. That needs credentials I do not have. This change makes the next one impossible to miss and leaves #1143 open.

## Verification

- TUI: typecheck, build, `177 passed | 66 skipped`
- Backend: `test_health_probes.py`, `test_health.py`, `test_observability.py` all pass; ruff clean. The full backend suite is slow locally and was still running at push time — CI is the authoritative check here, and I will report if it disagrees.
- Frontend: `tsc --noEmit` clean

Not merging — for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Health checks now report object-storage availability alongside database, Redis, and other service statuses.
  - The service reports a clear degraded status when object storage or another critical dependency is unavailable.

- **Bug Fixes**
  - Health checks now handle storage probe failures gracefully without returning an unexpected server error.

- **Tests**
  - Expanded automated coverage for health reporting and terminal keyboard interactions, including menus, pasted input, shortcuts, and process exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->