### PR TITLE
fix(ux): BYOK page: logged-out redirect drops the intended destination

### DIFF
--- a/frontend/src/app/byok/page.tsx
+++ b/frontend/src/app/byok/page.tsx
@@ -36,7 +36,7 @@ export default function BYOKPage() {
 
   useEffect(() => {
     if (!isPending && !session) {
-      router.push('/login')
+      router.push(`/login?redirect=${encodeURIComponent(window.location.pathname)}`)
     }
   }, [session, isPending, router])
 


### PR DESCRIPTION
Closes #1415

The BYOK settings page redirected unauthenticated visitors to `/login` without preserving where they were trying to go, so after signing in they landed on the default page instead of `/byok`.

**Change:**
- Redirect now uses `/login?redirect=${encodeURIComponent(window.location.pathname)}`, matching the `redirect` param the login page actually reads, so the user round-trips back to `/byok` after auth.

Part of the sev:high / sev:medium UX audit fix batch (`docs/qa/ux-improvements.md`).