### PR TITLE
fix(ux): No global keyboard-focus indicator — many interactive elements are invis

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -52,6 +52,15 @@
       radial-gradient(circle at 21% 82%, rgba(255, 255, 255, 0.04), transparent 24%);
     background-attachment: fixed;
   }
+
+  /* Global keyboard focus indicator (WCAG 2.4.7). Applies to any focusable
+     element — nav/footer/menu links included — that doesn't already define its
+     own focus-visible ring. Mouse clicks stay ring-free via :focus-visible. */
+  :focus-visible {
+    outline: 2px solid var(--focus);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
 }
 
 @layer components {


### PR DESCRIPTION
Closes #1427

Several nav/footer/menu links relied on browser-default focus styling (or none at all), failing WCAG 2.4.7 (focus visible) for keyboard-only navigation.

**Change:**
- Added a global `:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; border-radius: var(--radius-sm); }` rule so any focusable element without its own focus-visible ring still gets one
- Uses `:focus-visible` (not `:focus`) so mouse clicks stay ring-free

Part of the sev:high / sev:medium UX audit fix batch (`docs/qa/ux-improvements.md`).