### PR TITLE
fix(ux): Login page redirect-param handling needs to support every auth-guard's p

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,19 +1,36 @@
 'use client'
 
+import { Suspense } from 'react'
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
 import SignInForm from '@/components/auth/SignInForm'
 
-export default function LoginPage() {
+// Accept whichever intended-destination param an auth guard may have appended.
+const REDIRECT_KEYS = ['redirect', 'callbackURL', 'next', 'returnTo'] as const
+
+/** Return a safe same-origin relative path, or null. Blocks open-redirects. */
+function readRedirect(params: URLSearchParams): string | null {
+  for (const key of REDIRECT_KEYS) {
+    const raw = params.get(key)
+    if (raw && raw[0] === '/' && raw[1] !== '/' && raw[1] !== '\\') return raw
+  }
+  return null
+}
+
+function LoginInner() {
+  const redirect = readRedirect(useSearchParams())
+  const signupHref = redirect ? `/signup?redirect=${encodeURIComponent(redirect)}` : '/signup'
+
   return (
     <div className="bg-bg text-fg">
       <div className="mx-auto flex min-h-[80vh] max-w-6xl items-center justify-center px-5 py-16 sm:px-8">
         <div className="w-full max-w-md space-y-6">
-          <SignInForm />
+          <SignInForm redirect={redirect ?? undefined} />
 
           <p className="text-center font-body text-sm text-fg-3">
             Don&apos;t have an account?{' '}
             <Link
-              href="/signup"
+              href={signupHref}
               className="font-medium text-accent-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg rounded-[var(--radius-sm)]"
             >
               Sign up
@@ -22,5 +39,13 @@ export default function LoginPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginInner />
+    </Suspense>
   )
 }


### PR DESCRIPTION
Closes #1431

Different pages across the app were redirecting to `/login` with different query param names (`redirect`, `next`, `returnTo`), and login only read one of them, silently dropping the user's destination on several flows.

**Change:**
- Reads `redirect`/`callbackURL`/`next`/`returnTo` via a shared `REDIRECT_KEYS` array and `readRedirect()` same-origin guard, wrapped in `<Suspense>` for `useSearchParams()`, and passes the resolved destination to `SignInForm`

Part of the sev:high / sev:medium UX audit fix batch (`docs/qa/ux-improvements.md`).