### PR TITLE
fix(ux): Workspace merge page: logged-out redirect drops the intended destination

### DIFF
--- a/frontend/src/app/workspace/merge/page.tsx
+++ b/frontend/src/app/workspace/merge/page.tsx
@@ -35,7 +35,7 @@ export default function MergeResumesPage() {
   // Auth guard
   useEffect(() => {
     if (!isPending && !session) {
-      router.push('/login')
+      router.push(`/login?redirect=${encodeURIComponent(window.location.pathname)}`)
     }
   }, [isPending, session, router])
 


### PR DESCRIPTION
Closes #1457

Same class of bug as the other auth-guarded pages: the redirect to `/login` didn't use the param the login page actually reads, so users landed on the default destination instead of back on the merge page after signing in.

**Change:**
- Redirect now uses `/login?redirect=${encodeURIComponent(window.location.pathname)}`

Part of the sev:high / sev:medium UX audit fix batch (`docs/qa/ux-improvements.md`).