### PR TITLE
fix(ux): New-resume page: pressing Enter in template mode incorrectly creates a b

### DIFF
--- a/frontend/src/app/workspace/new/page.tsx
+++ b/frontend/src/app/workspace/new/page.tsx
@@ -242,7 +242,13 @@ export default function NewResumePage() {
             placeholder="Senior Backend Engineer – Q3 2026"
             value={title}
             onChange={e => setTitle(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter' && canCreate) handleCreate() }}
+            onKeyDown={e => {
+              // In template mode there is no single obvious create action — a
+              // template still needs to be picked — so Enter must NOT fall
+              // through to blank-resume creation. Only trigger create in the
+              // import/linkedin/builder flows where one create action exists.
+              if (e.key === 'Enter' && mode !== 'template' && canCreate) handleCreate()
+            }}
             className="w-full rounded-[var(--radius-md)] border border-line bg-bg px-4 py-3 text-base text-fg outline-none transition focus:border-accent"
           />
         </section>


### PR DESCRIPTION
Closes #1459

When "start from a template" mode was selected (which has no single obvious create action — a template still needs to be picked first), pressing Enter anywhere in the form fell through to the blank-resume create action instead of doing nothing, silently discarding the user's template choice.

**Change:**
- The Enter-key handler now only triggers `handleCreate()` for the import/LinkedIn/builder flows (which do have one unambiguous create action); template mode is explicitly excluded

Part of the sev:high / sev:medium UX audit fix batch (`docs/qa/ux-improvements.md`).