### PR TITLE
fix(ux): Loading skeletons are silent to screen readers — no 'Loading' announceme

### DIFF
--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -2,13 +2,26 @@
 
 export function Skeleton({ className }: { className?: string }) {
   return (
-    <div className={`animate-pulse rounded-[var(--radius-sm)] bg-surface-2 ${className}`} />
+    <div aria-hidden="true" className={`animate-pulse rounded-[var(--radius-sm)] bg-surface-2 ${className}`} />
+  )
+}
+
+/**
+ * Announces the loading state to assistive tech. Wrap any group of decorative
+ * <Skeleton /> shapes so screen readers hear "Loading…" instead of silence.
+ */
+export function SkeletonGroup({ label = 'Loading…', className, children }: { label?: string; className?: string; children: React.ReactNode }) {
+  return (
+    <div role="status" aria-live="polite" aria-busy="true" className={className}>
+      {children}
+      <span className="sr-only">{label}</span>
+    </div>
   )
 }
 
 export function CardSkeleton() {
   return (
-    <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 space-y-4">
+    <SkeletonGroup className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 space-y-4">
       <div className="flex items-center justify-between">
         <Skeleton className="h-4 w-24" />
         <Skeleton className="h-4 w-4 rounded-full" />
@@ -17,13 +30,13 @@ export function CardSkeleton() {
         <Skeleton className="h-8 w-16" />
         <Skeleton className="h-3 w-12" />
       </div>
-    </div>
+    </SkeletonGroup>
   )
 }
 
 export function ResumeCardSkeleton() {
   return (
-    <div className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 space-y-6">
+    <SkeletonGroup className="rounded-[var(--radius-lg)] border border-line bg-surface p-5 space-y-6">
       <div className="flex items-start justify-between">
         <Skeleton className="h-12 w-12 rounded-lg" />
         <Skeleton className="h-6 w-6" />
@@ -36,6 +49,6 @@ export function ResumeCardSkeleton() {
         <Skeleton className="h-8 flex-1 rounded-lg" />
         <Skeleton className="h-8 flex-1 rounded-lg" />
       </div>
-    </div>
+    </SkeletonGroup>
   )
 }


### PR DESCRIPTION
Closes #1483

Groups of decorative `<Skeleton />` placeholders had no accessible indication that content was loading; screen-reader users got silence instead of any "Loading…" cue.

**Change:**
- Added `aria-hidden="true"` to individual `<Skeleton>` shapes (they're purely decorative) and a new `SkeletonGroup` wrapper component with `role="status"`/`aria-live` that announces a "Loading…" label (configurable) to assistive tech around any group of skeletons

Part of the sev:high / sev:medium UX audit fix batch (`docs/qa/ux-improvements.md`).