### PR TITLE
fix(ux): 3 low-severity findings in page.tsx

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import {
   apiClient,
   type CoverLetterStatsResponse,
+  type JobResultResponse,
   type JobStateResponse,
   type ResumeStats,
   type UserAnalyticsResponse,
@@ -33,6 +34,10 @@ export default function DashboardPage() {
   const [recentJobs, setRecentJobs] = useState<JobStateResponse[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [selectedJob, setSelectedJob] = useState<JobStateResponse | null>(null)
+  const [selectedJobResult, setSelectedJobResult] = useState<JobResultResponse | null>(null)
+  const [selectedJobResultLoading, setSelectedJobResultLoading] = useState(false)
+  const [selectedJobResultError, setSelectedJobResultError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!sessionLoading && !session) {
@@ -72,6 +77,42 @@ export default function DashboardPage() {
     fetchDashboardData()
   }, [fetchDashboardData])
 
+  useEffect(() => {
+    if (!selectedJob) return
+    const jobId = selectedJob.job_id
+    if (!jobId) return
+
+    let cancelled = false
+    setSelectedJobResult(null)
+    setSelectedJobResultError(null)
+    setSelectedJobResultLoading(true)
+
+    apiClient
+      .getJobResult(jobId)
+      .then((result) => {
+        if (!cancelled) setSelectedJobResult(result)
+      })
+      .catch((err) => {
+        if (!cancelled) setSelectedJobResultError(err instanceof Error ? err.message : 'Failed to load run details')
+      })
+      .finally(() => {
+        if (!cancelled) setSelectedJobResultLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedJob])
+
+  useEffect(() => {
+    if (!selectedJob) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setSelectedJob(null)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [selectedJob])
+
   const dailySeries = useMemo(() => {
     if (timeseries?.activity_series?.length) {
       return timeseries.activity_series.map((point) => ({ date: point.date, value: point.events }))
@@ -101,21 +142,35 @@ export default function DashboardPage() {
     return Object.entries(counts).map(([name, value]) => ({ name, value }))
   }, [timeseries, recentJobs])
 
+  // When the server hasn't supplied a range-scoped status distribution, the
+  // donut falls back to whatever's in recentJobs, which is capped at 10 runs
+  // (see fetchDashboardData). Label that scope honestly instead of implying
+  // it reflects the full selected range.
+  const isStatusSeriesFallback = !timeseries?.status_distribution
+
   const kpis = useMemo(() => {
     if (!analytics || !stats) return []
 
     const activeDays = Object.keys(analytics.daily_activity).length
     const avgDailyActions = activeDays > 0 ? (Object.values(analytics.daily_activity).reduce((sum, value) => sum + value, 0) / activeDays).toFixed(1) : '0.0'
 
+    const avgLatency = analytics.avg_compilation_time
+    const latencyValue =
+      avgLatency === undefined || avgLatency === null || Number.isNaN(avgLatency)
+        ? '—'
+        : avgLatency < 10
+          ? `${avgLatency.toFixed(1)}s`
+          : `${Math.round(avgLatency)}s`
+
     return [
       {
         label: 'Success Rate',
-        value: `${Math.round(analytics.success_rate)}%`,
+        value: Number.isFinite(analytics.success_rate) ? `${Math.round(analytics.success_rate)}%` : '—',
         note: 'Compilation reliability',
       },
       {
         label: 'Avg Compile Latency',
-        value: `${analytics.avg_compilation_time}s`,
+        value: latencyValue,
         note: `For last ${selectedRange} days`,
       },
       {
@@ -272,14 +327,26 @@ export default function DashboardPage() {
 
         <aside className="space-y-6">
           <article className="rounded-[var(--radius-lg)] border border-line bg-surface p-5">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-fg-2">Run Status Distribution</h2>
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-fg-2">
+                {isStatusSeriesFallback ? 'Status of Last 10 Runs' : 'Run Status Distribution'}
+              </h2>
+              {isStatusSeriesFallback && !loading && !error && (
+                <span
+                  className="rounded-[var(--radius-md)] border border-line bg-surface-2 px-2 py-0.5 text-[9px] uppercase tracking-[0.1em] text-fg-3"
+                  title={`Range-scoped status data wasn't available, so this reflects only the ${recentJobs.length} most recent run${recentJobs.length === 1 ? '' : 's'} rather than the full ${selectedRange}-day window.`}
+                >
+                  Last 10 only
+                </span>
+              )}
+            </div>
             <div className="mt-4">
               {loading ? (
                 <div className="h-[220px] animate-pulse rounded-[var(--radius-lg)] bg-surface-2" />
               ) : error ? (
                 <ChartUnavailable heightClass="h-[220px]" onRetry={fetchDashboardData} />
               ) : (
-                <StatusDonutChart data={statusSeries} />
+                <StatusDonutChart data={statusSeries} totalLabel={isStatusSeriesFallback ? 'LAST 10' : 'RUNS'} />
               )}
             </div>
           </article>
@@ -302,16 +369,144 @@ export default function DashboardPage() {
             ) : (
               <div className="space-y-2">
                 {recentJobs.map((job, index) => (
-                  <div key={job.job_id ?? `${job.last_updated}-${index}`} className="rounded-[var(--radius-md)] border border-line bg-surface-2 p-3">
-                    <p className="text-xs uppercase tracking-[0.12em] text-fg-3">{job.stage || 'Pipeline'}</p>
-                    <p className="mt-1 text-sm capitalize text-fg">{job.status}</p>
-                    <p className="mt-1 text-xs text-fg-3">{new Date(job.last_updated * 1000).toLocaleString()}</p>
-                  </div>
+                  <button
+                    key={job.job_id ?? `${job.last_updated}-${index}`}
+                    type="button"
+                    onClick={() => setSelectedJob(job)}
+                    disabled={!job.job_id}
+                    className="w-full rounded-[var(--radius-md)] border border-line bg-surface-2 p-3 text-left transition hover:border-line-2 hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-default disabled:opacity-70 disabled:hover:border-line disabled:hover:brightness-100"
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.12em] text-fg-3">{job.stage || 'Pipeline'}</p>
+                        <p className="mt-1 text-sm capitalize text-fg">{job.status}</p>
+                        <p className="mt-1 text-xs text-fg-3">{new Date(job.last_updated * 1000).toLocaleString()}</p>
+                      </div>
+                      {job.job_id && <span className="mt-0.5 shrink-0 text-xs text-accent-strong">View →</span>}
+                    </div>
+                  </button>
                 ))}
               </div>
             )}
           </article>
         </aside>
+      </div>
+
+      {selectedJob && (
+        <JobDetailModal
+          job={selectedJob}
+          result={selectedJobResult}
+          loading={selectedJobResultLoading}
+          error={selectedJobResultError}
+          onClose={() => setSelectedJob(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function JobDetailModal({
+  job,
+  result,
+  loading,
+  error,
+  onClose,
+}: {
+  job: JobStateResponse
+  result: JobResultResponse | null
+  loading: boolean
+  error: string | null
+  onClose: () => void
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="job-detail-title"
+        onClick={(event) => event.stopPropagation()}
+        className="w-full max-w-md rounded-[var(--radius-lg)] border border-line bg-surface p-5 shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.14em] text-fg-3">{job.stage || 'Pipeline'}</p>
+            <h2 id="job-detail-title" className="mt-1 text-lg font-semibold capitalize text-fg">
+              Run {job.status}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-[var(--radius-md)] border border-line-2 px-2 py-1 text-xs text-fg-2 hover:bg-surface-2"
+          >
+            Close
+          </button>
+        </div>
+
+        <dl className="mt-4 space-y-2 text-sm">
+          <div className="flex justify-between gap-4">
+            <dt className="text-fg-3">Last updated</dt>
+            <dd className="text-fg">{new Date(job.last_updated * 1000).toLocaleString()}</dd>
+          </div>
+          {job.job_id && (
+            <div className="flex justify-between gap-4">
+              <dt className="text-fg-3">Job ID</dt>
+              <dd className="font-mono text-xs text-fg">{job.job_id}</dd>
+            </div>
+          )}
+          {typeof job.percent === 'number' && (
+            <div className="flex justify-between gap-4">
+              <dt className="text-fg-3">Progress</dt>
+              <dd className="text-fg">{job.percent}%</dd>
+            </div>
+          )}
+        </dl>
+
+        <div className="mt-4 border-t border-line pt-4">
+          {loading ? (
+            <p className="text-sm text-fg-3">Loading run result…</p>
+          ) : error ? (
+            <p className="text-sm text-err">{error}</p>
+          ) : result ? (
+            <dl className="space-y-2 text-sm">
+              {typeof result.ats_score === 'number' && (
+                <div className="flex justify-between gap-4">
+                  <dt className="text-fg-3">ATS score</dt>
+                  <dd className="text-fg">{Math.round(result.ats_score)}</dd>
+                </div>
+              )}
+              {typeof result.compilation_time === 'number' && (
+                <div className="flex justify-between gap-4">
+                  <dt className="text-fg-3">Compile time</dt>
+                  <dd className="text-fg">{result.compilation_time.toFixed(1)}s</dd>
+                </div>
+              )}
+              {typeof result.optimization_time === 'number' && (
+                <div className="flex justify-between gap-4">
+                  <dt className="text-fg-3">Optimize time</dt>
+                  <dd className="text-fg">{result.optimization_time.toFixed(1)}s</dd>
+                </div>
+              )}
+              {result.error && <p className="text-sm text-err">{result.error}</p>}
+              {!result.error &&
+                typeof result.ats_score !== 'number' &&
+                typeof result.compilation_time !== 'number' &&
+                typeof result.optimization_time !== 'number' && (
+                  <p className="text-sm text-fg-3">No additional result data for this run.</p>
+                )}
+            </dl>
+          ) : (
+            <p className="text-sm text-fg-3">No additional result data for this run.</p>
+          )}
+        </div>
+
+        <Link
+          href="/workspace/history"
+          className="mt-5 inline-block text-xs uppercase tracking-[0.12em] text-accent-strong hover:brightness-110"
+        >
+          View full history →
+        </Link>
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #1186
Closes #1187
Closes #1188

Findings addressed in this file:
- #1186: 'Recent Runs' cards are dead ends — clicking a run does nothing
- #1187: Status donut fallback is computed from only the last 10 jobs but presented as overall distribution
- #1188: KPI values are unformatted and can render awkwardly (raw latency, no units guard)

Part of the sev:low UX audit fix batch (`docs/qa/ux-improvements.md`), completing the backlog after the sev:high/medium batch (#1485).