### PR TITLE
fix(ux): Rename button is always enabled, firing no-op saves for unch

### DIFF
--- a/frontend/src/app/developer/page.tsx
+++ b/frontend/src/app/developer/page.tsx
@@ -304,7 +304,11 @@ console.log(payload);`,
                   />
                   <button
                     onClick={() => handleRename(key.id)}
-                    disabled={busyKeyId === key.id}
+                    disabled={
+                      busyKeyId === key.id ||
+                      !renaming[key.id]?.trim() ||
+                      renaming[key.id]?.trim() === key.name
+                    }
                     className={`${ghostBtn} shrink-0`}
                   >
                     Rename


### PR DESCRIPTION
Closes #1229

Findings addressed in this file:
- #1229: Rename button is always enabled, firing no-op saves for unchanged names

Part of the sev:low UX audit fix batch (`docs/qa/ux-improvements.md`), completing the backlog after the sev:high/medium batch (#1485).