### PR TITLE
fix(ux): 404 page inherits the wrong aesthetic (compiler) for unknown

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -3,10 +3,20 @@ import Link from 'next/link'
 /**
  * Themed 404 (redesign). Replaces Next's unstyled default. Renders inside the
  * root layout, so it inherits the active aesthetic + mode tokens.
+ *
+ * The pre-paint bootstrap script (root layout) sets `data-aesthetic` by
+ * matching the pathname against a typeset whitelist; any unrecognized path —
+ * i.e. exactly the 404 case — falls through to 'compiler', which would give
+ * this marketing-styled page the dark-orange app aesthetic instead of the
+ * typeset look its copy/design imply. Force it back to 'typeset' as soon as
+ * this page mounts, before paint is visible to the user.
  */
+const FORCE_TYPESET = `document.documentElement.setAttribute('data-aesthetic','typeset');`
+
 export default function NotFound() {
   return (
     <div className="flex min-h-[70vh] flex-col items-center justify-center bg-bg px-6 py-20 text-center text-fg">
+      <script dangerouslySetInnerHTML={{ __html: FORCE_TYPESET }} />
       <p className="font-mono text-sm uppercase tracking-[0.3em] text-accent-strong">404</p>
       <h1 className="mt-4 max-w-[18ch] text-balance font-display text-[clamp(2rem,5vw,3.4rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-fg">
         This page could not be found.


### PR DESCRIPTION
Closes #1207

Findings addressed in this file:
- #1207: 404 page inherits the wrong aesthetic (compiler) for unknown paths

Part of the sev:low UX audit fix batch (`docs/qa/ux-improvements.md`), completing the backlog after the sev:high/medium batch (#1485).