### PR TITLE
fix(ux): flag not-found's forced typeset for AestheticController to honor

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -11,7 +11,7 @@ import Link from 'next/link'
  * typeset look its copy/design imply. Force it back to 'typeset' as soon as
  * this page mounts, before paint is visible to the user.
  */
-const FORCE_TYPESET = `document.documentElement.setAttribute('data-aesthetic','typeset');`
+const FORCE_TYPESET = `document.documentElement.setAttribute('data-aesthetic','typeset');document.documentElement.setAttribute('data-force-typeset','1');`
 
 export default function NotFound() {
   return (


### PR DESCRIPTION
Closes #1513

Sets a `data-force-typeset` flag alongside the existing aesthetic override so AestheticController's route effect (see companion PR) can detect and honor it instead of silently overwriting it back to 'compiler'.