### PR TITLE
fix(p0): Extend the JSON log formatter's field allowlist for the new compile-timi

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -71,6 +71,20 @@ class JsonFormatter(logging.Formatter):
             value = getattr(record, key, None)
             if value is not None:
                 payload[key] = value
+        # Job-pipeline timing checkpoints (#1281 — "Compile latency: 37s median ->
+        # target <10s"). Emitted via logger.*(..., extra={...}) in latex_worker.py /
+        # orchestrator.py so a single log line carries every phase of a job instead
+        # of one opaque duration, and can be grepped/aggregated by "outcome" and
+        # "compiler" across all compiles.
+        for key in (
+            "compiler", "outcome",
+            "queue_wait_seconds", "cold_start_seconds",
+            "compile_subprocess_seconds", "reporting_seconds", "total_task_seconds",
+            "optimization_seconds", "ats_scoring_seconds",
+        ):
+            value = getattr(record, key, None)
+            if value is not None:
+                payload[key] = value
         if record.exc_info:
             payload["exception"] = self.formatException(record.exc_info)
         return json.dumps(_sanitize(payload), ensure_ascii=True)


### PR DESCRIPTION
Closes #1529
Part of #1281

Part of #1281 ("Compile latency: 37s median -> target <10s"). Without this, the new timing fields added to `latex_worker.py` and `orchestrator.py` would be silently dropped at log-formatting time.

**Problem:** `JsonFormatter` only serializes `extra` fields that appear on an explicit allowlist (`backend/app/core/logging.py`). This was verified as a real risk before adding the new instrumentation fields elsewhere — not a hypothetical.

**Fix:** extended the allowlist with `compiler`, `outcome`, `queue_wait_seconds`, `cold_start_seconds`, `compile_subprocess_seconds`, `reporting_seconds`, `total_task_seconds`, `optimization_seconds`, `ats_scoring_seconds`.

Verified: a live local compile job's `compile_task_timing` log line was confirmed to actually carry these fields end-to-end (not silently dropped).