### PR TITLE
fix(p0): Fix the Basic-plan pricing inversion: raise the enforced compile quota f

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -321,7 +321,7 @@ class Settings(BaseSettings):
             "plan_family": "basic",
             "discount_percent": 0,
             "features": {
-                "compilations": 50,
+                "compilations": 400,
                 "optimizations": 10,
                 "historyRetention": 30,
                 "prioritySupport": False,
@@ -338,7 +338,7 @@ class Settings(BaseSettings):
             "discount_percent": 20,
             "monthly_equivalent_price": 23925,
             "features": {
-                "compilations": 50,
+                "compilations": 400,
                 "optimizations": 10,
                 "historyRetention": 30,
                 "prioritySupport": False,
@@ -758,7 +758,7 @@ PLAN_QUOTAS: Dict[str, Dict[str, tuple[int | None, str]]] = {
         "ai_assists": (25, "month"),
     },
     "basic": {
-        "compilations": (50, "month"),
+        "compilations": (400, "month"),
         "optimizations": (10, "month"),
         "ai_assists": (100, "month"),
     },


### PR DESCRIPTION
Closes #1533
Closes #1283

Closes #1283 ("Fix the pricing inversion — the first paid tier is a downgrade").

**Problem, confirmed live in the current codebase (not stale):** `PLAN_QUOTAS["basic"]["compilations"]` was `(50, "month")`, while `PLAN_QUOTAS["free"]["compilations"]` is `(10, "day")` — an effective ~300-310/month ceiling for a user paying nothing. A user who upgrades to Basic (₹299/month) got a **~6x smaller** compile allowance than they had for free.

**Fix:** `PLAN_QUOTAS["basic"]["compilations"]` changed from `(50, "month")` to `(400, "month")` — 400 clears Free's worst-case monthly equivalent (10/day × 31 = 310) with real margin, a defensible strict upgrade. The corresponding pricing-page copy placeholders (`SUBSCRIPTION_PLANS["basic"]["features"]["compilations"]` and `SUBSCRIPTION_PLANS["basic_annual"]["features"]["compilations"]`) were updated to match, and verified live at runtime that `_sync_plan_feature_copy()` actually propagates the enforced number into both, so the advertised and enforced numbers cannot drift apart.

**Inversion check on the other quota dimensions (verified, not assumed):** `optimizations` (free 3/mo vs basic 10/mo) and `ai_assists` (free 25/mo vs basic 100/mo) have no inversion — basic already wins on both. Only `compilations` had the day-vs-month window mismatch that produced the inversion; that is the only dimension changed.

**Verified live:** `GET /subscription/plans` on the local dev stack now returns `"compilations": "400 / month"` for Basic. Full backend test suite: 0 failures.