### PR TITLE
fix(p0): Fix stale Basic-plan compile count in the in-app FAQ

### DIFF
--- a/frontend/src/components/help/HelpCenter.tsx
+++ b/frontend/src/components/help/HelpCenter.tsx
@@ -129,7 +129,7 @@ const faqData: FAQItem[] = [
   {
     id: 'subscription-plans',
     question: 'What subscription plans are available?',
-    answer: 'We offer: Free (10 compilations/day, 3 AI optimizations/month), Basic (₹299/month - 50 compilations, 10 optimizations per month), Pro (₹599/month - unlimited), and BYOK (₹199/month - unlimited with your API keys). All paid plans include resume history and priority support.',
+    answer: 'We offer: Free (10 compilations/day, 3 AI optimizations/month), Basic (₹299/month - 400 compilations, 10 optimizations per month), Pro (₹599/month - unlimited), and BYOK (₹199/month - unlimited with your API keys). All paid plans include resume history and priority support.',
     category: 'billing',
     tags: ['plans', 'pricing', 'subscription']
   },


### PR DESCRIPTION
Closes #1537
Part of #1283

Part of #1283 ("Fix the pricing inversion — the first paid tier is a downgrade"). The FAQ's "What subscription plans are available?" answer advertised Basic at "50 compilations", matching the old, now-fixed inverted quota. Updated to "400 compilations" to match the corrected `PLAN_QUOTAS` value in `backend/app/core/config.py`.