### PR TITLE
fix(p0): Fix stale Basic-plan compile count in the Terms of Service

### DIFF
--- a/legal/terms-of-service.md
+++ b/legal/terms-of-service.md
@@ -34,7 +34,7 @@ Latexy is an AI-powered ATS (Applicant Tracking System) resume optimizer that he
 
 ### 4.1 Plan Types
 - **Free Trial**: 3 free resume compilations per device (no registration required)
-- **Basic Plan**: ₹299/month - 50 compilations, 10 optimizations
+- **Basic Plan**: ₹299/month - 400 compilations, 10 optimizations
 - **Pro Plan**: ₹599/month - Unlimited compilations and optimizations
 - **BYOK Plan**: ₹199/month - Use your own API keys with premium features
 


### PR DESCRIPTION
Closes #1539
Part of #1283

Part of #1283 ("Fix the pricing inversion — the first paid tier is a downgrade"). §4.1 Plan Types listed "Basic Plan: ₹299/month - 50 compilations, 10 optimizations", matching the old, now-fixed inverted quota. Updated to "400 compilations" to match the corrected `PLAN_QUOTAS` value.