### PR TITLE
fix(p0): Fix stale Basic-plan compile count in the README pricing table

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Required repository secrets: `CI_DATABASE_URL`, `CI_JWT_SECRET_KEY`, `CI_BETTER_
 | Plan | Compilations | Optimizations | Deep analyses | Price |
 |------|-------------|---------------|---------------|-------|
 | Free (trial) | 3 lifetime | 3 lifetime | 2 lifetime | — |
-| Basic | 50 / mo | 50 / mo | 10 / mo | ₹299 / mo |
+| Basic | 400 / mo | 50 / mo | 10 / mo | ₹299 / mo |
 | Pro | Unlimited | Unlimited | Unlimited | ₹599 / mo |
 | BYOK | Unlimited | Unlimited | Unlimited | ₹199 / mo |
 


### PR DESCRIPTION
Closes #1541
Part of #1283

Part of #1283 ("Fix the pricing inversion — the first paid tier is a downgrade"). The pricing table's Basic/Compilations cell read "50 / mo", matching the old, now-fixed inverted quota. Updated to "400 / mo" to match the corrected `PLAN_QUOTAS` value. (The neighboring Optimizations cell, which reads "50 / mo" against an actual enforced value of 10/mo, is a separate pre-existing stale-doc issue unrelated to this pricing-inversion fix — left untouched, out of scope here.)