### PR TITLE
fix(p0): Refuse annual checkout cleanly when the Razorpay annual plan ID isn't co

### DIFF
--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -668,6 +668,19 @@ class PaymentService:
                     "error": "Invalid plan selected"
                 }
 
+            # Annual SKUs (basic_annual/pro_annual/byok_annual) are only
+            # launched once their RAZORPAY_PLAN_*_ANNUAL id is configured in
+            # the dashboard. Without that, falling through would spin up an
+            # ad-hoc Razorpay plan on every checkout attempt (via the
+            # create_razorpay_plan fallback in _create_paid_subscription)
+            # instead of billing against a reviewed, pre-configured annual
+            # SKU — refuse cleanly instead.
+            if concrete_plan_id.endswith("_annual") and not get_razorpay_plan_id(concrete_plan_id):
+                return {
+                    "success": False,
+                    "error": "Annual billing isn't available yet — please choose monthly.",
+                }
+
             # Handle free plan
             if plan_config["price"] == 0:
                 live = await self._get_live_provider_subscription(db, user_id)


### PR DESCRIPTION
Closes #1543
Closes #1285

Closes #1285 ("Annual SKUs + GST-inclusive price display").

**Problem, found by tracing the actual code path (not assumed):** `basic_annual`/`pro_annual`/`byok_annual` SKUs already exist in `SUBSCRIPTION_PLANS` with a 20% discount, but their `RAZORPAY_PLAN_*_ANNUAL` settings are empty strings in both `.env` and `.env.production` — nobody has created the actual annual plans in the Razorpay dashboard yet. `create_subscription()` -> `_resolve_concrete_plan_id()` -> `_create_paid_subscription()` does `get_razorpay_plan_id(concrete_plan_id) or await self.create_razorpay_plan(concrete_plan_id)` — an empty setting doesn't crash today, it silently calls Razorpay's `plan.create` API on **every single checkout attempt**, spinning up a brand-new, never-reused plan object each time.

**Fix:** added an explicit guard in `create_subscription()`, before any coupon/lock work happens, scoped only to `_annual`-suffixed plans (monthly/team/student fallback behavior is untouched):
```python
if concrete_plan_id.endswith("_annual") and not get_razorpay_plan_id(concrete_plan_id):
    return {"success": False, "error": "Annual billing isn't available yet — please choose monthly."}
```
Follows the codebase's existing envelope convention (HTTP 200, `{"success": false, "error": "..."}`) used by every other business-rule refusal in this function. The frontend already handles this exact envelope shape (`billing/page.tsx`: `if (created.success === false) toast.error(created.error)`), so this surfaces as a clean toast with zero additional frontend change needed.

**Also confirmed while implementing (evidence, not assumption):** `SUBSCRIPTION_PLANS[...]["price"]` is already the final, GST-inclusive, charge-to-card amount — `create_razorpay_plan()` sends `plan_config["price"]` verbatim as the Razorpay `item.amount` with no tax adjustment anywhere in the file (grepped for `gst|tax|1.18` — zero hits), and Razorpay does not auto-add GST on top of a merchant-set amount unless explicitly configured to. This is the evidence behind the GST-inclusive-pricing UI copy added in the companion frontend PRs.

**Verified:** `pytest test/ -k "payment or subscription or razorpay"` — 27/27 passed.