### PR TITLE
fix(p0): Add a section-level 'prices include GST' caption to the billing page

### DIFF
--- a/frontend/src/app/billing/page.tsx
+++ b/frontend/src/app/billing/page.tsx
@@ -477,6 +477,7 @@ function BillingPageContent() {
             <div>
               <h2 className="text-lg font-semibold text-fg">Choose a plan</h2>
               <p className="mt-1 text-sm text-fg-2">Annual billing saves 20% on Basic, Pro, and BYOK.</p>
+              <p className="mt-1 text-xs text-fg-3">All prices include GST — nothing extra added at checkout.</p>
             </div>
             <div
               role="group"


### PR DESCRIPTION
Closes #1545
Part of #1285

Part of #1285 ("Annual SKUs + GST-inclusive price display"). Added `"All prices include GST — nothing extra added at checkout."` directly under the "Choose a plan" heading, next to the Monthly/Annual toggle, using the existing `text-fg-3` token and spacing scale — no new visual style introduced.

This addresses the India-market checkout-abandonment cause the parent issue names: a surprise 18% GST addition at the payment step. The companion `PricingCard.tsx` PR adds the same reassurance per-card; together they cover every price-mention surface without repeating the message on every secondary price line (coupon-discounted price, comparison-table headers both derive from the same underlying price data).

**Verified live:** signed up a fresh account on the local dev stack, loaded `/billing`, confirmed the caption renders, and confirmed it persists correctly after toggling Monthly -> Annual. `tsc --noEmit` and `eslint` both clean.