### PR TITLE
fix(p0): Add a per-card 'Incl. GST' caption to every paid plan card

### DIFF
--- a/frontend/src/components/billing/PricingCard.tsx
+++ b/frontend/src/components/billing/PricingCard.tsx
@@ -71,6 +71,9 @@ export default function PricingCard({
         <h3 className="text-xl font-semibold text-fg">{plan.name}</h3>
         <p className="mt-2 text-3xl font-semibold text-fg">{formatPrice(plan.price)}</p>
         <p className="text-sm text-fg-2">{plan.price > 0 ? `per ${plan.interval}` : 'No payment required'}</p>
+        {plan.price > 0 ? (
+          <p className="mt-1 text-xs text-fg-3">Incl. GST &middot; no surprises at checkout</p>
+        ) : null}
         {plan.monthly_equivalent_price ? (
           <p className="mt-1 text-xs text-ok">₹{(plan.monthly_equivalent_price / 100).toFixed(0)}/month effective</p>
         ) : null}


### PR DESCRIPTION
Closes #1547
Part of #1285

Part of #1285 ("Annual SKUs + GST-inclusive price display"). Added `"Incl. GST · no surprises at checkout"` directly under the price/interval line, shown for every paid plan (both monthly and annual SKUs render through this one component), using only existing design tokens.

Companion to the `billing/page.tsx` section-level caption — see that PR for the evidence that the underlying `SUBSCRIPTION_PLANS` prices are already GST-inclusive at the Razorpay integration layer.

**Verified live:** confirmed on the local dev stack that the caption renders on Basic/Pro/BYOK cards in both Monthly and Annual view, and does not render on the Free card (price = 0). `tsc --noEmit` and `eslint` both clean.