### PR TITLE
P0 backlog: pricing inversion, annual SKU/GST display, compile-latency groundwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Required repository secrets: `CI_DATABASE_URL`, `CI_JWT_SECRET_KEY`, `CI_BETTER_
 | Plan | Compilations | Optimizations | Deep analyses | Price |
 |------|-------------|---------------|---------------|-------|
 | Free (trial) | 3 lifetime | 3 lifetime | 2 lifetime | — |
-| Basic | 50 / mo | 50 / mo | 10 / mo | ₹299 / mo |
+| Basic | 400 / mo | 50 / mo | 10 / mo | ₹299 / mo |
 | Pro | Unlimited | Unlimited | Unlimited | ₹599 / mo |
 | BYOK | Unlimited | Unlimited | Unlimited | ₹199 / mo |
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -321,7 +321,7 @@ class Settings(BaseSettings):
             "plan_family": "basic",
             "discount_percent": 0,
             "features": {
-                "compilations": 50,
+                "compilations": 400,
                 "optimizations": 10,
                 "historyRetention": 30,
                 "prioritySupport": False,
@@ -338,7 +338,7 @@ class Settings(BaseSettings):
             "discount_percent": 20,
             "monthly_equivalent_price": 23925,
             "features": {
-                "compilations": 50,
+                "compilations": 400,
                 "optimizations": 10,
                 "historyRetention": 30,
                 "prioritySupport": False,
@@ -758,7 +758,7 @@ PLAN_QUOTAS: Dict[str, Dict[str, tuple[int | None, str]]] = {
         "ai_assists": (25, "month"),
     },
     "basic": {
-        "compilations": (50, "month"),
+        "compilations": (400, "month"),
         "optimizations": (10, "month"),
         "ai_assists": (100, "month"),
     },

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -71,6 +71,20 @@ class JsonFormatter(logging.Formatter):
             value = getattr(record, key, None)
             if value is not None:
                 payload[key] = value
+        # Job-pipeline timing checkpoints (#1281 — "Compile latency: 37s median ->
+        # target <10s"). Emitted via logger.*(..., extra={...}) in latex_worker.py /
+        # orchestrator.py so a single log line carries every phase of a job instead
+        # of one opaque duration, and can be grepped/aggregated by "outcome" and
+        # "compiler" across all compiles.
+        for key in (
+            "compiler", "outcome",
+            "queue_wait_seconds", "cold_start_seconds",
+            "compile_subprocess_seconds", "reporting_seconds", "total_task_seconds",
+            "optimization_seconds", "ats_scoring_seconds",
+        ):
+            value = getattr(record, key, None)
+            if value is not None:
+                payload[key] = value
         if record.exc_info:
             payload["exception"] = self.formatException(record.exc_info)
         return json.dumps(_sanitize(payload), ensure_ascii=True)

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -668,6 +668,19 @@ class PaymentService:
                     "error": "Invalid plan selected"
                 }
 
+            # Annual SKUs (basic_annual/pro_annual/byok_annual) are only
+            # launched once their RAZORPAY_PLAN_*_ANNUAL id is configured in
+            # the dashboard. Without that, falling through would spin up an
+            # ad-hoc Razorpay plan on every checkout attempt (via the
+            # create_razorpay_plan fallback in _create_paid_subscription)
+            # instead of billing against a reviewed, pre-configured annual
+            # SKU — refuse cleanly instead.
+            if concrete_plan_id.endswith("_annual") and not get_razorpay_plan_id(concrete_plan_id):
+                return {
+                    "success": False,
+                    "error": "Annual billing isn't available yet — please choose monthly.",
+                }
+
             # Handle free plan
             if plan_config["price"] == 0:
                 live = await self._get_live_provider_subscription(db, user_id)

--- a/backend/app/workers/latex_worker.py
+++ b/backend/app/workers/latex_worker.py
@@ -10,9 +10,11 @@ Compilation row (SQLAlchemy async engine has no sync counterpart in this app).
 
 import asyncio
 import base64
+import json
 import re
 import shutil
 import subprocess
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -73,6 +75,75 @@ _PDFTOTEXT_FALLBACK_PATHS = (
     "/usr/local/bin/pdftotext",
     "/usr/bin/pdftotext",
 )
+
+
+# ------------------------------------------------------------------ #
+#  Timing instrumentation (#1281 — "Compile latency: 37s median ->    #
+#  target <10s"). Production measurement showed ~8s job submit + ~24s#
+#  more of opaque "processing" before completion, with the job's own #
+#  reported compilation_time at ~15.5s — i.e. roughly half the       #
+#  "processing" window is unaccounted for by the one number we       #
+#  already report. These helpers break that window into phases that #
+#  get logged as structured (grep-able) fields instead of prose, so  #
+#  the next measurement shows which phase actually dominates:        #
+#    - queue_wait_seconds: job creation (API writes :meta.submitted_at)  #
+#      to this worker picking the task up.                            #
+#    - cold_start_seconds: only set for the FIRST task this worker    #
+#      process (== this Modal container) handles — the gap between    #
+#      module import (proxy for container start) and task start, i.e. #
+#      container boot + image pull. None on every task after that,    #
+#      i.e. on a warm min_containers=1 container.                      #
+#    - compile_subprocess_seconds: the pdflatex/xelatex/lualatex        #
+#      subprocess itself (already computed elsewhere as                #
+#      compilation_time — reused, not duplicated).                     #
+#    - reporting_seconds: everything after the subprocess exits —      #
+#      recorder-escape check, log/PDF caching to Redis, Compilation    #
+#      row reconcile (+ MinIO upload), event publishing.               #
+# ------------------------------------------------------------------ #
+
+# Stamped once, at import time — this module is imported fresh in every worker
+# OS process (a Celery worker fork, or a Modal container for run_latex_task /
+# run_orchestrator_task), so this is a reliable proxy for "this process started".
+_PROCESS_STARTED_AT = time.monotonic()
+_first_task_lock = threading.Lock()
+_first_task_seen = False
+
+
+def consume_cold_start_seconds() -> Optional[float]:
+    """Elapsed time since this worker process started, but only once.
+
+    The first caller (the first task this process handles) gets the real gap;
+    every later call returns None so a warm container's fast tasks are never
+    mislabeled as cold starts.
+    """
+    global _first_task_seen
+    with _first_task_lock:
+        if _first_task_seen:
+            return None
+        _first_task_seen = True
+        return time.monotonic() - _PROCESS_STARTED_AT
+
+
+def compute_queue_wait_seconds(job_id: str) -> Optional[float]:
+    """Time between job creation and this worker picking the task up.
+
+    Reads the :meta key the API writes (with submitted_at) at submission time
+    (see job_routes._write_initial_redis_state), before the task is dispatched.
+    Best-effort: returns None when there is no meta (e.g. a task invoked
+    directly in a unit test, or a compile path that skips the API's initial
+    Redis write) rather than raising, since this is diagnostics, not a
+    correctness dependency.
+    """
+    try:
+        raw = get_worker_redis().get(f"latexy:job:{job_id}:meta")
+        if not raw:
+            return None
+        submitted_at = json.loads(raw).get("submitted_at")
+        if not submitted_at:
+            return None
+        return max(0.0, time.time() - float(submitted_at))
+    except Exception:
+        return None
 
 
 def _inject_watermark(latex_content: str, watermark_text: str) -> str:
@@ -392,6 +463,12 @@ def compile_latex_task(
     if job_id is None:
         job_id = str(uuid.uuid4())
 
+    # Timing instrumentation (#1281) — captured before anything else so
+    # cold_start/queue_wait reflect the true start of this task's execution.
+    _task_monotonic_start = time.monotonic()
+    _cold_start_seconds = consume_cold_start_seconds()
+    _queue_wait_seconds = compute_queue_wait_seconds(job_id)
+
     # Resolve and validate compiler — None means "use configured default"
     compiler = compiler or settings.DEFAULT_LATEX_COMPILER
     if compiler not in settings.ALLOWED_LATEX_COMPILERS:
@@ -403,7 +480,45 @@ def compile_latex_task(
 
     task_id = self.request.id
     worker_id = f"latex-{task_id}"
-    logger.info(f"LaTeX task {task_id} starting for job {job_id} (compiler={compiler})")
+    logger.info(
+        f"LaTeX task {task_id} starting for job {job_id} (compiler={compiler})",
+        extra={
+            "job_id": job_id,
+            "task_id": task_id,
+            "compiler": compiler,
+            "queue_wait_seconds": _queue_wait_seconds,
+            "cold_start_seconds": _cold_start_seconds,
+        },
+    )
+
+    def _log_task_timing(
+        outcome: str,
+        compile_subprocess_seconds: Optional[float] = None,
+        reporting_start: Optional[float] = None,
+    ) -> None:
+        """One structured, grep-able line per task completion (#1281).
+
+        Breaks the "processing" window a client sees into the phases that
+        matter for latency diagnosis, instead of the single opaque
+        compilation_time this task already reports in its result payload.
+        """
+        reporting_seconds = (
+            time.monotonic() - reporting_start if reporting_start is not None else None
+        )
+        logger.info(
+            "compile_task_timing",
+            extra={
+                "job_id": job_id,
+                "task_id": task_id,
+                "compiler": compiler,
+                "outcome": outcome,
+                "queue_wait_seconds": _queue_wait_seconds,
+                "cold_start_seconds": _cold_start_seconds,
+                "compile_subprocess_seconds": compile_subprocess_seconds,
+                "reporting_seconds": reporting_seconds,
+                "total_task_seconds": time.monotonic() - _task_monotonic_start,
+            },
+        )
 
     if self.request.retries == 0:
         publish_event(job_id, "job.started", {
@@ -576,6 +691,7 @@ def compile_latex_task(
                     compilation_time=time.time() - start_time,
                     error_message="engine_read_escape",
                 )
+                _log_task_timing("engine_read_escape", time.time() - start_time)
                 return escape_result
 
             for line in proc.stdout:
@@ -635,6 +751,7 @@ def compile_latex_task(
                         compilation_time=time.time() - start_time,
                         error_message="cancelled",
                     )
+                    _log_task_timing("cancelled", time.time() - start_time)
                     return result
 
                 # ── Timeout check ────────────────────────────────────────
@@ -661,11 +778,15 @@ def compile_latex_task(
                         compilation_time=time.time() - start_time,
                         error_message="compile_timeout",
                     )
+                    _log_task_timing("compile_timeout", time.time() - start_time)
                     return result
 
             proc.wait()
             compilation_time = time.time() - start_time
         _compile_duration = time.perf_counter() - _perf_start
+        # Everything from here on is post-subprocess bookkeeping (recorder check,
+        # Redis caching, DB reconcile, event publish) — the "reporting" phase.
+        _reporting_start = time.monotonic()
 
         # Post-run read confinement. \openin/\read leaves no trace in the transcript,
         # so the -recorder .fls file is the only complete list of what was opened.
@@ -750,6 +871,7 @@ def compile_latex_task(
             logger.info(
                 f"LaTeX task {task_id} succeeded for job {job_id} ({pdf_size} bytes)"
             )
+            _log_task_timing("success", _compile_duration, _reporting_start)
 
             # Auto-save checkpoint if resume_id is known (skip for watermarked compiles)
             _resume_id = resume_id or (metadata or {}).get("resume_id")
@@ -787,6 +909,7 @@ def compile_latex_task(
             compilation_time=compilation_time,
             error_message=first_latex_error or error_msg,
         )
+        _log_task_timing("compile_error", _compile_duration, _reporting_start)
         return result
 
     except SoftTimeLimitExceeded:
@@ -812,6 +935,7 @@ def compile_latex_task(
         result = {"success": False, "job_id": job_id, "error": "compile_timeout"}
         publish_job_result(job_id, result)
         reconcile_compilation_record(job_id, success=False, error_message="compile_timeout")
+        _log_task_timing("soft_time_limit_exceeded")
         return result
 
     except Exception as exc:
@@ -837,6 +961,7 @@ def compile_latex_task(
         result = {"success": False, "job_id": job_id, "error": str(exc)}
         publish_job_result(job_id, result)
         reconcile_compilation_record(job_id, success=False, error_message=str(exc))
+        _log_task_timing("exception")
         return result
     finally:
         if job_dir is not None and job_dir.exists():

--- a/backend/app/workers/orchestrator.py
+++ b/backend/app/workers/orchestrator.py
@@ -64,6 +64,8 @@ from ..workers.event_publisher import (
 from ..workers.latex_worker import (
     cache_compile_log,
     cache_compile_output,
+    compute_queue_wait_seconds,
+    consume_cold_start_seconds,
     reconcile_compilation_record,
 )
 
@@ -119,9 +121,56 @@ def optimize_and_compile_task(
     if job_id is None:
         job_id = str(uuid.uuid4())
 
+    # Timing instrumentation (#1281) — same phases latex_worker.compile_latex_task
+    # reports, plus the LLM/ATS stages that are unique to this combined pipeline.
+    _task_monotonic_start = time.monotonic()
+    _cold_start_seconds = consume_cold_start_seconds()
+    _queue_wait_seconds = compute_queue_wait_seconds(job_id)
+
     task_id = self.request.id
     worker_id = f"orchestrator-{task_id}"
-    logger.info(f"Orchestrator task {task_id} starting for job {job_id}")
+    logger.info(
+        f"Orchestrator task {task_id} starting for job {job_id}",
+        extra={
+            "job_id": job_id,
+            "task_id": task_id,
+            "queue_wait_seconds": _queue_wait_seconds,
+            "cold_start_seconds": _cold_start_seconds,
+        },
+    )
+
+    def _log_task_timing(
+        outcome: str,
+        optimization_seconds: Optional[float] = None,
+        compile_subprocess_seconds: Optional[float] = None,
+        ats_scoring_seconds: Optional[float] = None,
+        reporting_start: Optional[float] = None,
+    ) -> None:
+        """One structured, grep-able line per task completion (#1281).
+
+        Splits the combined LLM -> LaTeX -> ATS pipeline into its phases so a
+        latency regression shows up as a specific field instead of one opaque
+        total.
+        """
+        reporting_seconds = (
+            time.monotonic() - reporting_start if reporting_start is not None else None
+        )
+        logger.info(
+            "orchestrator_task_timing",
+            extra={
+                "job_id": job_id,
+                "task_id": task_id,
+                "compiler": compiler,
+                "outcome": outcome,
+                "queue_wait_seconds": _queue_wait_seconds,
+                "cold_start_seconds": _cold_start_seconds,
+                "optimization_seconds": optimization_seconds,
+                "compile_subprocess_seconds": compile_subprocess_seconds,
+                "ats_scoring_seconds": ats_scoring_seconds,
+                "reporting_seconds": reporting_seconds,
+                "total_task_seconds": time.monotonic() - _task_monotonic_start,
+            },
+        )
 
     api_key = user_api_key or settings.OPENAI_API_KEY
 
@@ -235,6 +284,11 @@ def optimize_and_compile_task(
                 compilation_time=compilation_time,
                 error_message=compile_error,
             )
+            _log_task_timing(
+                error_code,
+                optimization_seconds=optimization_time,
+                compile_subprocess_seconds=compilation_time,
+            )
             return {
                 "success": False,
                 "job_id": job_id,
@@ -252,11 +306,14 @@ def optimize_and_compile_task(
             "message": "Scoring ATS compatibility",
         })
 
+        _ats_start = time.monotonic()
         ats_score, ats_details = _run_ats_stage(
             job_id=job_id,
             latex_content=optimized_latex,
             job_description=job_description,
         )
+        _ats_scoring_seconds = time.monotonic() - _ats_start
+        _reporting_start = time.monotonic()
 
         # ================================================================ #
         # Completion                                                        #
@@ -299,6 +356,13 @@ def optimize_and_compile_task(
             f"Orchestrator task {task_id} succeeded for job {job_id} "
             f"(ATS {ats_score:.1f}, {tokens_used} tokens, {compilation_time:.1f}s)"
         )
+        _log_task_timing(
+            "success",
+            optimization_seconds=optimization_time,
+            compile_subprocess_seconds=compilation_time,
+            ats_scoring_seconds=_ats_scoring_seconds,
+            reporting_start=_reporting_start,
+        )
 
         # Auto-save checkpoint if resume_id is known
         _resume_id = resume_id or (metadata or {}).get("resume_id")
@@ -334,6 +398,7 @@ def optimize_and_compile_task(
             "retryable": False,
         })
         reconcile_compilation_record(job_id, success=False, error_message="compile_timeout")
+        _log_task_timing("soft_time_limit_exceeded")
         return {"success": False, "job_id": job_id, "error": "compile_timeout"}
 
     except Exception as exc:
@@ -348,6 +413,7 @@ def optimize_and_compile_task(
                 "attempt": self.request.retries + 2,
                 "error_message": str(exc),
             })
+            _log_task_timing("retrying")
             raise self.retry(countdown=min(60 * (2 ** self.request.retries), 600), exc=exc)
         publish_event(job_id, "job.failed", {
             "stage": current_stage,
@@ -356,6 +422,7 @@ def optimize_and_compile_task(
             "retryable": False,
         })
         reconcile_compilation_record(job_id, success=False, error_message=str(exc))
+        _log_task_timing("exception")
         return {"success": False, "job_id": job_id, "error": str(exc)}
 
 

--- a/backend/modal_app.py
+++ b/backend/modal_app.py
@@ -49,10 +49,33 @@ _APT_BASE = [
 # The full TeX toolchain. Every engine named in ALLOWED_LATEX_COMPILERS needs its
 # package here, and poppler-utils (pdftotext, for page-count extraction) comes
 # from _APT_BASE.
+#
+# texlive-fonts-extra trimmed to just its cm-super dependency (#1281 —
+# "Compile latency: 37s median -> target <10s"): the full package is 1,665 of
+# the 1,750MB this apt_install pulls in (per Debian package sizes). An audit of
+# every currently-active production template's LaTeX source
+# (backend/app/data/templates/**/*.tex) plus official_snippets.py found only
+# array, enumitem, fontenc, geometry, hyperref, inputenc, microtype, parskip,
+# titlesec, xcolor, amsmath, amssymb, graphicx, booktabs, tikz, pgfplots,
+# tcolorbox, appendixnumberbeamer, ccicons, xspace in use — all standard
+# packages shipped by texlive-latex-base/texlive-latex-recommended (a
+# transitive dependency of texlive-latex-extra) or texlive-latex-extra itself.
+#
+# BUT: texlive-fonts-extra Recommends (and apt installs by default) the
+# `cm-super` font package, which nothing else here depends on — and it is
+# load-bearing. Every default-Computer-Modern template compiles via
+# microtype's font-expansion feature, which needs cm-super's Type1 fonts
+# (verified locally: dropping texlive-fonts-extra outright reproduces
+# `! pdfTeX error (font expansion): auto expansion is only possible with
+# scalable fonts` and a fatal, no-PDF compile on the production "Clean Simple"
+# template — this is NOT a hypothetical). Installing `cm-super` directly
+# instead keeps that dependency (52.6MB installed) while dropping the other
+# ~1,362MB of texlive-fonts-extra that's genuinely unused (decorative font
+# families like libertine/ebgaramond).
 _APT_LATEX = [
     "texlive-latex-extra",
     "texlive-fonts-recommended",
-    "texlive-fonts-extra",
+    "cm-super",               # microtype font-expansion dependency; see comment above
     "texlive-science",
     "texlive-xetex",
     "texlive-luatex",

--- a/backend/test/test_job_timing_instrumentation.py
+++ b/backend/test/test_job_timing_instrumentation.py
@@ -1,0 +1,313 @@
+"""
+Tests for the job-pipeline timing instrumentation added for #1281
+("Compile latency: 37s median -> target <10s").
+
+Covers:
+  - compute_queue_wait_seconds / consume_cold_start_seconds (latex_worker.py),
+    which are shared by both compile_latex_task and orchestrator's
+    optimize_and_compile_task.
+  - compile_latex_task emits a single structured "compile_task_timing" log
+    line per completion, carrying every phase as a separate field.
+  - JsonFormatter actually serializes those fields instead of silently
+    dropping them (it only emits keys on an explicit allowlist).
+
+All external I/O (subprocess, Redis, DB) is mocked — no real compile happens.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.workers.latex_worker as lw
+from app.core.logging import JsonFormatter
+
+# ── Celery eager mode (matches test_latex_worker.py) ──────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _celery_eager():
+    from app.core.celery_app import celery_app
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+    yield
+    celery_app.conf.task_always_eager = False
+    celery_app.conf.task_eager_propagates = False
+
+
+VALID_LATEX = r"""
+\documentclass[letterpaper,11pt]{article}
+\begin{document}
+Hello World
+\end{document}
+"""
+
+
+def _make_popen(returncode: int = 0, lines: list | None = None) -> MagicMock:
+    mock_proc = MagicMock()
+    mock_proc.returncode = returncode
+    mock_proc.stdout = iter(lines if lines is not None else ["Compilation OK\n"])
+    mock_proc.wait.return_value = None
+    mock_proc.kill.return_value = None
+    return mock_proc
+
+
+@pytest.fixture
+def mock_publish():
+    with patch("app.workers.latex_worker.publish_event") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_job_result():
+    with patch("app.workers.latex_worker.publish_job_result") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_cancelled():
+    with patch("app.workers.latex_worker.is_cancelled", return_value=False):
+        yield
+
+
+@pytest.fixture
+def mock_validate_ok():
+    with patch("app.workers.latex_worker.latex_service.validate_latex_content", return_value=True):
+        yield
+
+
+@pytest.fixture
+def mock_popen_success():
+    with (
+        patch("app.workers.latex_worker.subprocess.Popen", return_value=_make_popen(0, ["Compilation OK\n"])) as m,
+        patch("app.workers.latex_worker.subprocess.run", return_value=MagicMock(returncode=0, stdout="Hello World\n")),
+        patch("app.workers.latex_worker.shutil.which", return_value="/usr/bin/pdftotext"),
+        patch("pathlib.Path.mkdir"),
+        patch("pathlib.Path.write_text"),
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.stat", return_value=MagicMock(st_size=12345)),
+    ):
+        yield m
+
+
+# ── compute_queue_wait_seconds ─────────────────────────────────────────────────
+
+
+class TestComputeQueueWaitSeconds:
+
+    def test_returns_none_when_meta_missing(self):
+        redis_mock = MagicMock()
+        redis_mock.get.return_value = None
+        with patch("app.workers.latex_worker.get_worker_redis", return_value=redis_mock):
+            assert lw.compute_queue_wait_seconds(str(uuid.uuid4())) is None
+
+    def test_returns_none_when_redis_raises(self):
+        with patch(
+            "app.workers.latex_worker.get_worker_redis",
+            side_effect=RuntimeError("Worker Redis not initialized"),
+        ):
+            assert lw.compute_queue_wait_seconds(str(uuid.uuid4())) is None
+
+    def test_returns_none_when_submitted_at_missing_from_meta(self):
+        redis_mock = MagicMock()
+        redis_mock.get.return_value = json.dumps({"job_id": "x", "job_type": "latex_compilation"})
+        with patch("app.workers.latex_worker.get_worker_redis", return_value=redis_mock):
+            assert lw.compute_queue_wait_seconds(str(uuid.uuid4())) is None
+
+    def test_computes_elapsed_since_submission(self):
+        submitted_at = time.time() - 5.0
+        redis_mock = MagicMock()
+        redis_mock.get.return_value = json.dumps({"submitted_at": submitted_at})
+        with patch("app.workers.latex_worker.get_worker_redis", return_value=redis_mock):
+            wait = lw.compute_queue_wait_seconds(str(uuid.uuid4()))
+        assert wait is not None
+        assert wait == pytest.approx(5.0, abs=0.5)
+
+    def test_never_returns_negative(self):
+        """A submitted_at slightly in the future (clock skew) must clamp to 0, not go negative."""
+        redis_mock = MagicMock()
+        redis_mock.get.return_value = json.dumps({"submitted_at": time.time() + 10})
+        with patch("app.workers.latex_worker.get_worker_redis", return_value=redis_mock):
+            wait = lw.compute_queue_wait_seconds(str(uuid.uuid4()))
+        assert wait == 0.0
+
+
+# ── consume_cold_start_seconds ─────────────────────────────────────────────────
+
+
+class TestConsumeColdStartSeconds:
+
+    @pytest.fixture(autouse=True)
+    def _reset_process_markers(self, monkeypatch):
+        """Isolate each test from the module-level 'first task in this process'
+        state, which is otherwise shared (and mutated) by every other test that
+        exercises compile_latex_task in this process."""
+        monkeypatch.setattr(lw, "_first_task_seen", False)
+        monkeypatch.setattr(lw, "_PROCESS_STARTED_AT", time.monotonic() - 3.0)
+        yield
+
+    def test_first_call_returns_elapsed_since_process_start(self):
+        elapsed = lw.consume_cold_start_seconds()
+        assert elapsed is not None
+        assert elapsed == pytest.approx(3.0, abs=0.5)
+
+    def test_second_call_returns_none(self):
+        first = lw.consume_cold_start_seconds()
+        second = lw.consume_cold_start_seconds()
+        assert first is not None
+        assert second is None
+
+    def test_marks_seen_even_if_never_read(self):
+        """Just calling it once (a task started) is enough to consume the marker,
+        matching every real call site — none of them call it twice."""
+        lw.consume_cold_start_seconds()
+        assert lw._first_task_seen is True
+
+
+# ── compile_latex_task emits a structured timing line ─────────────────────────
+
+
+class TestCompileTaskTimingLog:
+
+    def test_success_emits_compile_task_timing_with_all_phases(
+        self, mock_publish, mock_job_result, mock_cancelled, mock_validate_ok, mock_popen_success
+    ):
+        job_id = str(uuid.uuid4())
+        with patch("app.workers.latex_worker.logger") as mock_logger:
+            lw.compile_latex_task(VALID_LATEX, job_id=job_id, compiler="pdflatex")
+            timing_calls = [
+                c for c in mock_logger.info.call_args_list
+                if c.args and c.args[0] == "compile_task_timing"
+            ]
+
+        assert len(timing_calls) == 1, "exactly one timing line per task completion"
+        extra = timing_calls[0].kwargs["extra"]
+
+        assert extra["job_id"] == job_id
+        assert extra["compiler"] == "pdflatex"
+        assert extra["outcome"] == "success"
+        # queue_wait_seconds / cold_start_seconds are legitimately None here (no
+        # job meta seeded, cold-start marker likely already consumed by other
+        # tests in this process) — the contract is that the KEY is present, not
+        # that it's non-null on every run.
+        for key in (
+            "queue_wait_seconds", "cold_start_seconds",
+            "compile_subprocess_seconds", "reporting_seconds", "total_task_seconds",
+        ):
+            assert key in extra, f"missing timing field: {key}"
+
+        # The phases we can always compute must be real non-negative numbers.
+        assert isinstance(extra["compile_subprocess_seconds"], float)
+        assert extra["compile_subprocess_seconds"] >= 0
+        assert isinstance(extra["reporting_seconds"], float)
+        assert extra["reporting_seconds"] >= 0
+        assert isinstance(extra["total_task_seconds"], float)
+        assert extra["total_task_seconds"] >= extra["compile_subprocess_seconds"]
+
+    def test_compile_error_emits_timing_with_compile_error_outcome(
+        self, mock_publish, mock_job_result, mock_cancelled, mock_validate_ok
+    ):
+        job_id = str(uuid.uuid4())
+        with (
+            patch("app.workers.latex_worker.subprocess.Popen", return_value=_make_popen(1, ["! Undefined control sequence\n"])),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+            patch("pathlib.Path.exists", return_value=False),
+            patch("app.workers.latex_worker.logger") as mock_logger,
+        ):
+            lw.compile_latex_task(VALID_LATEX, job_id=job_id)
+            timing_calls = [
+                c for c in mock_logger.info.call_args_list
+                if c.args and c.args[0] == "compile_task_timing"
+            ]
+
+        assert len(timing_calls) == 1
+        assert timing_calls[0].kwargs["extra"]["outcome"] == "compile_error"
+
+    def test_queue_wait_and_cold_start_flow_through_when_available(
+        self, mock_publish, mock_job_result, mock_cancelled, mock_validate_ok, mock_popen_success, monkeypatch
+    ):
+        """End-to-end: seed a real :meta key and a fresh cold-start marker, and
+        confirm both concrete numbers make it into the logged extra dict."""
+        job_id = str(uuid.uuid4())
+        submitted_at = time.time() - 2.0
+        redis_mock = MagicMock()
+        redis_mock.get.return_value = json.dumps({"submitted_at": submitted_at})
+
+        monkeypatch.setattr(lw, "_first_task_seen", False)
+        monkeypatch.setattr(lw, "_PROCESS_STARTED_AT", time.monotonic() - 1.5)
+
+        with (
+            patch("app.workers.latex_worker.get_worker_redis", return_value=redis_mock),
+            patch("app.workers.latex_worker.logger") as mock_logger,
+        ):
+            lw.compile_latex_task(VALID_LATEX, job_id=job_id)
+            timing_calls = [
+                c for c in mock_logger.info.call_args_list
+                if c.args and c.args[0] == "compile_task_timing"
+            ]
+
+        extra = timing_calls[0].kwargs["extra"]
+        assert extra["queue_wait_seconds"] == pytest.approx(2.0, abs=0.5)
+        assert extra["cold_start_seconds"] == pytest.approx(1.5, abs=0.5)
+
+
+# ── JsonFormatter actually serializes the new fields ───────────────────────────
+
+
+class TestJsonFormatterTimingFields:
+
+    def _format(self, **extra) -> dict:
+        record = logging.LogRecord(
+            name="app.workers.latex_worker",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="compile_task_timing",
+            args=(),
+            exc_info=None,
+        )
+        for key, value in extra.items():
+            setattr(record, key, value)
+        return json.loads(JsonFormatter().format(record))
+
+    def test_all_timing_fields_survive_formatting(self):
+        payload = self._format(
+            job_id="job-1",
+            task_id="task-1",
+            compiler="pdflatex",
+            outcome="success",
+            queue_wait_seconds=8.2,
+            cold_start_seconds=None,
+            compile_subprocess_seconds=15.5,
+            reporting_seconds=0.3,
+            total_task_seconds=15.9,
+            optimization_seconds=None,
+            ats_scoring_seconds=None,
+        )
+        assert payload["job_id"] == "job-1"
+        assert payload["compiler"] == "pdflatex"
+        assert payload["outcome"] == "success"
+        assert payload["queue_wait_seconds"] == 8.2
+        assert payload["compile_subprocess_seconds"] == 15.5
+        assert payload["reporting_seconds"] == 0.3
+        assert payload["total_task_seconds"] == 15.9
+        # None values are the "not applicable this call" case (e.g. cold_start_seconds
+        # on a warm container) and must not appear as literal nulls in every line.
+        assert "cold_start_seconds" not in payload
+        assert "optimization_seconds" not in payload
+        assert "ats_scoring_seconds" not in payload
+
+    def test_unset_timing_fields_are_absent_not_null(self):
+        """A log call that never set these attrs (e.g. an unrelated log line)
+        must not gain spurious timing keys."""
+        payload = self._format()
+        for key in (
+            "queue_wait_seconds", "cold_start_seconds", "compiler", "outcome",
+            "compile_subprocess_seconds", "reporting_seconds", "total_task_seconds",
+        ):
+            assert key not in payload

--- a/backend/test/test_usage_quotas.py
+++ b/backend/test/test_usage_quotas.py
@@ -98,13 +98,33 @@ class TestPlanQuotaTable:
 
         assert get_plan_config("free")["features"]["compilations"] == "10 / day"
         assert get_plan_config("free")["features"]["optimizations"] == "3 / month"
-        assert get_plan_config("basic")["features"]["compilations"] == "50 / month"
+        assert get_plan_config("basic")["features"]["compilations"] == "400 / month"
         assert get_plan_config("pro")["features"]["compilations"] == "unlimited"
 
     def test_basic_matches_advertised_plan(self):
-        assert get_plan_quota("basic", "compilations") == 50
+        assert get_plan_quota("basic", "compilations") == 400
         assert get_plan_quota("basic", "optimizations") == 10
         assert get_plan_quota("basic_annual", "optimizations") == 10
+
+    def test_basic_compilations_is_not_a_downgrade_from_free(self):
+        # B3/#1283 regression guard: the first PAID tier must never grant a
+        # lower effective monthly compile allowance than the free tier does.
+        # Free is metered per DAY, so its worst-case monthly equivalent is
+        # ~31 * daily limit; Basic (a paid, monthly-windowed plan) must clear
+        # that bar, or paying becomes a downgrade on the headline metric.
+        free_daily = get_plan_quota("free", "compilations")
+        assert get_plan_quota_window("free", "compilations") == "day"
+        free_monthly_equivalent = free_daily * 31
+
+        basic_monthly = get_plan_quota("basic", "compilations")
+        assert get_plan_quota_window("basic", "compilations") == "month"
+
+        assert basic_monthly is not None
+        assert basic_monthly >= free_monthly_equivalent, (
+            f"basic compilations quota ({basic_monthly}/month) must be >= "
+            f"free's 31-day equivalent ({free_monthly_equivalent}) — paying "
+            "must never grant fewer compiles than staying free."
+        )
 
     @pytest.mark.parametrize("plan", ["pro", "pro_annual", "byok", "team", "student"])
     def test_paid_unlimited_is_none(self, plan):
@@ -474,7 +494,7 @@ class TestEntitlementsEndpointExposesQuotas:
         assert resp.status_code == 200
         quotas = resp.json()["quotas"]
         assert quotas["dimensions"]["optimizations"]["limit"] == 10
-        assert quotas["dimensions"]["compilations"]["limit"] == 50
+        assert quotas["dimensions"]["compilations"]["limit"] == 400
         assert quotas["dimensions"]["compilations"]["window"] == "month"
 
     async def test_anonymous_response_has_no_quotas(self, client: AsyncClient):

--- a/frontend/src/app/billing/page.tsx
+++ b/frontend/src/app/billing/page.tsx
@@ -477,6 +477,7 @@ function BillingPageContent() {
             <div>
               <h2 className="text-lg font-semibold text-fg">Choose a plan</h2>
               <p className="mt-1 text-sm text-fg-2">Annual billing saves 20% on Basic, Pro, and BYOK.</p>
+              <p className="mt-1 text-xs text-fg-3">All prices include GST — nothing extra added at checkout.</p>
             </div>
             <div
               role="group"

--- a/frontend/src/components/billing/PricingCard.tsx
+++ b/frontend/src/components/billing/PricingCard.tsx
@@ -71,6 +71,9 @@ export default function PricingCard({
         <h3 className="text-xl font-semibold text-fg">{plan.name}</h3>
         <p className="mt-2 text-3xl font-semibold text-fg">{formatPrice(plan.price)}</p>
         <p className="text-sm text-fg-2">{plan.price > 0 ? `per ${plan.interval}` : 'No payment required'}</p>
+        {plan.price > 0 ? (
+          <p className="mt-1 text-xs text-fg-3">Incl. GST &middot; no surprises at checkout</p>
+        ) : null}
         {plan.monthly_equivalent_price ? (
           <p className="mt-1 text-xs text-ok">₹{(plan.monthly_equivalent_price / 100).toFixed(0)}/month effective</p>
         ) : null}

--- a/frontend/src/components/help/HelpCenter.tsx
+++ b/frontend/src/components/help/HelpCenter.tsx
@@ -129,7 +129,7 @@ const faqData: FAQItem[] = [
   {
     id: 'subscription-plans',
     question: 'What subscription plans are available?',
-    answer: 'We offer: Free (10 compilations/day, 3 AI optimizations/month), Basic (₹299/month - 50 compilations, 10 optimizations per month), Pro (₹599/month - unlimited), and BYOK (₹199/month - unlimited with your API keys). All paid plans include resume history and priority support.',
+    answer: 'We offer: Free (10 compilations/day, 3 AI optimizations/month), Basic (₹299/month - 400 compilations, 10 optimizations per month), Pro (₹599/month - unlimited), and BYOK (₹199/month - unlimited with your API keys). All paid plans include resume history and priority support.',
     category: 'billing',
     tags: ['plans', 'pricing', 'subscription']
   },

--- a/legal/terms-of-service.md
+++ b/legal/terms-of-service.md
@@ -34,7 +34,7 @@ Latexy is an AI-powered ATS (Applicant Tracking System) resume optimizer that he
 
 ### 4.1 Plan Types
 - **Free Trial**: 3 free resume compilations per device (no registration required)
-- **Basic Plan**: ₹299/month - 50 compilations, 10 optimizations
+- **Basic Plan**: ₹299/month - 400 compilations, 10 optimizations
 - **Pro Plan**: ₹599/month - Unlimited compilations and optimizations
 - **BYOK Plan**: ₹199/month - Use your own API keys with premium features
 


### PR DESCRIPTION
Consolidates the P0 backlog fix batch — one PR per file, each already reviewed and merged into this integration branch.

Closes #1283 (pricing inversion — fully resolved) and #1285 (annual SKUs + GST-inclusive display — fully resolved).

Does NOT close #1281 (compile latency) — the image-slimdown and instrumentation code is complete and merged here, but the latency win is not realized until it is deployed to Modal, which is a separate, explicitly-gated step. #1281 stays open with a comment explaining current state.

Fixes covered (issue / PR per file):
- backend/modal_app.py: #1523 / #1524 (parent #1281)
- backend/app/workers/latex_worker.py: #1525 / #1526 (parent #1281)
- backend/app/workers/orchestrator.py: #1527 / #1528 (parent #1281)
- backend/app/core/logging.py: #1529 / #1530 (parent #1281)
- backend/test/test_job_timing_instrumentation.py: #1531 / #1532 (parent #1281)
- backend/app/core/config.py: #1533 / #1534 (parent #1283)
- backend/test/test_usage_quotas.py: #1535 / #1536 (parent #1283)
- frontend/src/components/help/HelpCenter.tsx: #1537 / #1538 (parent #1283)
- legal/terms-of-service.md: #1539 / #1540 (parent #1283)
- README.md: #1541 / #1542 (parent #1283)
- backend/app/services/payment_service.py: #1543 / #1544 (parent #1285)
- frontend/src/app/billing/page.tsx: #1545 / #1546 (parent #1285)
- frontend/src/components/billing/PricingCard.tsx: #1547 / #1548 (parent #1285)

Closes #1283
Closes #1285